### PR TITLE
Deserializer can allow deserialization of derived properties, on demand

### DIFF
--- a/SySML2.NET.REST/RestClient.cs
+++ b/SySML2.NET.REST/RestClient.cs
@@ -410,7 +410,7 @@ namespace SySML2.NET.REST
 
             using var stream = await response.Content.ReadAsStreamAsync();
 
-            var result = await this.deserializer.DeSerializeAsync(stream, SerializationModeKind.JSON, SerializationTargetKind.PSM, cancellationToken);
+            var result = await this.deserializer.DeSerializeAsync(stream, SerializationModeKind.JSON, SerializationTargetKind.PSM, false, cancellationToken);
 
             return result;
         }

--- a/SysML2.NET.API/Modules/ProjectModule.cs
+++ b/SysML2.NET.API/Modules/ProjectModule.cs
@@ -140,7 +140,7 @@ namespace SysML2.NET.API.Modules
                     var stream = new MemoryStream();
                     await req.Body.CopyToAsync(stream, cancellationToken);
 
-                    var dataItems = await this.deserializer.DeSerializeAsync(stream, SerializationModeKind.JSON, SerializationTargetKind.PSM, CancellationToken.None);
+                    var dataItems = await this.deserializer.DeSerializeAsync(stream, SerializationModeKind.JSON, SerializationTargetKind.PSM, false, CancellationToken.None);
 
                     var project = (Project)dataItems.Single();
                     

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/AnnotatingElementDeSerializer.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/AnnotatingElementDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IAnnotatingElement"/>
         /// </returns>
-        internal static IAnnotatingElement DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IAnnotatingElement DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("AnnotatingElementDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="AnnotatingElement" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="AnnotatingElement"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAnnotatingElement"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Root.Annotations.AnnotatingElement dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -465,8 +495,128 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the AnnotatingElement: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="AnnotatingElement" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="AnnotatingElement"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAnnotatingElement"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Root.Annotations.AnnotatingElement dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the AnnotatingElement: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the AnnotatingElement: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the AnnotatingElement: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the AnnotatingElement: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the AnnotatingElement: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the AnnotatingElement: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the AnnotatingElement: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/AssociationDeSerializer.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/AssociationDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IAssociation"/>
         /// </returns>
-        internal static IAssociation DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IAssociation DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("AssociationDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Association" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Association"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAssociation"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Associations.Association dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1105,8 +1135,208 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the Association: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Association" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Association"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAssociation"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Associations.Association dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Association: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Association: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Association: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Association: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the Association: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the Association: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Association: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the Association: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the Association: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Association: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the Association: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Association: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/DependencyDeSerializer.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/DependencyDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IDependency"/>
         /// </returns>
-        internal static IDependency DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IDependency DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("DependencyDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Dependency" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Dependency"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IDependency"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Root.Dependencies.Dependency dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -497,8 +527,224 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the Dependency: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Dependency" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Dependency"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IDependency"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Root.Dependencies.Dependency dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Dependency: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("client"u8, out var clientProperty))
+            {
+                foreach (var arrayItem in clientProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var clientExternalIdProperty))
+                    {
+                        var propertyValue = clientExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.Client.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the client Json property was not found in the Dependency: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Dependency: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Dependency: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Dependency: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the Dependency: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Dependency: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the Dependency: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Dependency: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the Dependency: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Dependency: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("supplier"u8, out var supplierProperty))
+            {
+                foreach (var arrayItem in supplierProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var supplierExternalIdProperty))
+                    {
+                        var propertyValue = supplierExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.Supplier.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the supplier Json property was not found in the Dependency: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/EnumerationDefinitionDeSerializer.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/EnumerationDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IEnumerationDefinition"/>
         /// </returns>
-        internal static IEnumerationDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IEnumerationDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("EnumerationDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="EnumerationDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="EnumerationDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IEnumerationDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Enumerations.EnumerationDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1617,8 +1647,164 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the EnumerationDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="EnumerationDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="EnumerationDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IEnumerationDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Enumerations.EnumerationDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the EnumerationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the EnumerationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the EnumerationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the EnumerationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the EnumerationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the EnumerationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the EnumerationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the EnumerationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the EnumerationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the EnumerationDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/FeatureDeSerializer.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/FeatureDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IFeature"/>
         /// </returns>
-        internal static IFeature DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IFeature DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("FeatureDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Feature" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Feature"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFeature"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.Feature dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1419,8 +1449,257 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the Feature: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Feature" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Feature"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFeature"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.Feature dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/FeatureTypingDeSerializer.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/FeatureTypingDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IFeatureTyping"/>
         /// </returns>
-        internal static IFeatureTyping DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IFeatureTyping DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("FeatureTypingDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="FeatureTyping" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FeatureTyping"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFeatureTyping"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.FeatureTyping dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -531,8 +561,234 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the typedFeature Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="FeatureTyping" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FeatureTyping"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFeatureTyping"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.FeatureTyping dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("type"u8, out var typeProperty))
+            {
+                if (typeProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.Type = Guid.Empty;
+                    logger.LogDebug($"the FeatureTyping.Type property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (typeProperty.TryGetProperty("@id"u8, out var typeExternalIdProperty))
+                    {
+                        var propertyValue = typeExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.Type = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the type Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("typedFeature"u8, out var typedFeatureProperty))
+            {
+                if (typedFeatureProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.TypedFeature = Guid.Empty;
+                    logger.LogDebug($"the FeatureTyping.TypedFeature property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (typedFeatureProperty.TryGetProperty("@id"u8, out var typedFeatureExternalIdProperty))
+                    {
+                        var propertyValue = typedFeatureExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.TypedFeature = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the typedFeature Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/FlowDeSerializer.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/FlowDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IFlow"/>
         /// </returns>
-        internal static IFlow DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IFlow DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("FlowDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Flow" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Flow"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFlow"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Interactions.Flow dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1675,8 +1705,313 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the Flow: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Flow" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Flow"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFlow"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Interactions.Flow dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/FramedConcernMembershipDeSerializer.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/FramedConcernMembershipDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IFramedConcernMembership"/>
         /// </returns>
-        internal static IFramedConcernMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IFramedConcernMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("FramedConcernMembershipDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="FramedConcernMembership" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FramedConcernMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFramedConcernMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Requirements.FramedConcernMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -582,8 +612,202 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="FramedConcernMembership" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FramedConcernMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFramedConcernMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Requirements.FramedConcernMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("kind"u8, out var kindProperty))
+            {
+                dtoInstance.Kind = RequirementConstraintKindDeSerializer.Deserialize(kindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the kind Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/LiteralIntegerDeSerializer.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/LiteralIntegerDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ILiteralInteger"/>
         /// </returns>
-        internal static ILiteralInteger DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ILiteralInteger DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("LiteralIntegerDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="LiteralInteger" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="LiteralInteger"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ILiteralInteger"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.LiteralInteger dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1489,8 +1519,266 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the value Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="LiteralInteger" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="LiteralInteger"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ILiteralInteger"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.LiteralInteger dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("value"u8, out var valueProperty))
+            {
+                dtoInstance.Value = valueProperty.GetInt32();
+            }
+            else
+            {
+                logger.LogDebug("the value Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/LiteralRationalDeSerializer.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/LiteralRationalDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ILiteralRational"/>
         /// </returns>
-        internal static ILiteralRational DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ILiteralRational DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("LiteralRationalDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="LiteralRational" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="LiteralRational"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ILiteralRational"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.LiteralRational dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1489,8 +1519,266 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the value Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="LiteralRational" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="LiteralRational"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ILiteralRational"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.LiteralRational dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("value"u8, out var valueProperty))
+            {
+                dtoInstance.Value = valueProperty.GetDouble();
+            }
+            else
+            {
+                logger.LogDebug("the value Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/MembershipDeSerializer.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/MembershipDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IMembership"/>
         /// </returns>
-        internal static IMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("MembershipDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Membership" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Membership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Root.Namespaces.Membership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -548,8 +578,236 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the Membership: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Membership" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Membership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Root.Namespaces.Membership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("memberElement"u8, out var memberElementProperty))
+            {
+                if (memberElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.MemberElement = Guid.Empty;
+                    logger.LogDebug($"the Membership.MemberElement property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (memberElementProperty.TryGetProperty("@id"u8, out var memberElementExternalIdProperty))
+                    {
+                        var propertyValue = memberElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.MemberElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the memberElement Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("memberName"u8, out var memberNameProperty))
+            {
+                dtoInstance.MemberName = memberNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the memberName Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("memberShortName"u8, out var memberShortNameProperty))
+            {
+                dtoInstance.MemberShortName = memberShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the memberShortName Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/MultiplicityRangeDeSerializer.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/MultiplicityRangeDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IMultiplicityRange"/>
         /// </returns>
-        internal static IMultiplicityRange DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IMultiplicityRange DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("MultiplicityRangeDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="MultiplicityRange" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="MultiplicityRange"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMultiplicityRange"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Multiplicities.MultiplicityRange dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1488,8 +1518,257 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the upperBound Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="MultiplicityRange" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="MultiplicityRange"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMultiplicityRange"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Multiplicities.MultiplicityRange dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/OwningMembershipDeSerializer.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/OwningMembershipDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IOwningMembership"/>
         /// </returns>
-        internal static IOwningMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IOwningMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("OwningMembershipDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="OwningMembership" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="OwningMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IOwningMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Root.Namespaces.OwningMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -548,8 +578,193 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the OwningMembership: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="OwningMembership" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="OwningMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IOwningMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Root.Namespaces.OwningMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the OwningMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the OwningMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the OwningMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the OwningMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the OwningMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the OwningMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the OwningMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the OwningMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the OwningMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the OwningMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the OwningMembership: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/ReferenceSubsettingDeSerializer.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/ReferenceSubsettingDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IReferenceSubsetting"/>
         /// </returns>
-        internal static IReferenceSubsetting DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IReferenceSubsetting DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ReferenceSubsettingDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ReferenceSubsetting" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ReferenceSubsetting"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IReferenceSubsetting"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.ReferenceSubsetting dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -507,8 +537,209 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the ReferenceSubsetting: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ReferenceSubsetting" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ReferenceSubsetting"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IReferenceSubsetting"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.ReferenceSubsetting dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ReferenceSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ReferenceSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ReferenceSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ReferenceSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the ReferenceSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ReferenceSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the ReferenceSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ReferenceSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the ReferenceSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ReferenceSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("referencedFeature"u8, out var referencedFeatureProperty))
+            {
+                if (referencedFeatureProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.ReferencedFeature = Guid.Empty;
+                    logger.LogDebug($"the ReferenceSubsetting.ReferencedFeature property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (referencedFeatureProperty.TryGetProperty("@id"u8, out var referencedFeatureExternalIdProperty))
+                    {
+                        var propertyValue = referencedFeatureExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.ReferencedFeature = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the referencedFeature Json property was not found in the ReferenceSubsetting: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/RequirementUsageDeSerializer.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/RequirementUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IRequirementUsage"/>
         /// </returns>
-        internal static IRequirementUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IRequirementUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("RequirementUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="RequirementUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="RequirementUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IRequirementUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Requirements.RequirementUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actorParameter"u8, out var actorParameterProperty))
             {
                 foreach (var arrayItem in actorParameterProperty.EnumerateArray())
@@ -2359,8 +2389,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="RequirementUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="RequirementUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IRequirementUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Requirements.RequirementUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("reqId"u8, out var reqIdProperty))
+            {
+                dtoInstance.ReqId = reqIdProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the reqId Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/SelectExpressionDeSerializer.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/SelectExpressionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ISelectExpression"/>
         /// </returns>
-        internal static ISelectExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ISelectExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("SelectExpressionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="SelectExpression" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="SelectExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISelectExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.SelectExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1539,8 +1569,271 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="SelectExpression" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="SelectExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISelectExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.SelectExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("operator"u8, out var operatorProperty))
+            {
+                var propertyValue = operatorProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.Operator = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the operator Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/SubclassificationDeSerializer.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/SubclassificationDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ISubclassification"/>
         /// </returns>
-        internal static ISubclassification DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ISubclassification DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("SubclassificationDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Subclassification" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Subclassification"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISubclassification"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Classifiers.Subclassification dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -531,8 +561,234 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Subclassification" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Subclassification"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISubclassification"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Classifiers.Subclassification dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("subclassifier"u8, out var subclassifierProperty))
+            {
+                if (subclassifierProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.Subclassifier = Guid.Empty;
+                    logger.LogDebug($"the Subclassification.Subclassifier property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (subclassifierProperty.TryGetProperty("@id"u8, out var subclassifierExternalIdProperty))
+                    {
+                        var propertyValue = subclassifierExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.Subclassifier = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the subclassifier Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("superclassifier"u8, out var superclassifierProperty))
+            {
+                if (superclassifierProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.Superclassifier = Guid.Empty;
+                    logger.LogDebug($"the Subclassification.Superclassifier property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (superclassifierProperty.TryGetProperty("@id"u8, out var superclassifierExternalIdProperty))
+                    {
+                        var propertyValue = superclassifierExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.Superclassifier = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the superclassifier Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/TextualRepresentationDeSerializer.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/TextualRepresentationDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ITextualRepresentation"/>
         /// </returns>
-        internal static ITextualRepresentation DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ITextualRepresentation DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("TextualRepresentationDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="TextualRepresentation" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="TextualRepresentation"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ITextualRepresentation"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Root.Annotations.TextualRepresentation dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -498,8 +528,156 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the TextualRepresentation: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="TextualRepresentation" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="TextualRepresentation"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ITextualRepresentation"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Root.Annotations.TextualRepresentation dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the TextualRepresentation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("body"u8, out var bodyProperty))
+            {
+                var propertyValue = bodyProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.Body = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the body Json property was not found in the TextualRepresentation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the TextualRepresentation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the TextualRepresentation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the TextualRepresentation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the TextualRepresentation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("language"u8, out var languageProperty))
+            {
+                var propertyValue = languageProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.Language = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the language Json property was not found in the TextualRepresentation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the TextualRepresentation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the TextualRepresentation: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/UsageDeSerializer.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenDeSerializer/UsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IUsage"/>
         /// </returns>
-        internal static IUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("UsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Usage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Usage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.DefinitionAndUsage.Usage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2111,8 +2141,257 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the Usage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Usage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Usage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.DefinitionAndUsage.Usage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.CodeGenerator/Templates/Uml/core-json-dto-deserialization-provider-uml-template.hbs
+++ b/SysML2.NET.CodeGenerator/Templates/Uml/core-json-dto-deserialization-provider-uml-template.hbs
@@ -41,7 +41,7 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <summary>
         /// a dictionary that provides delegates for deserialization
         /// </summary>
-        private static readonly Dictionary<string, Func<JsonElement, SerializationModeKind, ILoggerFactory, IData>> DeSerializerActionMap = new Dictionary<string, Func<JsonElement, SerializationModeKind, ILoggerFactory, IData>>
+        private static readonly Dictionary<string, Func<JsonElement, SerializationModeKind, bool, ILoggerFactory, IData>> DeSerializerActionMap = new Dictionary<string, Func<JsonElement, SerializationModeKind, bool, ILoggerFactory, IData>>
         {
             {{#each this as | class |}}
             { "{{ class.Name }}", {{ class.Name }}DeSerializer.DeSerialize },
@@ -49,19 +49,19 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         };
 
         /// <summary>
-        /// Provides the delegate <see cref="Func{JsonElement, SerializationModeKind, ILoggerFactory, IData}"/> for the
+        /// Provides the delegate <see cref="Func{JsonElement, SerializationModeKind, bool, ILoggerFactory, IData}"/> for the
         /// <see cref="System.Type"/> that is to be deserialized
         /// </summary>
         /// <param name="typeName">
         /// The name of the subject <see cref="System.Type"/> that is to be serialized
         /// </param>
         /// <returns>
-        /// A Delegate of <see cref="Func{JsonElement, SerializationModeKind, ILoggerFactory, IData}"/>
+        /// A Delegate of <see cref="Func{JsonElement, SerializationModeKind, bool, ILoggerFactory, IData}"/>
         /// </returns>
         /// <exception cref="NotSupportedException">
         /// Thrown when the <see cref="System.Type"/> is not supported.
         /// </exception>
-        internal static Func<JsonElement, SerializationModeKind, ILoggerFactory, IData> Provide(string typeName)
+        internal static Func<JsonElement, SerializationModeKind, bool, ILoggerFactory, IData> Provide(string typeName)
         {
             if (!DeSerializerActionMap.TryGetValue(typeName, out var func))
             {

--- a/SysML2.NET.CodeGenerator/Templates/Uml/core-json-dto-deserializer-uml-template.hbs
+++ b/SysML2.NET.CodeGenerator/Templates/Uml/core-json-dto-deserializer-uml-template.hbs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="I{{ this.Name }}"/>
         /// </returns>
-        internal static I{{ this.Name }} DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static I{{ this.Name }} DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("{{ this.Name }}DeSerializer");
 
@@ -85,133 +88,302 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if(deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+            
+        /// <summary>
+        /// Deserializes properties of a <see cref="{{ this.Name }}" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="{{ this.Name }}"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="I{{ this.Name }}"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.{{ #NamedElement.WriteFullyQualifiedNameSpace this }}.{{ this.Name }} dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             {{#with this as |class| }}
                 {{ #each (Class.QueryAllProperties this) as | property | }}
-                        {{#unless this.IsTransient}}
-                            {{#unless (Property.IsPropertyRedefinedInClass this class)}}
-                            if (jsonElement.TryGetProperty("{{ property.Name }}"u8, out var {{ property.Name }}Property))
-                            {
-                            {{#if (Property.QueryIsReferenceProperty property)}}
-                                {{#if (Property.QueryIsEnumerable property)}}
-                                    foreach (var arrayItem in {{ property.Name }}Property.EnumerateArray())
-                                    {
-                                        if (arrayItem.TryGetProperty("@id"u8, out var {{ property.Name }}ExternalIdProperty))
-                                        {
-                                            var propertyValue = {{ property.Name }}ExternalIdProperty.GetString();
-                                    
-                                            if (propertyValue != null)
-                                            {
-                                                {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }}.Add(Guid.Parse(propertyValue));
-                                            }
-                                        }
-                                    }
-                                {{ else }}
-                                    if ({{ property.Name }}Property.ValueKind == JsonValueKind.Null)
-                                    {
-                                    {{#if (Property.QueryIsNullable property) }}
-                                        {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = null;
-                                    {{else}}
-                                        {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = Guid.Empty;
-                                        logger.LogDebug($"the {{ class.Name }}.{{Property.WritePropertyName property}} property was not found in the Json. The value is set to Guid.Empty");
-                                    {{/if}}
-                                    }
-                                    else
-                                    {
-                                        if ({{ property.Name }}Property.TryGetProperty("@id"u8, out var {{ property.Name }}ExternalIdProperty))
-                                        {
-                                            var propertyValue = {{ property.Name }}ExternalIdProperty.GetString();
-                                    
-                                            if (propertyValue != null)
-                                            {
-                                                {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = Guid.Parse(propertyValue);
-                                            }
-                                        }
-                                    }
-                                {{/if}}
+                {{#unless this.IsTransient}}
+                    {{#unless (Property.IsPropertyRedefinedInClass this class)}}
+                        if (jsonElement.TryGetProperty("{{ property.Name }}"u8, out var {{ property.Name }}Property))
+                        {
+                        {{#if (Property.QueryIsReferenceProperty property)}}
+                            {{#if (Property.QueryIsEnumerable property)}}
+                                foreach (var arrayItem in {{ property.Name }}Property.EnumerateArray())
+                                {
+                                if (arrayItem.TryGetProperty("@id"u8, out var {{ property.Name }}ExternalIdProperty))
+                                {
+                                var propertyValue = {{ property.Name }}ExternalIdProperty.GetString();
+            
+                                if (propertyValue != null)
+                                {
+                                {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }}.Add(Guid.Parse(propertyValue));
+                                }
+                                }
+                                }
                             {{ else }}
-                                {{#if (Property.QueryIsEnumerable property)}}
-                                    foreach (var arrayItem in {{ property.Name }}Property.EnumerateArray())
-                                    {
-                                    {{#if (Property.QueryIsBool property )}}
-                                        var propertyValue = arrayItem.GetBoolean();
-                                        
-                                        if (propertyValue != null)
-                                        {
-                                            {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }}.Add(propertyValue);
-                                        }
-                                    {{else if (Property.QueryIsEnum property )}}
-                                        throw new NotImplementedException("Enumerable Enum - {{class.Name}}.{{property.Name}} is not yet supported");
-                                    {{else if (Property.QueryIsNumeric property )}}
-                                        {{#if (Property.QueryIsInteger property) }}
-                                            {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }}.Add(arrayItem.GetInt32());
-                                        {{else if (Property.QueryIsDouble property) }}
-                                            {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }}.Add(arrayItem.GetDouble());
-                                        {{ else }}
-                                            throw new NotImplementedException("Enumerable Double - {{class.Name}}.{{property.Name}} is not yet supported");
-                                        {{/if}}
-                                    {{else}}
-                                        var propertyValue = arrayItem.GetString();
-                                        
-                                        if (propertyValue != null)
-                                        {
-                                         {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }}.Add(propertyValue);
-                                        }
-                                    {{/if}}
-                                    }
-                                {{ else if (Property.QueryIsNullable property) }}
-                                    {{#if (Property.QueryIsBool property )}}
-                                        {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Name }}Property.GetBoolean();
-                                    {{else if (Property.QueryIsEnum property )}}
-                                        {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Type.Name }}DeSerializer.DeserializeNullable({{ property.Name }}Property.GetString());
-                                    {{else if (Property.QueryIsNumeric property )}}
-                                        {{#if (Property.QueryIsInteger property) }}
-                                            {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Name }}Property.GetInt32();
-                                        {{else if (Property.QueryIsDouble property) }}
-                                            {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Name }}Property.GetDouble();
-                                        {{ else }}
-                                            new NotImplementedException("nullable - {{class.Name}}.{{property.Name}} is not yet supported");
-                                        {{/if}}
-                                    {{else}}
-                                        {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Name }}Property.GetString();
-                                    {{/if}}
-                                {{ else if (Property.QueryIsScalar property) }}
-                                    {{#if (Property.QueryIsBool property )}}
-                                        if ({{ property.Name }}Property.ValueKind != JsonValueKind.Null)
-                                        {
-                                            {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Name }}Property.GetBoolean();
-                                        }
-                                    {{else if (Property.QueryIsEnum property )}}
-                                        {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Type.Name }}DeSerializer.Deserialize({{ property.Name }}Property.GetString());
-                                    {{else if (Property.QueryIsNumeric property )}}
-                                        {{#if (Property.QueryIsInteger property) }}
-                                            {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Name }}Property.GetInt32();
-                                        {{else if (Property.QueryIsDouble property) }}
-                                            {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Name }}Property.GetDouble();
-                                        {{ else }}
-                                            new NotImplementedException("Scalar - {{class.Name}}.{{property.Name}} is not yet supported");
-                                        {{/if}}
-                                    {{else}}
-                                        var propertyValue = {{property.Name }}Property.GetString();
-                                        
-                                        if (propertyValue != null)
-                                        {
-                                        {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = propertyValue;
-                                        }
-                                    {{/if}}
+                                if ({{ property.Name }}Property.ValueKind == JsonValueKind.Null)
+                                {
+                                {{#if (Property.QueryIsNullable property) }}
+                                    {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = null;
+                                {{else}}
+                                    {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = Guid.Empty;
+                                    logger.LogDebug($"the {{ class.Name }}.{{Property.WritePropertyName property}} property was not found in the Json. The value is set to Guid.Empty");
                                 {{/if}}
+                                }
+                                else
+                                {
+                                if ({{ property.Name }}Property.TryGetProperty("@id"u8, out var {{ property.Name }}ExternalIdProperty))
+                                {
+                                var propertyValue = {{ property.Name }}ExternalIdProperty.GetString();
+            
+                                if (propertyValue != null)
+                                {
+                                {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = Guid.Parse(propertyValue);
+                                }
+                                }
+                                }
+                            {{/if}}
+                        {{ else }}
+                            {{#if (Property.QueryIsEnumerable property)}}
+                                foreach (var arrayItem in {{ property.Name }}Property.EnumerateArray())
+                                {
+                                {{#if (Property.QueryIsBool property )}}
+                                    var propertyValue = arrayItem.GetBoolean();
+            
+                                    if (propertyValue != null)
+                                    {
+                                    {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }}.Add(propertyValue);
+                                    }
+                                {{else if (Property.QueryIsEnum property )}}
+                                    throw new NotImplementedException("Enumerable Enum - {{class.Name}}.{{property.Name}} is not yet supported");
+                                {{else if (Property.QueryIsNumeric property )}}
+                                    {{#if (Property.QueryIsInteger property) }}
+                                        {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }}.Add(arrayItem.GetInt32());
+                                    {{else if (Property.QueryIsDouble property) }}
+                                        {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }}.Add(arrayItem.GetDouble());
+                                    {{ else }}
+                                        throw new NotImplementedException("Enumerable Double - {{class.Name}}.{{property.Name}} is not yet supported");
+                                    {{/if}}
+                                {{else}}
+                                    var propertyValue = arrayItem.GetString();
+            
+                                    if (propertyValue != null)
+                                    {
+                                    {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }}.Add(propertyValue);
+                                    }
+                                {{/if}}
+                                }
+                            {{ else if (Property.QueryIsNullable property) }}
+                                {{#if (Property.QueryIsBool property )}}
+                                    {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Name }}Property.GetBoolean();
+                                {{else if (Property.QueryIsEnum property )}}
+                                    {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Type.Name }}DeSerializer.DeserializeNullable({{ property.Name }}Property.GetString());
+                                {{else if (Property.QueryIsNumeric property )}}
+                                    {{#if (Property.QueryIsInteger property) }}
+                                        {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Name }}Property.GetInt32();
+                                    {{else if (Property.QueryIsDouble property) }}
+                                        {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Name }}Property.GetDouble();
+                                    {{ else }}
+                                        new NotImplementedException("nullable - {{class.Name}}.{{property.Name}} is not yet supported");
+                                    {{/if}}
+                                {{else}}
+                                    {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Name }}Property.GetString();
+                                {{/if}}
+                            {{ else if (Property.QueryIsScalar property) }}
+                                {{#if (Property.QueryIsBool property )}}
+                                    if ({{ property.Name }}Property.ValueKind != JsonValueKind.Null)
+                                    {
+                                    {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Name }}Property.GetBoolean();
+                                    }
+                                {{else if (Property.QueryIsEnum property )}}
+                                    {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Type.Name }}DeSerializer.Deserialize({{ property.Name }}Property.GetString());
+                                {{else if (Property.QueryIsNumeric property )}}
+                                    {{#if (Property.QueryIsInteger property) }}
+                                        {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Name }}Property.GetInt32();
+                                    {{else if (Property.QueryIsDouble property) }}
+                                        {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Name }}Property.GetDouble();
+                                    {{ else }}
+                                        new NotImplementedException("Scalar - {{class.Name}}.{{property.Name}} is not yet supported");
+                                    {{/if}}
+                                {{else}}
+                                    var propertyValue = {{property.Name }}Property.GetString();
+            
+                                    if (propertyValue != null)
+                                    {
+                                    {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = propertyValue;
+                                    }
+                                {{/if}}
+                            {{/if}}
+                        {{/if}}
+                        }
+                        else
+                        {
+                        logger.LogDebug("the {{ property.Name }} Json property was not found in the {{ class.Name }}: { Id }", dtoInstance.Id);
+                        }
+            
+                    {{/unless}}
+                {{/unless}}
+            {{/each}}
+            {{/with}}
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="{{ this.Name }}" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="{{ this.Name }}"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="I{{ this.Name }}"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.{{ #NamedElement.WriteFullyQualifiedNameSpace this }}.{{ this.Name }} dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+        {{#with this as |class| }}
+            {{ #each (Class.QueryAllProperties this) as | property | }}
+            {{#unless this.IsTransient}}
+            {{#unless this.IsDerived}}
+                {{#unless (Property.IsPropertyRedefinedInClass this class)}}
+                    if (jsonElement.TryGetProperty("{{ property.Name }}"u8, out var {{ property.Name }}Property))
+                    {
+                    {{#if (Property.QueryIsReferenceProperty property)}}
+                        {{#if (Property.QueryIsEnumerable property)}}
+                            foreach (var arrayItem in {{ property.Name }}Property.EnumerateArray())
+                            {
+                            if (arrayItem.TryGetProperty("@id"u8, out var {{ property.Name }}ExternalIdProperty))
+                            {
+                            var propertyValue = {{ property.Name }}ExternalIdProperty.GetString();
+
+                            if (propertyValue != null)
+                            {
+                            {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }}.Add(Guid.Parse(propertyValue));
+                            }
+                            }
+                            }
+                        {{ else }}
+                            if ({{ property.Name }}Property.ValueKind == JsonValueKind.Null)
+                            {
+                            {{#if (Property.QueryIsNullable property) }}
+                                {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = null;
+                            {{else}}
+                                {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = Guid.Empty;
+                                logger.LogDebug($"the {{ class.Name }}.{{Property.WritePropertyName property}} property was not found in the Json. The value is set to Guid.Empty");
                             {{/if}}
                             }
                             else
                             {
-                                logger.LogDebug("the {{ property.Name }} Json property was not found in the {{ class.Name }}: { Id }", dtoInstance.Id);
-                            }
-            
-                        {{/unless}}
-                    {{/unless}}
-                {{/each}}
-            {{/with}}
+                            if ({{ property.Name }}Property.TryGetProperty("@id"u8, out var {{ property.Name }}ExternalIdProperty))
+                            {
+                            var propertyValue = {{ property.Name }}ExternalIdProperty.GetString();
 
-            return dtoInstance;
+                            if (propertyValue != null)
+                            {
+                            {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = Guid.Parse(propertyValue);
+                            }
+                            }
+                            }
+                        {{/if}}
+                    {{ else }}
+                        {{#if (Property.QueryIsEnumerable property)}}
+                            foreach (var arrayItem in {{ property.Name }}Property.EnumerateArray())
+                            {
+                            {{#if (Property.QueryIsBool property )}}
+                                var propertyValue = arrayItem.GetBoolean();
+
+                                if (propertyValue != null)
+                                {
+                                {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }}.Add(propertyValue);
+                                }
+                            {{else if (Property.QueryIsEnum property )}}
+                                throw new NotImplementedException("Enumerable Enum - {{class.Name}}.{{property.Name}} is not yet supported");
+                            {{else if (Property.QueryIsNumeric property )}}
+                                {{#if (Property.QueryIsInteger property) }}
+                                    {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }}.Add(arrayItem.GetInt32());
+                                {{else if (Property.QueryIsDouble property) }}
+                                    {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }}.Add(arrayItem.GetDouble());
+                                {{ else }}
+                                    throw new NotImplementedException("Enumerable Double - {{class.Name}}.{{property.Name}} is not yet supported");
+                                {{/if}}
+                            {{else}}
+                                var propertyValue = arrayItem.GetString();
+
+                                if (propertyValue != null)
+                                {
+                                {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }}.Add(propertyValue);
+                                }
+                            {{/if}}
+                            }
+                        {{ else if (Property.QueryIsNullable property) }}
+                            {{#if (Property.QueryIsBool property )}}
+                                {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Name }}Property.GetBoolean();
+                            {{else if (Property.QueryIsEnum property )}}
+                                {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Type.Name }}DeSerializer.DeserializeNullable({{ property.Name }}Property.GetString());
+                            {{else if (Property.QueryIsNumeric property )}}
+                                {{#if (Property.QueryIsInteger property) }}
+                                    {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Name }}Property.GetInt32();
+                                {{else if (Property.QueryIsDouble property) }}
+                                    {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Name }}Property.GetDouble();
+                                {{ else }}
+                                    new NotImplementedException("nullable - {{class.Name}}.{{property.Name}} is not yet supported");
+                                {{/if}}
+                            {{else}}
+                                {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Name }}Property.GetString();
+                            {{/if}}
+                        {{ else if (Property.QueryIsScalar property) }}
+                            {{#if (Property.QueryIsBool property )}}
+                                if ({{ property.Name }}Property.ValueKind != JsonValueKind.Null)
+                                {
+                                {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Name }}Property.GetBoolean();
+                                }
+                            {{else if (Property.QueryIsEnum property )}}
+                                {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Type.Name }}DeSerializer.Deserialize({{ property.Name }}Property.GetString());
+                            {{else if (Property.QueryIsNumeric property )}}
+                                {{#if (Property.QueryIsInteger property) }}
+                                    {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Name }}Property.GetInt32();
+                                {{else if (Property.QueryIsDouble property) }}
+                                    {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = {{ property.Name }}Property.GetDouble();
+                                {{ else }}
+                                    new NotImplementedException("Scalar - {{class.Name}}.{{property.Name}} is not yet supported");
+                                {{/if}}
+                            {{else}}
+                                var propertyValue = {{property.Name }}Property.GetString();
+
+                                if (propertyValue != null)
+                                {
+                                {{ #Property.WritePropertyWithExplicitInterfaceIfRequiredForDTO property class dtoInstance }} = propertyValue;
+                                }
+                            {{/if}}
+                        {{/if}}
+                    {{/if}}
+                    }
+                    else
+                    {
+                    logger.LogDebug("the {{ property.Name }} Json property was not found in the {{ class.Name }}: { Id }", dtoInstance.Id);
+                    }
+
+                {{/unless}}
+            {{/unless}}
+            {{/unless}}
+        {{/each}}
+{{/with}}
         }
     }
 }

--- a/SysML2.NET.Serializer.Json.Tests/DeSerializerTestFixture.cs
+++ b/SysML2.NET.Serializer.Json.Tests/DeSerializerTestFixture.cs
@@ -50,19 +50,25 @@ namespace SysML2.NET.Serializer.Json.Tests
         }
         
         [Test]
-        public void Verify_that_idada_from_sysmlcore_json_can_be_deserialized()
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Verify_that_idada_from_sysmlcore_json_can_be_deserialized(bool shouldDeserializeDerivedProperties)
         {
             var fileName = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Data", "projects.000e9890-6935-43e6-a5d7-5d7cac601f4c.commits.6d7ad9fd-6520-4ff2-885b-8c5c129e6c27.elements.json");
-            using (var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read))
+            using var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
+
+            var data = this.deSerializer.DeSerialize(stream, SerializationModeKind.JSON, SerializationTargetKind.CORE, shouldDeserializeDerivedProperties);
+
+            using (Assert.EnterMultipleScope())
             {
-                var data = this.deSerializer.DeSerialize(stream, SerializationModeKind.JSON, SerializationTargetKind.CORE);
-
                 Assert.That(data.Count(), Is.EqualTo(100));
-
                 Assert.That(data.OfType<IFeature>().Count(), Is.EqualTo(30));
+            }
 
-                var feature = data.OfType<IFeature>().Single(x => x.Id == Guid.Parse("00a6ef10-d3dc-4741-9029-2c9978c2f083"));
+            var feature = data.OfType<IFeature>().Single(x => x.Id == Guid.Parse("00a6ef10-d3dc-4741-9029-2c9978c2f083"));
 
+            using (Assert.EnterMultipleScope())
+            {
                 Assert.That(feature.AliasIds, Is.Empty);
                 Assert.That(feature.ElementId, Is.EqualTo("00a6ef10-d3dc-4741-9029-2c9978c2f083"));
                 Assert.That(feature.IsAbstract, Is.False);
@@ -79,21 +85,29 @@ namespace SysML2.NET.Serializer.Json.Tests
         }
 
         [Test]
-        public async Task Verify_that_idada_from_sysmlcore_json_can_be_deserialized_async()
+        [TestCase(false)]
+        [TestCase(true)]
+        public async Task Verify_that_idada_from_sysmlcore_json_can_be_deserialized_async(bool shouldDeserializeDerivedProperties)
         {
             var fileName = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Data", "projects.000e9890-6935-43e6-a5d7-5d7cac601f4c.commits.6d7ad9fd-6520-4ff2-885b-8c5c129e6c27.elements.json");
-            using (var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read))
+
+            await using var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
+
+            var cts = new CancellationTokenSource();
+
+            var data = await this.deSerializer.DeSerializeAsync(stream, SerializationModeKind.JSON, SerializationTargetKind.CORE, shouldDeserializeDerivedProperties, cts.Token);
+
+            using (Assert.EnterMultipleScope())
             {
-                var cts = new CancellationTokenSource();
-
-                var data = await this.deSerializer.DeSerializeAsync(stream, SerializationModeKind.JSON, SerializationTargetKind.CORE, cts.Token);
-
                 Assert.That(data.Count(), Is.EqualTo(100));
 
                 Assert.That(data.OfType<IFeature>().Count(), Is.EqualTo(30));
+            }
 
-                var feature = data.OfType<IFeature>().Single(x => x.Id == Guid.Parse("00a6ef10-d3dc-4741-9029-2c9978c2f083"));
+            var feature = data.OfType<IFeature>().Single(x => x.Id == Guid.Parse("00a6ef10-d3dc-4741-9029-2c9978c2f083"));
 
+            using (Assert.EnterMultipleScope())
+            {
                 Assert.That(feature.AliasIds, Is.Empty);
                 Assert.That(feature.ElementId, Is.EqualTo("00a6ef10-d3dc-4741-9029-2c9978c2f083"));
                 Assert.That(feature.IsAbstract, Is.False);
@@ -110,17 +124,21 @@ namespace SysML2.NET.Serializer.Json.Tests
         }
 
         [Test]
-        public void Verify_that_projects_from_restapi_json_can_be_deserialized()
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Verify_that_projects_from_restapi_json_can_be_deserialized(bool shouldDeserializeDerivedProperties)
         {
             var fileName = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Data", "projects.json");
-            using (var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read))
+            using var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
+
+            var data = this.deSerializer.DeSerialize(stream, SerializationModeKind.JSON, SerializationTargetKind.PSM, shouldDeserializeDerivedProperties);
+
+            Assert.That(data.Count(), Is.EqualTo(43));
+
+            var project = data.OfType<Project>().Single(x => x.Id == Guid.Parse("000e9890-6935-43e6-a5d7-5d7cac601f4c"));
+
+            using (Assert.EnterMultipleScope())
             {
-                var data = this.deSerializer.DeSerialize(stream, SerializationModeKind.JSON, SerializationTargetKind.PSM);
-
-                Assert.That(data.Count(), Is.EqualTo(43));
-
-                var project = data.OfType<Project>().Single(x => x.Id == Guid.Parse("000e9890-6935-43e6-a5d7-5d7cac601f4c"));
-
                 Assert.That(project.DefaultBranch, Is.EqualTo(Guid.Parse("c294a463-6c9c-47a8-b592-01252c5ab2a7")));
                 Assert.That(project.Name, Is.EqualTo("7b-Variant Configurations Mon Mar 13 17:54:29 EDT 2023"));
                 Assert.That(project.Description, Is.Null);
@@ -128,17 +146,21 @@ namespace SysML2.NET.Serializer.Json.Tests
         }
 
         [Test]
-        public void Verify_that_particular_project_from_restapi_json_can_be_deserialized()
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Verify_that_particular_project_from_restapi_json_can_be_deserialized(bool shouldDeserializeDerivedProperties)
         {
             var fileName = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Data", "projects.000e9890-6935-43e6-a5d7-5d7cac601f4c.json");
-            using (var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read))
+            using var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
+
+            var data = this.deSerializer.DeSerialize(stream, SerializationModeKind.JSON, SerializationTargetKind.PSM, shouldDeserializeDerivedProperties);
+
+            Assert.That(data.Count(), Is.EqualTo(1));
+
+            var project = data.OfType<Project>().Single(x => x.Id == Guid.Parse("000e9890-6935-43e6-a5d7-5d7cac601f4c"));
+
+            using (Assert.EnterMultipleScope())
             {
-                var data = this.deSerializer.DeSerialize(stream, SerializationModeKind.JSON, SerializationTargetKind.PSM);
-
-                Assert.That(data.Count(), Is.EqualTo(1));
-
-                var project = data.OfType<Project>().Single(x => x.Id == Guid.Parse("000e9890-6935-43e6-a5d7-5d7cac601f4c"));
-
                 Assert.That(project.DefaultBranch, Is.EqualTo(Guid.Parse("c294a463-6c9c-47a8-b592-01252c5ab2a7")));
                 Assert.That(project.Name, Is.EqualTo("7b-Variant Configurations Mon Mar 13 17:54:29 EDT 2023"));
                 Assert.That(project.Description, Is.Null);
@@ -146,16 +168,21 @@ namespace SysML2.NET.Serializer.Json.Tests
         }
 
         [Test]
-        public void Verify_that_particular_project_and_commits_from_restapi_json_can_be_deserialized()
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Verify_that_particular_project_and_commits_from_restapi_json_can_be_deserialized(bool shouldDeserializeDerivedProperties)
         {
             var fileName = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Data", "projects.000e9890-6935-43e6-a5d7-5d7cac601f4c.commits.json");
-            using (var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read))
+            using var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
+
+            var data = this.deSerializer.DeSerialize(stream, SerializationModeKind.JSON, SerializationTargetKind.PSM, shouldDeserializeDerivedProperties);
+
+            Assert.That(data.Count(), Is.EqualTo(1));
+
+            var firstCommit = data.OfType<Commit>().Single(x => x.Id == Guid.Parse("6d7ad9fd-6520-4ff2-885b-8c5c129e6c27"));
+
+            using (Assert.EnterMultipleScope())
             {
-                var data = this.deSerializer.DeSerialize(stream, SerializationModeKind.JSON, SerializationTargetKind.PSM);
-
-                Assert.That(data.Count(), Is.EqualTo(1));
-
-                var firstCommit = data.OfType<Commit>().Single(x => x.Id == Guid.Parse("6d7ad9fd-6520-4ff2-885b-8c5c129e6c27"));
                 Assert.That(firstCommit.OwningProject, Is.EqualTo(Guid.Parse("000e9890-6935-43e6-a5d7-5d7cac601f4c")));
                 Assert.That(firstCommit.PreviousCommit, Is.EqualTo(Guid.Empty));
                 Assert.That(firstCommit.Description, Is.Null);
@@ -164,16 +191,21 @@ namespace SysML2.NET.Serializer.Json.Tests
         }
 
         [Test]
-        public void Verify_that_particular_project_and_particular_commit_from_restapi_json_can_be_deserialized()
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Verify_that_particular_project_and_particular_commit_from_restapi_json_can_be_deserialized(bool shouldDeserializeDerivedProperties)
         {
             var fileName = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Data", "projects.000e9890-6935-43e6-a5d7-5d7cac601f4c.commits.6d7ad9fd-6520-4ff2-885b-8c5c129e6c27.json");
-            using (var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read))
+            using var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
+
+            var data = this.deSerializer.DeSerialize(stream, SerializationModeKind.JSON, SerializationTargetKind.PSM, shouldDeserializeDerivedProperties);
+
+            Assert.That(data.Count(), Is.EqualTo(1));
+
+            var firstCommit = data.OfType<Commit>().Single(x => x.Id == Guid.Parse("6d7ad9fd-6520-4ff2-885b-8c5c129e6c27"));
+
+            using (Assert.EnterMultipleScope())
             {
-                var data = this.deSerializer.DeSerialize(stream, SerializationModeKind.JSON, SerializationTargetKind.PSM);
-
-                Assert.That(data.Count(), Is.EqualTo(1));
-
-                var firstCommit = data.OfType<Commit>().Single(x => x.Id == Guid.Parse("6d7ad9fd-6520-4ff2-885b-8c5c129e6c27"));
                 Assert.That(firstCommit.OwningProject, Is.EqualTo(Guid.Parse("000e9890-6935-43e6-a5d7-5d7cac601f4c")));
                 Assert.That(firstCommit.PreviousCommit, Is.EqualTo(Guid.Empty));
                 Assert.That(firstCommit.Description, Is.Null);
@@ -182,16 +214,21 @@ namespace SysML2.NET.Serializer.Json.Tests
         }
 
         [Test]
-        public void Verify_that_particular_project_and_branches_from_restapi_json_can_be_deserialized()
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Verify_that_particular_project_and_branches_from_restapi_json_can_be_deserialized(bool shouldDeserializeDerivedProperties)
         {
             var fileName = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Data", "projects.000e9890-6935-43e6-a5d7-5d7cac601f4c.branches.json");
-            using (var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read))
+            using var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
+
+            var data = this.deSerializer.DeSerialize(stream, SerializationModeKind.JSON, SerializationTargetKind.PSM, shouldDeserializeDerivedProperties);
+
+            Assert.That(data.Count(), Is.EqualTo(1));
+
+            var branch = data.OfType<Branch>().Single(x => x.Id == Guid.Parse("c294a463-6c9c-47a8-b592-01252c5ab2a7"));
+
+            using (Assert.EnterMultipleScope())
             {
-                var data = this.deSerializer.DeSerialize(stream, SerializationModeKind.JSON, SerializationTargetKind.PSM);
-
-                Assert.That(data.Count(), Is.EqualTo(1));
-
-                var branch = data.OfType<Branch>().Single(x => x.Id == Guid.Parse("c294a463-6c9c-47a8-b592-01252c5ab2a7"));
                 Assert.That(branch.OwningProject, Is.EqualTo(Guid.Parse("000e9890-6935-43e6-a5d7-5d7cac601f4c")));
                 Assert.That(branch.Name, Is.EqualTo("main"));
                 Assert.That(branch.Description, Is.Null);

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AcceptActionUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AcceptActionUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IAcceptActionUsage"/>
         /// </returns>
-        internal static IAcceptActionUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IAcceptActionUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("AcceptActionUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="AcceptActionUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="AcceptActionUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAcceptActionUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.AcceptActionUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actionDefinition"u8, out var actionDefinitionProperty))
             {
                 foreach (var arrayItem in actionDefinitionProperty.EnumerateArray())
@@ -2229,8 +2259,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the AcceptActionUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="AcceptActionUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="AcceptActionUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAcceptActionUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.AcceptActionUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the AcceptActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the AcceptActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the AcceptActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the AcceptActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the AcceptActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the AcceptActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the AcceptActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the AcceptActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the AcceptActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the AcceptActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the AcceptActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the AcceptActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the AcceptActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the AcceptActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the AcceptActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the AcceptActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the AcceptActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the AcceptActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the AcceptActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the AcceptActionUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ActionDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ActionDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IActionDefinition"/>
         /// </returns>
-        internal static IActionDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IActionDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ActionDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ActionDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ActionDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IActionDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.ActionDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("action"u8, out var actionProperty))
             {
                 foreach (var arrayItem in actionProperty.EnumerateArray())
@@ -1669,8 +1699,176 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the ActionDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ActionDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ActionDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IActionDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.ActionDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ActionDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ActionDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ActionDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ActionDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the ActionDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ActionDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the ActionDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the ActionDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the ActionDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ActionDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ActionDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ActionUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ActionUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IActionUsage"/>
         /// </returns>
-        internal static IActionUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IActionUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ActionUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ActionUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ActionUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IActionUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.ActionUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actionDefinition"u8, out var actionDefinitionProperty))
             {
                 foreach (var arrayItem in actionDefinitionProperty.EnumerateArray())
@@ -2156,8 +2186,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the ActionUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ActionUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ActionUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IActionUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.ActionUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the ActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the ActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the ActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the ActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the ActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the ActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the ActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the ActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the ActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the ActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the ActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the ActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the ActionUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ActorMembershipDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ActorMembershipDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IActorMembership"/>
         /// </returns>
-        internal static IActorMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IActorMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ActorMembershipDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ActorMembership" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ActorMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IActorMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Requirements.ActorMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -548,8 +578,193 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the ActorMembership: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ActorMembership" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ActorMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IActorMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Requirements.ActorMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ActorMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ActorMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ActorMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ActorMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the ActorMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ActorMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the ActorMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ActorMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the ActorMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ActorMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the ActorMembership: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AllocationDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AllocationDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IAllocationDefinition"/>
         /// </returns>
-        internal static IAllocationDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IAllocationDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("AllocationDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="AllocationDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="AllocationDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAllocationDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Allocations.AllocationDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1769,8 +1799,232 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the AllocationDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="AllocationDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="AllocationDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAllocationDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Allocations.AllocationDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the AllocationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the AllocationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the AllocationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the AllocationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the AllocationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the AllocationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the AllocationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the AllocationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the AllocationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the AllocationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the AllocationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the AllocationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the AllocationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the AllocationDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AllocationUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AllocationUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IAllocationUsage"/>
         /// </returns>
-        internal static IAllocationUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IAllocationUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("AllocationUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="AllocationUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="AllocationUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAllocationUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Allocations.AllocationUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2360,8 +2390,334 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the AllocationUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="AllocationUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="AllocationUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAllocationUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Allocations.AllocationUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the AllocationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the AllocationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the AllocationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the AllocationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the AllocationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the AllocationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the AllocationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the AllocationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the AllocationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the AllocationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the AllocationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the AllocationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the AllocationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the AllocationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the AllocationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the AllocationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the AllocationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the AllocationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the AllocationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the AllocationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the AllocationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the AllocationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the AllocationUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AnalysisCaseDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AnalysisCaseDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IAnalysisCaseDefinition"/>
         /// </returns>
-        internal static IAnalysisCaseDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IAnalysisCaseDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("AnalysisCaseDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="AnalysisCaseDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="AnalysisCaseDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAnalysisCaseDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.AnalysisCases.AnalysisCaseDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("action"u8, out var actionProperty))
             {
                 foreach (var arrayItem in actionProperty.EnumerateArray())
@@ -1839,8 +1869,176 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the AnalysisCaseDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="AnalysisCaseDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="AnalysisCaseDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAnalysisCaseDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.AnalysisCases.AnalysisCaseDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the AnalysisCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the AnalysisCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the AnalysisCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the AnalysisCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the AnalysisCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the AnalysisCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the AnalysisCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the AnalysisCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the AnalysisCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the AnalysisCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the AnalysisCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AnalysisCaseUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AnalysisCaseUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IAnalysisCaseUsage"/>
         /// </returns>
-        internal static IAnalysisCaseUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IAnalysisCaseUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("AnalysisCaseUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="AnalysisCaseUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="AnalysisCaseUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAnalysisCaseUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.AnalysisCases.AnalysisCaseUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actorParameter"u8, out var actorParameterProperty))
             {
                 foreach (var arrayItem in actorParameterProperty.EnumerateArray())
@@ -2290,8 +2320,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the AnalysisCaseUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="AnalysisCaseUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="AnalysisCaseUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAnalysisCaseUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.AnalysisCases.AnalysisCaseUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the AnalysisCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the AnalysisCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the AnalysisCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the AnalysisCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the AnalysisCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the AnalysisCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the AnalysisCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the AnalysisCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the AnalysisCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the AnalysisCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the AnalysisCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the AnalysisCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the AnalysisCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the AnalysisCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the AnalysisCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the AnalysisCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the AnalysisCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the AnalysisCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the AnalysisCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the AnalysisCaseUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AnnotatingElementDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AnnotatingElementDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IAnnotatingElement"/>
         /// </returns>
-        internal static IAnnotatingElement DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IAnnotatingElement DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("AnnotatingElementDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="AnnotatingElement" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="AnnotatingElement"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAnnotatingElement"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Root.Annotations.AnnotatingElement dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -465,8 +495,128 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the AnnotatingElement: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="AnnotatingElement" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="AnnotatingElement"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAnnotatingElement"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Root.Annotations.AnnotatingElement dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the AnnotatingElement: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the AnnotatingElement: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the AnnotatingElement: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the AnnotatingElement: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the AnnotatingElement: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the AnnotatingElement: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the AnnotatingElement: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AnnotationDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AnnotationDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IAnnotation"/>
         /// </returns>
-        internal static IAnnotation DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IAnnotation DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("AnnotationDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Annotation" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Annotation"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAnnotation"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Root.Annotations.Annotation dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -579,8 +609,209 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the Annotation: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Annotation" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Annotation"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAnnotation"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Root.Annotations.Annotation dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Annotation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("annotatedElement"u8, out var annotatedElementProperty))
+            {
+                if (annotatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.AnnotatedElement = Guid.Empty;
+                    logger.LogDebug($"the Annotation.AnnotatedElement property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (annotatedElementProperty.TryGetProperty("@id"u8, out var annotatedElementExternalIdProperty))
+                    {
+                        var propertyValue = annotatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.AnnotatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the annotatedElement Json property was not found in the Annotation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Annotation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Annotation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Annotation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the Annotation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Annotation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the Annotation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Annotation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the Annotation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Annotation: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AssertConstraintUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AssertConstraintUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IAssertConstraintUsage"/>
         /// </returns>
-        internal static IAssertConstraintUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IAssertConstraintUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("AssertConstraintUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="AssertConstraintUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="AssertConstraintUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAssertConstraintUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Constraints.AssertConstraintUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2254,8 +2284,290 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the AssertConstraintUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="AssertConstraintUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="AssertConstraintUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAssertConstraintUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Constraints.AssertConstraintUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the AssertConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the AssertConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the AssertConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the AssertConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the AssertConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the AssertConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the AssertConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the AssertConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the AssertConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the AssertConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the AssertConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the AssertConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isNegated"u8, out var isNegatedProperty))
+            {
+                if (isNegatedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsNegated = isNegatedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isNegated Json property was not found in the AssertConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the AssertConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the AssertConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the AssertConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the AssertConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the AssertConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the AssertConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the AssertConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the AssertConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AssignmentActionUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AssignmentActionUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IAssignmentActionUsage"/>
         /// </returns>
-        internal static IAssignmentActionUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IAssignmentActionUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("AssignmentActionUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="AssignmentActionUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="AssignmentActionUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAssignmentActionUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.AssignmentActionUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actionDefinition"u8, out var actionDefinitionProperty))
             {
                 foreach (var arrayItem in actionDefinitionProperty.EnumerateArray())
@@ -2229,8 +2259,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the AssignmentActionUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="AssignmentActionUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="AssignmentActionUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAssignmentActionUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.AssignmentActionUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the AssignmentActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the AssignmentActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the AssignmentActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the AssignmentActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the AssignmentActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the AssignmentActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the AssignmentActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the AssignmentActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the AssignmentActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the AssignmentActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the AssignmentActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the AssignmentActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the AssignmentActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the AssignmentActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the AssignmentActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the AssignmentActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the AssignmentActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the AssignmentActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the AssignmentActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the AssignmentActionUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AssociationDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AssociationDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IAssociation"/>
         /// </returns>
-        internal static IAssociation DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IAssociation DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("AssociationDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Association" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Association"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAssociation"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Associations.Association dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1105,8 +1135,208 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the Association: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Association" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Association"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAssociation"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Associations.Association dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Association: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Association: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Association: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Association: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the Association: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the Association: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Association: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the Association: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the Association: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Association: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the Association: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Association: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AssociationStructureDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AssociationStructureDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IAssociationStructure"/>
         /// </returns>
-        internal static IAssociationStructure DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IAssociationStructure DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("AssociationStructureDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="AssociationStructure" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="AssociationStructure"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAssociationStructure"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Associations.AssociationStructure dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1105,8 +1135,208 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the AssociationStructure: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="AssociationStructure" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="AssociationStructure"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAssociationStructure"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Associations.AssociationStructure dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the AssociationStructure: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the AssociationStructure: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the AssociationStructure: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the AssociationStructure: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the AssociationStructure: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the AssociationStructure: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the AssociationStructure: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the AssociationStructure: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the AssociationStructure: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the AssociationStructure: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the AssociationStructure: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the AssociationStructure: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AttributeDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AttributeDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IAttributeDefinition"/>
         /// </returns>
-        internal static IAttributeDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IAttributeDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("AttributeDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="AttributeDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="AttributeDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAttributeDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Attributes.AttributeDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1617,8 +1647,164 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the AttributeDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="AttributeDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="AttributeDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAttributeDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Attributes.AttributeDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the AttributeDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the AttributeDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the AttributeDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the AttributeDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the AttributeDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the AttributeDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the AttributeDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the AttributeDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the AttributeDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the AttributeDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AttributeUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/AttributeUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IAttributeUsage"/>
         /// </returns>
-        internal static IAttributeUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IAttributeUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("AttributeUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="AttributeUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="AttributeUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAttributeUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Attributes.AttributeUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2111,8 +2141,257 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the AttributeUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="AttributeUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="AttributeUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IAttributeUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Attributes.AttributeUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the AttributeUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the AttributeUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the AttributeUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the AttributeUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the AttributeUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the AttributeUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the AttributeUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the AttributeUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the AttributeUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the AttributeUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the AttributeUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the AttributeUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the AttributeUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the AttributeUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the AttributeUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the AttributeUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the AttributeUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the AttributeUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/BehaviorDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/BehaviorDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IBehavior"/>
         /// </returns>
-        internal static IBehavior DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IBehavior DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("BehaviorDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Behavior" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Behavior"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IBehavior"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Behaviors.Behavior dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1005,8 +1035,152 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the Behavior: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Behavior" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Behavior"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IBehavior"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Behaviors.Behavior dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Behavior: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Behavior: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Behavior: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Behavior: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the Behavior: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Behavior: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the Behavior: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Behavior: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Behavior: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/BindingConnectorAsUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/BindingConnectorAsUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IBindingConnectorAsUsage"/>
         /// </returns>
-        internal static IBindingConnectorAsUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IBindingConnectorAsUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("BindingConnectorAsUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="BindingConnectorAsUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="BindingConnectorAsUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IBindingConnectorAsUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Connections.BindingConnectorAsUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2275,8 +2305,313 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the BindingConnectorAsUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="BindingConnectorAsUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="BindingConnectorAsUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IBindingConnectorAsUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Connections.BindingConnectorAsUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the BindingConnectorAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the BindingConnectorAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the BindingConnectorAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the BindingConnectorAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the BindingConnectorAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the BindingConnectorAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the BindingConnectorAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the BindingConnectorAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the BindingConnectorAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the BindingConnectorAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the BindingConnectorAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the BindingConnectorAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the BindingConnectorAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the BindingConnectorAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the BindingConnectorAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the BindingConnectorAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the BindingConnectorAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the BindingConnectorAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the BindingConnectorAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the BindingConnectorAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the BindingConnectorAsUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/BindingConnectorDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/BindingConnectorDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IBindingConnector"/>
         /// </returns>
-        internal static IBindingConnector DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IBindingConnector DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("BindingConnectorDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="BindingConnector" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="BindingConnector"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IBindingConnector"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Connectors.BindingConnector dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1563,8 +1593,313 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the BindingConnector: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="BindingConnector" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="BindingConnector"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IBindingConnector"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Connectors.BindingConnector dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the BindingConnector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the BindingConnector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the BindingConnector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the BindingConnector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the BindingConnector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the BindingConnector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the BindingConnector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the BindingConnector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the BindingConnector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the BindingConnector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the BindingConnector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the BindingConnector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the BindingConnector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the BindingConnector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the BindingConnector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the BindingConnector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the BindingConnector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the BindingConnector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the BindingConnector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the BindingConnector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the BindingConnector: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/BooleanExpressionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/BooleanExpressionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IBooleanExpression"/>
         /// </returns>
-        internal static IBooleanExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IBooleanExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("BooleanExpressionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="BooleanExpression" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="BooleanExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IBooleanExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Functions.BooleanExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1480,8 +1510,257 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the BooleanExpression: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="BooleanExpression" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="BooleanExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IBooleanExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Functions.BooleanExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the BooleanExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the BooleanExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the BooleanExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the BooleanExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the BooleanExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the BooleanExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the BooleanExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the BooleanExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the BooleanExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the BooleanExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the BooleanExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the BooleanExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the BooleanExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the BooleanExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the BooleanExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the BooleanExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the BooleanExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the BooleanExpression: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/CalculationDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/CalculationDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ICalculationDefinition"/>
         /// </returns>
-        internal static ICalculationDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ICalculationDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("CalculationDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="CalculationDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="CalculationDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ICalculationDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Calculations.CalculationDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("action"u8, out var actionProperty))
             {
                 foreach (var arrayItem in actionProperty.EnumerateArray())
@@ -1746,8 +1776,176 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the CalculationDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="CalculationDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="CalculationDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ICalculationDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Calculations.CalculationDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the CalculationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the CalculationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the CalculationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the CalculationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the CalculationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the CalculationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the CalculationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the CalculationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the CalculationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the CalculationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the CalculationDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/CalculationUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/CalculationUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ICalculationUsage"/>
         /// </returns>
-        internal static ICalculationUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ICalculationUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("CalculationUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="CalculationUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="CalculationUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ICalculationUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Calculations.CalculationUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2197,8 +2227,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the CalculationUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="CalculationUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="CalculationUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ICalculationUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Calculations.CalculationUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the CalculationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the CalculationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the CalculationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the CalculationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the CalculationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the CalculationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the CalculationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the CalculationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the CalculationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the CalculationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the CalculationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the CalculationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the CalculationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the CalculationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the CalculationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the CalculationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the CalculationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the CalculationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the CalculationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the CalculationUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/CaseDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/CaseDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ICaseDefinition"/>
         /// </returns>
-        internal static ICaseDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ICaseDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("CaseDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="CaseDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="CaseDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ICaseDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Cases.CaseDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("action"u8, out var actionProperty))
             {
                 foreach (var arrayItem in actionProperty.EnumerateArray())
@@ -1815,8 +1845,176 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the CaseDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="CaseDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="CaseDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ICaseDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Cases.CaseDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the CaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the CaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the CaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the CaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the CaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the CaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the CaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the CaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the CaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the CaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the CaseDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/CaseUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/CaseUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ICaseUsage"/>
         /// </returns>
-        internal static ICaseUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ICaseUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("CaseUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="CaseUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="CaseUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ICaseUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Cases.CaseUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actorParameter"u8, out var actorParameterProperty))
             {
                 foreach (var arrayItem in actorParameterProperty.EnumerateArray())
@@ -2266,8 +2296,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the CaseUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="CaseUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="CaseUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ICaseUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Cases.CaseUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the CaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the CaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the CaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the CaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the CaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the CaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the CaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the CaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the CaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the CaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the CaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the CaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the CaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the CaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the CaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the CaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the CaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the CaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the CaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the CaseUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ClassDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ClassDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IClass"/>
         /// </returns>
-        internal static IClass DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IClass DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ClassDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Class" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Class"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IClass"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Classes.Class dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -985,8 +1015,152 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the Class: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Class" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Class"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IClass"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Classes.Class dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Class: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Class: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Class: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Class: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the Class: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Class: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the Class: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Class: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Class: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ClassifierDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ClassifierDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IClassifier"/>
         /// </returns>
-        internal static IClassifier DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IClassifier DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ClassifierDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Classifier" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Classifier"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IClassifier"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Classifiers.Classifier dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -985,8 +1015,152 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the Classifier: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Classifier" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Classifier"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IClassifier"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Classifiers.Classifier dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Classifier: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Classifier: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Classifier: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Classifier: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the Classifier: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Classifier: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the Classifier: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Classifier: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Classifier: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/CollectExpressionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/CollectExpressionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ICollectExpression"/>
         /// </returns>
-        internal static ICollectExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ICollectExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("CollectExpressionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="CollectExpression" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="CollectExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ICollectExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.CollectExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1539,8 +1569,271 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the CollectExpression: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="CollectExpression" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="CollectExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ICollectExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.CollectExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the CollectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the CollectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the CollectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the CollectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the CollectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the CollectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the CollectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the CollectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the CollectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the CollectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the CollectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the CollectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the CollectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the CollectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the CollectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the CollectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("operator"u8, out var operatorProperty))
+            {
+                var propertyValue = operatorProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.Operator = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the operator Json property was not found in the CollectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the CollectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the CollectExpression: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/CommentDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/CommentDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IComment"/>
         /// </returns>
-        internal static IComment DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IComment DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("CommentDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Comment" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Comment"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IComment"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Root.Annotations.Comment dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -488,8 +518,151 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the Comment: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Comment" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Comment"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IComment"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Root.Annotations.Comment dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Comment: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("body"u8, out var bodyProperty))
+            {
+                var propertyValue = bodyProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.Body = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the body Json property was not found in the Comment: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Comment: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Comment: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Comment: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Comment: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("locale"u8, out var localeProperty))
+            {
+                dtoInstance.Locale = localeProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the locale Json property was not found in the Comment: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Comment: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Comment: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ConcernDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ConcernDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IConcernDefinition"/>
         /// </returns>
-        internal static IConcernDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IConcernDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ConcernDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ConcernDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ConcernDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IConcernDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Requirements.ConcernDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actorParameter"u8, out var actorParameterProperty))
             {
                 foreach (var arrayItem in actorParameterProperty.EnumerateArray())
@@ -1848,8 +1878,176 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the ConcernDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ConcernDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ConcernDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IConcernDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Requirements.ConcernDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ConcernDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ConcernDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ConcernDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the ConcernDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ConcernDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the ConcernDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the ConcernDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the ConcernDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ConcernDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ConcernDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("reqId"u8, out var reqIdProperty))
+            {
+                dtoInstance.ReqId = reqIdProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the reqId Json property was not found in the ConcernDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ConcernUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ConcernUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IConcernUsage"/>
         /// </returns>
-        internal static IConcernUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IConcernUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ConcernUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ConcernUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ConcernUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IConcernUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Requirements.ConcernUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actorParameter"u8, out var actorParameterProperty))
             {
                 foreach (var arrayItem in actorParameterProperty.EnumerateArray())
@@ -2359,8 +2389,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the ConcernUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ConcernUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ConcernUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IConcernUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Requirements.ConcernUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ConcernUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ConcernUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the ConcernUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ConcernUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the ConcernUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the ConcernUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the ConcernUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the ConcernUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the ConcernUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ConcernUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the ConcernUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the ConcernUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the ConcernUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the ConcernUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the ConcernUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the ConcernUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ConcernUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ConcernUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the ConcernUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("reqId"u8, out var reqIdProperty))
+            {
+                dtoInstance.ReqId = reqIdProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the reqId Json property was not found in the ConcernUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ConjugatedPortDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ConjugatedPortDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IConjugatedPortDefinition"/>
         /// </returns>
-        internal static IConjugatedPortDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IConjugatedPortDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ConjugatedPortDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ConjugatedPortDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ConjugatedPortDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IConjugatedPortDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Ports.ConjugatedPortDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1655,8 +1685,176 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the ConjugatedPortDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ConjugatedPortDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ConjugatedPortDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IConjugatedPortDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Ports.ConjugatedPortDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ConjugatedPortDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ConjugatedPortDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ConjugatedPortDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ConjugatedPortDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the ConjugatedPortDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ConjugatedPortDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the ConjugatedPortDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the ConjugatedPortDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the ConjugatedPortDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ConjugatedPortDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ConjugatedPortDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ConjugatedPortTypingDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ConjugatedPortTypingDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IConjugatedPortTyping"/>
         /// </returns>
-        internal static IConjugatedPortTyping DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IConjugatedPortTyping DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ConjugatedPortTypingDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ConjugatedPortTyping" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ConjugatedPortTyping"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IConjugatedPortTyping"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Ports.ConjugatedPortTyping dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -556,8 +586,234 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the typedFeature Json property was not found in the ConjugatedPortTyping: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ConjugatedPortTyping" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ConjugatedPortTyping"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IConjugatedPortTyping"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Ports.ConjugatedPortTyping dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ConjugatedPortTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("conjugatedPortDefinition"u8, out var conjugatedPortDefinitionProperty))
+            {
+                if (conjugatedPortDefinitionProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.ConjugatedPortDefinition = Guid.Empty;
+                    logger.LogDebug($"the ConjugatedPortTyping.ConjugatedPortDefinition property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (conjugatedPortDefinitionProperty.TryGetProperty("@id"u8, out var conjugatedPortDefinitionExternalIdProperty))
+                    {
+                        var propertyValue = conjugatedPortDefinitionExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.ConjugatedPortDefinition = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the conjugatedPortDefinition Json property was not found in the ConjugatedPortTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ConjugatedPortTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ConjugatedPortTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ConjugatedPortTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the ConjugatedPortTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ConjugatedPortTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the ConjugatedPortTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ConjugatedPortTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the ConjugatedPortTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ConjugatedPortTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("typedFeature"u8, out var typedFeatureProperty))
+            {
+                if (typedFeatureProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.TypedFeature = Guid.Empty;
+                    logger.LogDebug($"the ConjugatedPortTyping.TypedFeature property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (typedFeatureProperty.TryGetProperty("@id"u8, out var typedFeatureExternalIdProperty))
+                    {
+                        var propertyValue = typedFeatureExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.TypedFeature = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the typedFeature Json property was not found in the ConjugatedPortTyping: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ConjugationDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ConjugationDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IConjugation"/>
         /// </returns>
-        internal static IConjugation DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IConjugation DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ConjugationDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Conjugation" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Conjugation"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IConjugation"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Types.Conjugation dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -531,8 +561,234 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the Conjugation: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Conjugation" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Conjugation"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IConjugation"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Types.Conjugation dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Conjugation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("conjugatedType"u8, out var conjugatedTypeProperty))
+            {
+                if (conjugatedTypeProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.ConjugatedType = Guid.Empty;
+                    logger.LogDebug($"the Conjugation.ConjugatedType property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (conjugatedTypeProperty.TryGetProperty("@id"u8, out var conjugatedTypeExternalIdProperty))
+                    {
+                        var propertyValue = conjugatedTypeExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.ConjugatedType = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the conjugatedType Json property was not found in the Conjugation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Conjugation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Conjugation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Conjugation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the Conjugation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Conjugation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("originalType"u8, out var originalTypeProperty))
+            {
+                if (originalTypeProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OriginalType = Guid.Empty;
+                    logger.LogDebug($"the Conjugation.OriginalType property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (originalTypeProperty.TryGetProperty("@id"u8, out var originalTypeExternalIdProperty))
+                    {
+                        var propertyValue = originalTypeExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OriginalType = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the originalType Json property was not found in the Conjugation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the Conjugation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Conjugation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the Conjugation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Conjugation: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ConnectionDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ConnectionDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IConnectionDefinition"/>
         /// </returns>
-        internal static IConnectionDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IConnectionDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ConnectionDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ConnectionDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ConnectionDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IConnectionDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Connections.ConnectionDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1749,8 +1779,232 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the ConnectionDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ConnectionDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ConnectionDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IConnectionDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Connections.ConnectionDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ConnectionDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ConnectionDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ConnectionDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ConnectionDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the ConnectionDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the ConnectionDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ConnectionDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the ConnectionDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the ConnectionDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the ConnectionDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the ConnectionDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ConnectionDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the ConnectionDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ConnectionDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ConnectionUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ConnectionUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IConnectionUsage"/>
         /// </returns>
-        internal static IConnectionUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IConnectionUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ConnectionUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ConnectionUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ConnectionUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IConnectionUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Connections.ConnectionUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2360,8 +2390,334 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the ConnectionUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ConnectionUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ConnectionUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IConnectionUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Connections.ConnectionUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ConnectionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ConnectionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ConnectionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the ConnectionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ConnectionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the ConnectionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the ConnectionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the ConnectionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the ConnectionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the ConnectionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the ConnectionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ConnectionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the ConnectionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the ConnectionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the ConnectionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the ConnectionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the ConnectionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the ConnectionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the ConnectionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ConnectionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the ConnectionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ConnectionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the ConnectionUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ConnectorDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ConnectorDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IConnector"/>
         /// </returns>
-        internal static IConnector DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IConnector DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ConnectorDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Connector" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Connector"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IConnector"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Connectors.Connector dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1563,8 +1593,313 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the Connector: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Connector" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Connector"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IConnector"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Connectors.Connector dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Connector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Connector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Connector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the Connector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Connector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the Connector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the Connector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the Connector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the Connector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the Connector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the Connector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Connector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the Connector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the Connector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the Connector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the Connector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the Connector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the Connector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Connector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the Connector: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Connector: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ConstraintDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ConstraintDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IConstraintDefinition"/>
         /// </returns>
-        internal static IConstraintDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IConstraintDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ConstraintDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ConstraintDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ConstraintDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IConstraintDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Constraints.ConstraintDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1706,8 +1736,176 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the ConstraintDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ConstraintDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ConstraintDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IConstraintDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Constraints.ConstraintDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ConstraintDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ConstraintDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ConstraintDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ConstraintDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the ConstraintDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ConstraintDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the ConstraintDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the ConstraintDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the ConstraintDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ConstraintDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ConstraintDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ConstraintUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ConstraintUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IConstraintUsage"/>
         /// </returns>
-        internal static IConstraintUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IConstraintUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ConstraintUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ConstraintUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ConstraintUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IConstraintUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Constraints.ConstraintUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2217,8 +2247,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the ConstraintUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ConstraintUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ConstraintUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IConstraintUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Constraints.ConstraintUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the ConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the ConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the ConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the ConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the ConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the ConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the ConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the ConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the ConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the ConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the ConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the ConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the ConstraintUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ConstructorExpressionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ConstructorExpressionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IConstructorExpression"/>
         /// </returns>
-        internal static IConstructorExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IConstructorExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ConstructorExpressionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ConstructorExpression" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ConstructorExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IConstructorExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.ConstructorExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1525,8 +1555,257 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the ConstructorExpression: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ConstructorExpression" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ConstructorExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IConstructorExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.ConstructorExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ConstructorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ConstructorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ConstructorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the ConstructorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ConstructorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the ConstructorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the ConstructorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the ConstructorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the ConstructorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the ConstructorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ConstructorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the ConstructorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the ConstructorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the ConstructorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the ConstructorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the ConstructorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ConstructorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ConstructorExpression: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/CrossSubsettingDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/CrossSubsettingDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ICrossSubsetting"/>
         /// </returns>
-        internal static ICrossSubsetting DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ICrossSubsetting DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("CrossSubsettingDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="CrossSubsetting" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="CrossSubsetting"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ICrossSubsetting"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.CrossSubsetting dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -507,8 +537,209 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the CrossSubsetting: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="CrossSubsetting" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="CrossSubsetting"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ICrossSubsetting"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.CrossSubsetting dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the CrossSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("crossedFeature"u8, out var crossedFeatureProperty))
+            {
+                if (crossedFeatureProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.CrossedFeature = Guid.Empty;
+                    logger.LogDebug($"the CrossSubsetting.CrossedFeature property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (crossedFeatureProperty.TryGetProperty("@id"u8, out var crossedFeatureExternalIdProperty))
+                    {
+                        var propertyValue = crossedFeatureExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.CrossedFeature = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the crossedFeature Json property was not found in the CrossSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the CrossSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the CrossSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the CrossSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the CrossSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the CrossSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the CrossSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the CrossSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the CrossSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the CrossSubsetting: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/DataTypeDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/DataTypeDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IDataType"/>
         /// </returns>
-        internal static IDataType DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IDataType DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("DataTypeDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="DataType" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="DataType"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IDataType"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.DataTypes.DataType dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -985,8 +1015,152 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the DataType: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="DataType" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="DataType"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IDataType"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.DataTypes.DataType dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the DataType: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the DataType: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the DataType: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the DataType: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the DataType: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the DataType: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the DataType: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the DataType: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the DataType: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/DeSerializationProvider.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/DeSerializationProvider.cs
@@ -41,7 +41,7 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <summary>
         /// a dictionary that provides delegates for deserialization
         /// </summary>
-        private static readonly Dictionary<string, Func<JsonElement, SerializationModeKind, ILoggerFactory, IData>> DeSerializerActionMap = new Dictionary<string, Func<JsonElement, SerializationModeKind, ILoggerFactory, IData>>
+        private static readonly Dictionary<string, Func<JsonElement, SerializationModeKind, bool, ILoggerFactory, IData>> DeSerializerActionMap = new Dictionary<string, Func<JsonElement, SerializationModeKind, bool, ILoggerFactory, IData>>
         {
             { "AcceptActionUsage", AcceptActionUsageDeSerializer.DeSerialize },
             { "ActionDefinition", ActionDefinitionDeSerializer.DeSerialize },
@@ -213,19 +213,19 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         };
 
         /// <summary>
-        /// Provides the delegate <see cref="Func{JsonElement, SerializationModeKind, ILoggerFactory, IData}"/> for the
+        /// Provides the delegate <see cref="Func{JsonElement, SerializationModeKind, bool, ILoggerFactory, IData}"/> for the
         /// <see cref="System.Type"/> that is to be deserialized
         /// </summary>
         /// <param name="typeName">
         /// The name of the subject <see cref="System.Type"/> that is to be serialized
         /// </param>
         /// <returns>
-        /// A Delegate of <see cref="Func{JsonElement, SerializationModeKind, ILoggerFactory, IData}"/>
+        /// A Delegate of <see cref="Func{JsonElement, SerializationModeKind, bool, ILoggerFactory, IData}"/>
         /// </returns>
         /// <exception cref="NotSupportedException">
         /// Thrown when the <see cref="System.Type"/> is not supported.
         /// </exception>
-        internal static Func<JsonElement, SerializationModeKind, ILoggerFactory, IData> Provide(string typeName)
+        internal static Func<JsonElement, SerializationModeKind, bool, ILoggerFactory, IData> Provide(string typeName)
         {
             if (!DeSerializerActionMap.TryGetValue(typeName, out var func))
             {

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/DecisionNodeDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/DecisionNodeDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IDecisionNode"/>
         /// </returns>
-        internal static IDecisionNode DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IDecisionNode DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("DecisionNodeDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="DecisionNode" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="DecisionNode"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IDecisionNode"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.DecisionNode dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actionDefinition"u8, out var actionDefinitionProperty))
             {
                 foreach (var arrayItem in actionDefinitionProperty.EnumerateArray())
@@ -2156,8 +2186,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the DecisionNode: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="DecisionNode" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="DecisionNode"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IDecisionNode"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.DecisionNode dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the DecisionNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the DecisionNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the DecisionNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the DecisionNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the DecisionNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the DecisionNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the DecisionNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the DecisionNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the DecisionNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the DecisionNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the DecisionNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the DecisionNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the DecisionNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the DecisionNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the DecisionNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the DecisionNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the DecisionNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the DecisionNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the DecisionNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the DecisionNode: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/DefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/DefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IDefinition"/>
         /// </returns>
-        internal static IDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("DefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Definition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Definition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.DefinitionAndUsage.Definition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1617,8 +1647,164 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the Definition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Definition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Definition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.DefinitionAndUsage.Definition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Definition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Definition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Definition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Definition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the Definition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Definition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the Definition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the Definition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Definition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Definition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/DependencyDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/DependencyDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IDependency"/>
         /// </returns>
-        internal static IDependency DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IDependency DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("DependencyDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Dependency" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Dependency"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IDependency"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Root.Dependencies.Dependency dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -497,8 +527,224 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the Dependency: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Dependency" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Dependency"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IDependency"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Root.Dependencies.Dependency dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Dependency: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("client"u8, out var clientProperty))
+            {
+                foreach (var arrayItem in clientProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var clientExternalIdProperty))
+                    {
+                        var propertyValue = clientExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.Client.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the client Json property was not found in the Dependency: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Dependency: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Dependency: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Dependency: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the Dependency: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Dependency: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the Dependency: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Dependency: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the Dependency: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Dependency: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("supplier"u8, out var supplierProperty))
+            {
+                foreach (var arrayItem in supplierProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var supplierExternalIdProperty))
+                    {
+                        var propertyValue = supplierExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.Supplier.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the supplier Json property was not found in the Dependency: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/DifferencingDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/DifferencingDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IDifferencing"/>
         /// </returns>
-        internal static IDifferencing DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IDifferencing DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("DifferencingDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Differencing" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Differencing"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IDifferencing"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Types.Differencing dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -507,8 +537,209 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the typeDifferenced Json property was not found in the Differencing: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Differencing" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Differencing"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IDifferencing"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Types.Differencing dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Differencing: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Differencing: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Differencing: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("differencingType"u8, out var differencingTypeProperty))
+            {
+                if (differencingTypeProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.DifferencingType = Guid.Empty;
+                    logger.LogDebug($"the Differencing.DifferencingType property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (differencingTypeProperty.TryGetProperty("@id"u8, out var differencingTypeExternalIdProperty))
+                    {
+                        var propertyValue = differencingTypeExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.DifferencingType = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the differencingType Json property was not found in the Differencing: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Differencing: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the Differencing: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Differencing: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the Differencing: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Differencing: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the Differencing: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Differencing: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/DisjoiningDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/DisjoiningDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IDisjoining"/>
         /// </returns>
-        internal static IDisjoining DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IDisjoining DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("DisjoiningDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Disjoining" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Disjoining"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IDisjoining"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Types.Disjoining dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -531,8 +561,234 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the typeDisjoined Json property was not found in the Disjoining: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Disjoining" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Disjoining"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IDisjoining"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Types.Disjoining dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Disjoining: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Disjoining: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Disjoining: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("disjoiningType"u8, out var disjoiningTypeProperty))
+            {
+                if (disjoiningTypeProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.DisjoiningType = Guid.Empty;
+                    logger.LogDebug($"the Disjoining.DisjoiningType property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (disjoiningTypeProperty.TryGetProperty("@id"u8, out var disjoiningTypeExternalIdProperty))
+                    {
+                        var propertyValue = disjoiningTypeExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.DisjoiningType = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the disjoiningType Json property was not found in the Disjoining: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Disjoining: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the Disjoining: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Disjoining: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the Disjoining: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Disjoining: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the Disjoining: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Disjoining: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("typeDisjoined"u8, out var typeDisjoinedProperty))
+            {
+                if (typeDisjoinedProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.TypeDisjoined = Guid.Empty;
+                    logger.LogDebug($"the Disjoining.TypeDisjoined property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (typeDisjoinedProperty.TryGetProperty("@id"u8, out var typeDisjoinedExternalIdProperty))
+                    {
+                        var propertyValue = typeDisjoinedExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.TypeDisjoined = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the typeDisjoined Json property was not found in the Disjoining: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/DocumentationDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/DocumentationDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IDocumentation"/>
         /// </returns>
-        internal static IDocumentation DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IDocumentation DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("DocumentationDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Documentation" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Documentation"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IDocumentation"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Root.Annotations.Documentation dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -493,8 +523,151 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the Documentation: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Documentation" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Documentation"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IDocumentation"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Root.Annotations.Documentation dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Documentation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("body"u8, out var bodyProperty))
+            {
+                var propertyValue = bodyProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.Body = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the body Json property was not found in the Documentation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Documentation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Documentation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Documentation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Documentation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("locale"u8, out var localeProperty))
+            {
+                dtoInstance.Locale = localeProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the locale Json property was not found in the Documentation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Documentation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Documentation: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ElementFilterMembershipDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ElementFilterMembershipDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IElementFilterMembership"/>
         /// </returns>
-        internal static IElementFilterMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IElementFilterMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ElementFilterMembershipDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ElementFilterMembership" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ElementFilterMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IElementFilterMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Packages.ElementFilterMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -548,8 +578,193 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the ElementFilterMembership: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ElementFilterMembership" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ElementFilterMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IElementFilterMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Packages.ElementFilterMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ElementFilterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ElementFilterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ElementFilterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ElementFilterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the ElementFilterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ElementFilterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the ElementFilterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ElementFilterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the ElementFilterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ElementFilterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the ElementFilterMembership: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/EndFeatureMembershipDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/EndFeatureMembershipDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IEndFeatureMembership"/>
         /// </returns>
-        internal static IEndFeatureMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IEndFeatureMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("EndFeatureMembershipDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="EndFeatureMembership" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="EndFeatureMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IEndFeatureMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.EndFeatureMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -548,8 +578,193 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the EndFeatureMembership: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="EndFeatureMembership" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="EndFeatureMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IEndFeatureMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.EndFeatureMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the EndFeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the EndFeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the EndFeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the EndFeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the EndFeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the EndFeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the EndFeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the EndFeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the EndFeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the EndFeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the EndFeatureMembership: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/EnumerationDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/EnumerationDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IEnumerationDefinition"/>
         /// </returns>
-        internal static IEnumerationDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IEnumerationDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("EnumerationDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="EnumerationDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="EnumerationDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IEnumerationDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Enumerations.EnumerationDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1617,8 +1647,164 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the EnumerationDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="EnumerationDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="EnumerationDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IEnumerationDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Enumerations.EnumerationDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the EnumerationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the EnumerationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the EnumerationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the EnumerationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the EnumerationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the EnumerationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the EnumerationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the EnumerationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the EnumerationDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the EnumerationDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/EnumerationUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/EnumerationUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IEnumerationUsage"/>
         /// </returns>
-        internal static IEnumerationUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IEnumerationUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("EnumerationUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="EnumerationUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="EnumerationUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IEnumerationUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Enumerations.EnumerationUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2116,8 +2146,257 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the EnumerationUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="EnumerationUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="EnumerationUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IEnumerationUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Enumerations.EnumerationUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the EnumerationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the EnumerationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the EnumerationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the EnumerationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the EnumerationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the EnumerationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the EnumerationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the EnumerationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the EnumerationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the EnumerationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the EnumerationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the EnumerationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the EnumerationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the EnumerationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the EnumerationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the EnumerationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the EnumerationUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the EnumerationUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/EventOccurrenceUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/EventOccurrenceUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IEventOccurrenceUsage"/>
         /// </returns>
-        internal static IEventOccurrenceUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IEventOccurrenceUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("EventOccurrenceUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="EventOccurrenceUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="EventOccurrenceUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IEventOccurrenceUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Occurrences.EventOccurrenceUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2181,8 +2211,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the EventOccurrenceUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="EventOccurrenceUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="EventOccurrenceUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IEventOccurrenceUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Occurrences.EventOccurrenceUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the EventOccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the EventOccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the EventOccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the EventOccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the EventOccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the EventOccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the EventOccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the EventOccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the EventOccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the EventOccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the EventOccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the EventOccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the EventOccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the EventOccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the EventOccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the EventOccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the EventOccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the EventOccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the EventOccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the EventOccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ExhibitStateUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ExhibitStateUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IExhibitStateUsage"/>
         /// </returns>
-        internal static IExhibitStateUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IExhibitStateUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ExhibitStateUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ExhibitStateUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ExhibitStateUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IExhibitStateUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.States.ExhibitStateUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2265,8 +2295,290 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the ExhibitStateUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ExhibitStateUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ExhibitStateUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IExhibitStateUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.States.ExhibitStateUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ExhibitStateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ExhibitStateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ExhibitStateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the ExhibitStateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ExhibitStateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the ExhibitStateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the ExhibitStateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the ExhibitStateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the ExhibitStateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the ExhibitStateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ExhibitStateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the ExhibitStateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the ExhibitStateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isParallel"u8, out var isParallelProperty))
+            {
+                if (isParallelProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsParallel = isParallelProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isParallel Json property was not found in the ExhibitStateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the ExhibitStateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the ExhibitStateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the ExhibitStateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the ExhibitStateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ExhibitStateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ExhibitStateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the ExhibitStateUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ExpressionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ExpressionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IExpression"/>
         /// </returns>
-        internal static IExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ExpressionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Expression" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Expression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Functions.Expression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1480,8 +1510,257 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the Expression: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Expression" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Expression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Functions.Expression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Expression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Expression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Expression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the Expression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Expression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the Expression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the Expression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the Expression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the Expression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the Expression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Expression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the Expression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the Expression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the Expression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the Expression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the Expression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Expression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Expression: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FeatureChainExpressionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FeatureChainExpressionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IFeatureChainExpression"/>
         /// </returns>
-        internal static IFeatureChainExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IFeatureChainExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("FeatureChainExpressionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="FeatureChainExpression" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FeatureChainExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFeatureChainExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.FeatureChainExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1564,8 +1594,271 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the FeatureChainExpression: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="FeatureChainExpression" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FeatureChainExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFeatureChainExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.FeatureChainExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the FeatureChainExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the FeatureChainExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the FeatureChainExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the FeatureChainExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the FeatureChainExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the FeatureChainExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the FeatureChainExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the FeatureChainExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the FeatureChainExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the FeatureChainExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the FeatureChainExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the FeatureChainExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the FeatureChainExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the FeatureChainExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the FeatureChainExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the FeatureChainExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("operator"u8, out var operatorProperty))
+            {
+                var propertyValue = operatorProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.Operator = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the operator Json property was not found in the FeatureChainExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the FeatureChainExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the FeatureChainExpression: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FeatureChainingDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FeatureChainingDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IFeatureChaining"/>
         /// </returns>
-        internal static IFeatureChaining DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IFeatureChaining DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("FeatureChainingDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="FeatureChaining" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FeatureChaining"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFeatureChaining"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.FeatureChaining dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -507,8 +537,209 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the FeatureChaining: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="FeatureChaining" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FeatureChaining"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFeatureChaining"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.FeatureChaining dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the FeatureChaining: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("chainingFeature"u8, out var chainingFeatureProperty))
+            {
+                if (chainingFeatureProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.ChainingFeature = Guid.Empty;
+                    logger.LogDebug($"the FeatureChaining.ChainingFeature property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (chainingFeatureProperty.TryGetProperty("@id"u8, out var chainingFeatureExternalIdProperty))
+                    {
+                        var propertyValue = chainingFeatureExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.ChainingFeature = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the chainingFeature Json property was not found in the FeatureChaining: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the FeatureChaining: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the FeatureChaining: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the FeatureChaining: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the FeatureChaining: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the FeatureChaining: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the FeatureChaining: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the FeatureChaining: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the FeatureChaining: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the FeatureChaining: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FeatureDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FeatureDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IFeature"/>
         /// </returns>
-        internal static IFeature DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IFeature DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("FeatureDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Feature" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Feature"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFeature"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.Feature dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1419,8 +1449,257 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the Feature: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Feature" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Feature"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFeature"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.Feature dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Feature: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FeatureInvertingDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FeatureInvertingDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IFeatureInverting"/>
         /// </returns>
-        internal static IFeatureInverting DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IFeatureInverting DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("FeatureInvertingDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="FeatureInverting" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FeatureInverting"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFeatureInverting"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.FeatureInverting dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -531,8 +561,234 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the FeatureInverting: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="FeatureInverting" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FeatureInverting"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFeatureInverting"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.FeatureInverting dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the FeatureInverting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the FeatureInverting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the FeatureInverting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the FeatureInverting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("featureInverted"u8, out var featureInvertedProperty))
+            {
+                if (featureInvertedProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.FeatureInverted = Guid.Empty;
+                    logger.LogDebug($"the FeatureInverting.FeatureInverted property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (featureInvertedProperty.TryGetProperty("@id"u8, out var featureInvertedExternalIdProperty))
+                    {
+                        var propertyValue = featureInvertedExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.FeatureInverted = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the featureInverted Json property was not found in the FeatureInverting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("invertingFeature"u8, out var invertingFeatureProperty))
+            {
+                if (invertingFeatureProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.InvertingFeature = Guid.Empty;
+                    logger.LogDebug($"the FeatureInverting.InvertingFeature property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (invertingFeatureProperty.TryGetProperty("@id"u8, out var invertingFeatureExternalIdProperty))
+                    {
+                        var propertyValue = invertingFeatureExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.InvertingFeature = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the invertingFeature Json property was not found in the FeatureInverting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the FeatureInverting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the FeatureInverting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the FeatureInverting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the FeatureInverting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the FeatureInverting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the FeatureInverting: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FeatureMembershipDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FeatureMembershipDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IFeatureMembership"/>
         /// </returns>
-        internal static IFeatureMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IFeatureMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("FeatureMembershipDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="FeatureMembership" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FeatureMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFeatureMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Types.FeatureMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -548,8 +578,193 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the FeatureMembership: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="FeatureMembership" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FeatureMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFeatureMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Types.FeatureMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the FeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the FeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the FeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the FeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the FeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the FeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the FeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the FeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the FeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the FeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the FeatureMembership: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FeatureReferenceExpressionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FeatureReferenceExpressionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IFeatureReferenceExpression"/>
         /// </returns>
-        internal static IFeatureReferenceExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IFeatureReferenceExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("FeatureReferenceExpressionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="FeatureReferenceExpression" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FeatureReferenceExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFeatureReferenceExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.FeatureReferenceExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1505,8 +1535,257 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the FeatureReferenceExpression: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="FeatureReferenceExpression" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FeatureReferenceExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFeatureReferenceExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.FeatureReferenceExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the FeatureReferenceExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the FeatureReferenceExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the FeatureReferenceExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the FeatureReferenceExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the FeatureReferenceExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the FeatureReferenceExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the FeatureReferenceExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the FeatureReferenceExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the FeatureReferenceExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the FeatureReferenceExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the FeatureReferenceExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the FeatureReferenceExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the FeatureReferenceExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the FeatureReferenceExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the FeatureReferenceExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the FeatureReferenceExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the FeatureReferenceExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the FeatureReferenceExpression: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FeatureTypingDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FeatureTypingDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IFeatureTyping"/>
         /// </returns>
-        internal static IFeatureTyping DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IFeatureTyping DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("FeatureTypingDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="FeatureTyping" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FeatureTyping"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFeatureTyping"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.FeatureTyping dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -531,8 +561,234 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the typedFeature Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="FeatureTyping" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FeatureTyping"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFeatureTyping"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.FeatureTyping dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("type"u8, out var typeProperty))
+            {
+                if (typeProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.Type = Guid.Empty;
+                    logger.LogDebug($"the FeatureTyping.Type property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (typeProperty.TryGetProperty("@id"u8, out var typeExternalIdProperty))
+                    {
+                        var propertyValue = typeExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.Type = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the type Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("typedFeature"u8, out var typedFeatureProperty))
+            {
+                if (typedFeatureProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.TypedFeature = Guid.Empty;
+                    logger.LogDebug($"the FeatureTyping.TypedFeature property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (typedFeatureProperty.TryGetProperty("@id"u8, out var typedFeatureExternalIdProperty))
+                    {
+                        var propertyValue = typedFeatureExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.TypedFeature = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the typedFeature Json property was not found in the FeatureTyping: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FeatureValueDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FeatureValueDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IFeatureValue"/>
         /// </returns>
-        internal static IFeatureValue DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IFeatureValue DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("FeatureValueDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="FeatureValue" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FeatureValue"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFeatureValue"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.FeatureValues.FeatureValue dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -597,8 +627,217 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the FeatureValue: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="FeatureValue" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FeatureValue"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFeatureValue"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.FeatureValues.FeatureValue dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the FeatureValue: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the FeatureValue: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the FeatureValue: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the FeatureValue: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDefault"u8, out var isDefaultProperty))
+            {
+                if (isDefaultProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDefault = isDefaultProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDefault Json property was not found in the FeatureValue: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the FeatureValue: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the FeatureValue: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isInitial"u8, out var isInitialProperty))
+            {
+                if (isInitialProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsInitial = isInitialProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isInitial Json property was not found in the FeatureValue: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the FeatureValue: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the FeatureValue: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the FeatureValue: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the FeatureValue: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the FeatureValue: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FlowDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FlowDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IFlow"/>
         /// </returns>
-        internal static IFlow DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IFlow DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("FlowDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Flow" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Flow"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFlow"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Interactions.Flow dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1675,8 +1705,313 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the Flow: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Flow" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Flow"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFlow"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Interactions.Flow dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Flow: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FlowDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FlowDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IFlowDefinition"/>
         /// </returns>
-        internal static IFlowDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IFlowDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("FlowDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="FlowDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FlowDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFlowDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Flows.FlowDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("action"u8, out var actionProperty))
             {
                 foreach (var arrayItem in actionProperty.EnumerateArray())
@@ -1789,8 +1819,232 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the FlowDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="FlowDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FlowDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFlowDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Flows.FlowDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the FlowDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the FlowDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the FlowDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the FlowDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the FlowDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the FlowDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the FlowDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the FlowDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the FlowDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the FlowDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the FlowDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the FlowDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the FlowDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the FlowDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FlowEndDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FlowEndDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IFlowEnd"/>
         /// </returns>
-        internal static IFlowEnd DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IFlowEnd DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("FlowEndDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="FlowEnd" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FlowEnd"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFlowEnd"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Interactions.FlowEnd dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1419,8 +1449,257 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the FlowEnd: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="FlowEnd" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FlowEnd"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFlowEnd"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Interactions.FlowEnd dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the FlowEnd: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the FlowEnd: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the FlowEnd: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the FlowEnd: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the FlowEnd: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the FlowEnd: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the FlowEnd: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the FlowEnd: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the FlowEnd: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the FlowEnd: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the FlowEnd: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the FlowEnd: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the FlowEnd: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the FlowEnd: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the FlowEnd: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the FlowEnd: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the FlowEnd: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the FlowEnd: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FlowUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FlowUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IFlowUsage"/>
         /// </returns>
-        internal static IFlowUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IFlowUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("FlowUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="FlowUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FlowUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFlowUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Flows.FlowUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2412,8 +2442,334 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the FlowUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="FlowUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FlowUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFlowUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Flows.FlowUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the FlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the FlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the FlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the FlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the FlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the FlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the FlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the FlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the FlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the FlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the FlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the FlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the FlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the FlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the FlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the FlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the FlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the FlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the FlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the FlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the FlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the FlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the FlowUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ForLoopActionUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ForLoopActionUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IForLoopActionUsage"/>
         /// </returns>
-        internal static IForLoopActionUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IForLoopActionUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ForLoopActionUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ForLoopActionUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ForLoopActionUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IForLoopActionUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.ForLoopActionUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actionDefinition"u8, out var actionDefinitionProperty))
             {
                 foreach (var arrayItem in actionDefinitionProperty.EnumerateArray())
@@ -2231,8 +2261,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the ForLoopActionUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ForLoopActionUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ForLoopActionUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IForLoopActionUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.ForLoopActionUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ForLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ForLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ForLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the ForLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ForLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the ForLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the ForLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the ForLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the ForLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the ForLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ForLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the ForLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the ForLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the ForLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the ForLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the ForLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the ForLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ForLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ForLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the ForLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ForkNodeDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ForkNodeDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IForkNode"/>
         /// </returns>
-        internal static IForkNode DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IForkNode DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ForkNodeDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ForkNode" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ForkNode"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IForkNode"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.ForkNode dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actionDefinition"u8, out var actionDefinitionProperty))
             {
                 foreach (var arrayItem in actionDefinitionProperty.EnumerateArray())
@@ -2156,8 +2186,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the ForkNode: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ForkNode" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ForkNode"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IForkNode"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.ForkNode dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ForkNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ForkNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ForkNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the ForkNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ForkNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the ForkNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the ForkNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the ForkNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the ForkNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the ForkNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ForkNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the ForkNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the ForkNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the ForkNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the ForkNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the ForkNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the ForkNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ForkNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ForkNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the ForkNode: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FramedConcernMembershipDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FramedConcernMembershipDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IFramedConcernMembership"/>
         /// </returns>
-        internal static IFramedConcernMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IFramedConcernMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("FramedConcernMembershipDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="FramedConcernMembership" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FramedConcernMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFramedConcernMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Requirements.FramedConcernMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -582,8 +612,202 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="FramedConcernMembership" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="FramedConcernMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFramedConcernMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Requirements.FramedConcernMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("kind"u8, out var kindProperty))
+            {
+                dtoInstance.Kind = RequirementConstraintKindDeSerializer.Deserialize(kindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the kind Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the FramedConcernMembership: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FunctionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/FunctionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IFunction"/>
         /// </returns>
-        internal static IFunction DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IFunction DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("FunctionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Function" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Function"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFunction"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Functions.Function dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1062,8 +1092,152 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the Function: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Function" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Function"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IFunction"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Functions.Function dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Function: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Function: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Function: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Function: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the Function: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Function: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the Function: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Function: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Function: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/IfActionUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/IfActionUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IIfActionUsage"/>
         /// </returns>
-        internal static IIfActionUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IIfActionUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("IfActionUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="IfActionUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="IfActionUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IIfActionUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.IfActionUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actionDefinition"u8, out var actionDefinitionProperty))
             {
                 foreach (var arrayItem in actionDefinitionProperty.EnumerateArray())
@@ -2230,8 +2260,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the IfActionUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="IfActionUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="IfActionUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IIfActionUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.IfActionUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the IfActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the IfActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the IfActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the IfActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the IfActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the IfActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the IfActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the IfActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the IfActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the IfActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the IfActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the IfActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the IfActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the IfActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the IfActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the IfActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the IfActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the IfActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the IfActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the IfActionUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/IncludeUseCaseUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/IncludeUseCaseUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IIncludeUseCaseUsage"/>
         /// </returns>
-        internal static IIncludeUseCaseUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IIncludeUseCaseUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("IncludeUseCaseUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="IncludeUseCaseUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="IncludeUseCaseUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IIncludeUseCaseUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.UseCases.IncludeUseCaseUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actorParameter"u8, out var actorParameterProperty))
             {
                 foreach (var arrayItem in actorParameterProperty.EnumerateArray())
@@ -2311,8 +2341,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the IncludeUseCaseUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="IncludeUseCaseUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="IncludeUseCaseUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IIncludeUseCaseUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.UseCases.IncludeUseCaseUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the IncludeUseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the IncludeUseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the IncludeUseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the IncludeUseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the IncludeUseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the IncludeUseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the IncludeUseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the IncludeUseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the IncludeUseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the IncludeUseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the IncludeUseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the IncludeUseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the IncludeUseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the IncludeUseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the IncludeUseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the IncludeUseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the IncludeUseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the IncludeUseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the IncludeUseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the IncludeUseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/IndexExpressionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/IndexExpressionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IIndexExpression"/>
         /// </returns>
-        internal static IIndexExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IIndexExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("IndexExpressionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="IndexExpression" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="IndexExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IIndexExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.IndexExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1539,8 +1569,271 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the IndexExpression: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="IndexExpression" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="IndexExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IIndexExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.IndexExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the IndexExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the IndexExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the IndexExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the IndexExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the IndexExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the IndexExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the IndexExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the IndexExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the IndexExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the IndexExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the IndexExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the IndexExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the IndexExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the IndexExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the IndexExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the IndexExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("operator"u8, out var operatorProperty))
+            {
+                var propertyValue = operatorProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.Operator = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the operator Json property was not found in the IndexExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the IndexExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the IndexExpression: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/InteractionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/InteractionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IInteraction"/>
         /// </returns>
-        internal static IInteraction DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IInteraction DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("InteractionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Interaction" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Interaction"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IInteraction"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Interactions.Interaction dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1125,8 +1155,208 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the Interaction: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Interaction" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Interaction"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IInteraction"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Interactions.Interaction dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Interaction: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Interaction: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Interaction: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Interaction: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the Interaction: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the Interaction: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Interaction: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the Interaction: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the Interaction: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Interaction: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the Interaction: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Interaction: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/InterfaceDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/InterfaceDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IInterfaceDefinition"/>
         /// </returns>
-        internal static IInterfaceDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IInterfaceDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("InterfaceDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="InterfaceDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="InterfaceDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IInterfaceDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Interfaces.InterfaceDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1749,8 +1779,232 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the InterfaceDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="InterfaceDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="InterfaceDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IInterfaceDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Interfaces.InterfaceDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the InterfaceDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the InterfaceDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the InterfaceDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the InterfaceDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the InterfaceDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the InterfaceDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the InterfaceDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the InterfaceDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the InterfaceDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the InterfaceDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the InterfaceDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the InterfaceDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the InterfaceDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the InterfaceDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/InterfaceUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/InterfaceUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IInterfaceUsage"/>
         /// </returns>
-        internal static IInterfaceUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IInterfaceUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("InterfaceUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="InterfaceUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="InterfaceUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IInterfaceUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Interfaces.InterfaceUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2360,8 +2390,334 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the InterfaceUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="InterfaceUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="InterfaceUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IInterfaceUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Interfaces.InterfaceUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the InterfaceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the InterfaceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the InterfaceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the InterfaceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the InterfaceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the InterfaceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the InterfaceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the InterfaceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the InterfaceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the InterfaceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the InterfaceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the InterfaceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the InterfaceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the InterfaceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the InterfaceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the InterfaceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the InterfaceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the InterfaceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the InterfaceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the InterfaceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the InterfaceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the InterfaceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the InterfaceUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/IntersectingDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/IntersectingDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IIntersecting"/>
         /// </returns>
-        internal static IIntersecting DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IIntersecting DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("IntersectingDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Intersecting" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Intersecting"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IIntersecting"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Types.Intersecting dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -507,8 +537,209 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the typeIntersected Json property was not found in the Intersecting: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Intersecting" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Intersecting"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IIntersecting"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Types.Intersecting dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Intersecting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Intersecting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Intersecting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Intersecting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("intersectingType"u8, out var intersectingTypeProperty))
+            {
+                if (intersectingTypeProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.IntersectingType = Guid.Empty;
+                    logger.LogDebug($"the Intersecting.IntersectingType property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (intersectingTypeProperty.TryGetProperty("@id"u8, out var intersectingTypeExternalIdProperty))
+                    {
+                        var propertyValue = intersectingTypeExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.IntersectingType = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the intersectingType Json property was not found in the Intersecting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the Intersecting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Intersecting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the Intersecting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Intersecting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the Intersecting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Intersecting: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/InvariantDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/InvariantDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IInvariant"/>
         /// </returns>
-        internal static IInvariant DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IInvariant DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("InvariantDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Invariant" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Invariant"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IInvariant"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Functions.Invariant dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1492,8 +1522,269 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the Invariant: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Invariant" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Invariant"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IInvariant"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Functions.Invariant dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Invariant: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Invariant: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Invariant: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the Invariant: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Invariant: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the Invariant: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the Invariant: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the Invariant: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the Invariant: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the Invariant: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Invariant: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isNegated"u8, out var isNegatedProperty))
+            {
+                if (isNegatedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsNegated = isNegatedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isNegated Json property was not found in the Invariant: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the Invariant: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the Invariant: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the Invariant: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the Invariant: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the Invariant: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Invariant: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Invariant: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/InvocationExpressionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/InvocationExpressionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IInvocationExpression"/>
         /// </returns>
-        internal static IInvocationExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IInvocationExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("InvocationExpressionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="InvocationExpression" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="InvocationExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IInvocationExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.InvocationExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1525,8 +1555,257 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the InvocationExpression: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="InvocationExpression" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="InvocationExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IInvocationExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.InvocationExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the InvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the InvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the InvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the InvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the InvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the InvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the InvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the InvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the InvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the InvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the InvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the InvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the InvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the InvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the InvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the InvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the InvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the InvocationExpression: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ItemDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ItemDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IItemDefinition"/>
         /// </returns>
-        internal static IItemDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IItemDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ItemDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ItemDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ItemDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IItemDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Items.ItemDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1629,8 +1659,176 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the ItemDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ItemDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ItemDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IItemDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Items.ItemDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ItemDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ItemDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ItemDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ItemDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the ItemDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ItemDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the ItemDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the ItemDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the ItemDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ItemDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ItemDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ItemUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ItemUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IItemUsage"/>
         /// </returns>
-        internal static IItemUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IItemUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ItemUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ItemUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ItemUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IItemUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Items.ItemUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2176,8 +2206,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the ItemUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ItemUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ItemUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IItemUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Items.ItemUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ItemUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ItemUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ItemUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the ItemUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ItemUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the ItemUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the ItemUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the ItemUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the ItemUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the ItemUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ItemUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the ItemUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the ItemUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the ItemUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the ItemUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the ItemUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the ItemUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ItemUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ItemUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the ItemUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/JoinNodeDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/JoinNodeDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IJoinNode"/>
         /// </returns>
-        internal static IJoinNode DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IJoinNode DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("JoinNodeDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="JoinNode" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="JoinNode"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IJoinNode"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.JoinNode dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actionDefinition"u8, out var actionDefinitionProperty))
             {
                 foreach (var arrayItem in actionDefinitionProperty.EnumerateArray())
@@ -2156,8 +2186,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the JoinNode: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="JoinNode" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="JoinNode"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IJoinNode"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.JoinNode dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the JoinNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the JoinNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the JoinNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the JoinNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the JoinNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the JoinNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the JoinNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the JoinNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the JoinNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the JoinNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the JoinNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the JoinNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the JoinNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the JoinNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the JoinNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the JoinNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the JoinNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the JoinNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the JoinNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the JoinNode: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/LibraryPackageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/LibraryPackageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ILibraryPackage"/>
         /// </returns>
-        internal static ILibraryPackage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ILibraryPackage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("LibraryPackageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="LibraryPackage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="LibraryPackage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ILibraryPackage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Packages.LibraryPackage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -533,8 +563,140 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the LibraryPackage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="LibraryPackage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="LibraryPackage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ILibraryPackage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Packages.LibraryPackage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the LibraryPackage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the LibraryPackage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the LibraryPackage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the LibraryPackage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the LibraryPackage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isStandard"u8, out var isStandardProperty))
+            {
+                if (isStandardProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsStandard = isStandardProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isStandard Json property was not found in the LibraryPackage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the LibraryPackage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the LibraryPackage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/LiteralBooleanDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/LiteralBooleanDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ILiteralBoolean"/>
         /// </returns>
-        internal static ILiteralBoolean DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ILiteralBoolean DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("LiteralBooleanDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="LiteralBoolean" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="LiteralBoolean"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ILiteralBoolean"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.LiteralBoolean dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1492,8 +1522,269 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the value Json property was not found in the LiteralBoolean: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="LiteralBoolean" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="LiteralBoolean"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ILiteralBoolean"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.LiteralBoolean dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the LiteralBoolean: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the LiteralBoolean: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the LiteralBoolean: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the LiteralBoolean: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the LiteralBoolean: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the LiteralBoolean: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the LiteralBoolean: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the LiteralBoolean: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the LiteralBoolean: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the LiteralBoolean: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the LiteralBoolean: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the LiteralBoolean: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the LiteralBoolean: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the LiteralBoolean: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the LiteralBoolean: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the LiteralBoolean: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the LiteralBoolean: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the LiteralBoolean: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("value"u8, out var valueProperty))
+            {
+                if (valueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.Value = valueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the value Json property was not found in the LiteralBoolean: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/LiteralExpressionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/LiteralExpressionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ILiteralExpression"/>
         /// </returns>
-        internal static ILiteralExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ILiteralExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("LiteralExpressionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="LiteralExpression" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="LiteralExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ILiteralExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.LiteralExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1480,8 +1510,257 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the LiteralExpression: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="LiteralExpression" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="LiteralExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ILiteralExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.LiteralExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the LiteralExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the LiteralExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the LiteralExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the LiteralExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the LiteralExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the LiteralExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the LiteralExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the LiteralExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the LiteralExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the LiteralExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the LiteralExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the LiteralExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the LiteralExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the LiteralExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the LiteralExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the LiteralExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the LiteralExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the LiteralExpression: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/LiteralInfinityDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/LiteralInfinityDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ILiteralInfinity"/>
         /// </returns>
-        internal static ILiteralInfinity DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ILiteralInfinity DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("LiteralInfinityDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="LiteralInfinity" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="LiteralInfinity"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ILiteralInfinity"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.LiteralInfinity dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1480,8 +1510,257 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the LiteralInfinity: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="LiteralInfinity" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="LiteralInfinity"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ILiteralInfinity"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.LiteralInfinity dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the LiteralInfinity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the LiteralInfinity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the LiteralInfinity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the LiteralInfinity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the LiteralInfinity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the LiteralInfinity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the LiteralInfinity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the LiteralInfinity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the LiteralInfinity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the LiteralInfinity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the LiteralInfinity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the LiteralInfinity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the LiteralInfinity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the LiteralInfinity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the LiteralInfinity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the LiteralInfinity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the LiteralInfinity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the LiteralInfinity: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/LiteralIntegerDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/LiteralIntegerDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ILiteralInteger"/>
         /// </returns>
-        internal static ILiteralInteger DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ILiteralInteger DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("LiteralIntegerDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="LiteralInteger" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="LiteralInteger"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ILiteralInteger"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.LiteralInteger dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1489,8 +1519,266 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the value Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="LiteralInteger" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="LiteralInteger"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ILiteralInteger"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.LiteralInteger dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("value"u8, out var valueProperty))
+            {
+                dtoInstance.Value = valueProperty.GetInt32();
+            }
+            else
+            {
+                logger.LogDebug("the value Json property was not found in the LiteralInteger: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/LiteralRationalDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/LiteralRationalDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ILiteralRational"/>
         /// </returns>
-        internal static ILiteralRational DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ILiteralRational DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("LiteralRationalDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="LiteralRational" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="LiteralRational"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ILiteralRational"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.LiteralRational dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1489,8 +1519,266 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the value Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="LiteralRational" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="LiteralRational"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ILiteralRational"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.LiteralRational dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("value"u8, out var valueProperty))
+            {
+                dtoInstance.Value = valueProperty.GetDouble();
+            }
+            else
+            {
+                logger.LogDebug("the value Json property was not found in the LiteralRational: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/LiteralStringDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/LiteralStringDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ILiteralString"/>
         /// </returns>
-        internal static ILiteralString DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ILiteralString DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("LiteralStringDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="LiteralString" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="LiteralString"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ILiteralString"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.LiteralString dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1494,8 +1524,271 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the value Json property was not found in the LiteralString: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="LiteralString" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="LiteralString"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ILiteralString"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.LiteralString dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the LiteralString: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the LiteralString: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the LiteralString: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the LiteralString: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the LiteralString: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the LiteralString: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the LiteralString: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the LiteralString: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the LiteralString: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the LiteralString: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the LiteralString: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the LiteralString: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the LiteralString: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the LiteralString: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the LiteralString: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the LiteralString: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the LiteralString: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the LiteralString: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("value"u8, out var valueProperty))
+            {
+                var propertyValue = valueProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.Value = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the value Json property was not found in the LiteralString: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/MembershipDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/MembershipDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IMembership"/>
         /// </returns>
-        internal static IMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("MembershipDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Membership" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Membership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Root.Namespaces.Membership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -548,8 +578,236 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the Membership: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Membership" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Membership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Root.Namespaces.Membership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("memberElement"u8, out var memberElementProperty))
+            {
+                if (memberElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.MemberElement = Guid.Empty;
+                    logger.LogDebug($"the Membership.MemberElement property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (memberElementProperty.TryGetProperty("@id"u8, out var memberElementExternalIdProperty))
+                    {
+                        var propertyValue = memberElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.MemberElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the memberElement Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("memberName"u8, out var memberNameProperty))
+            {
+                dtoInstance.MemberName = memberNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the memberName Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("memberShortName"u8, out var memberShortNameProperty))
+            {
+                dtoInstance.MemberShortName = memberShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the memberShortName Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the Membership: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/MembershipExposeDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/MembershipExposeDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IMembershipExpose"/>
         /// </returns>
-        internal static IMembershipExpose DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IMembershipExpose DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("MembershipExposeDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="MembershipExpose" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="MembershipExpose"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMembershipExpose"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Views.MembershipExpose dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -565,8 +595,242 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the MembershipExpose: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="MembershipExpose" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="MembershipExpose"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMembershipExpose"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Views.MembershipExpose dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the MembershipExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the MembershipExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the MembershipExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the MembershipExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("importedMembership"u8, out var importedMembershipProperty))
+            {
+                if (importedMembershipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.ImportedMembership = Guid.Empty;
+                    logger.LogDebug($"the MembershipExpose.ImportedMembership property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (importedMembershipProperty.TryGetProperty("@id"u8, out var importedMembershipExternalIdProperty))
+                    {
+                        var propertyValue = importedMembershipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.ImportedMembership = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the importedMembership Json property was not found in the MembershipExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the MembershipExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the MembershipExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImportAll"u8, out var isImportAllProperty))
+            {
+                if (isImportAllProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImportAll = isImportAllProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImportAll Json property was not found in the MembershipExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isRecursive"u8, out var isRecursiveProperty))
+            {
+                if (isRecursiveProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsRecursive = isRecursiveProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isRecursive Json property was not found in the MembershipExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the MembershipExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the MembershipExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the MembershipExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the MembershipExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the MembershipExpose: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/MembershipImportDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/MembershipImportDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IMembershipImport"/>
         /// </returns>
-        internal static IMembershipImport DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IMembershipImport DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("MembershipImportDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="MembershipImport" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="MembershipImport"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMembershipImport"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Root.Namespaces.MembershipImport dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -565,8 +595,242 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the MembershipImport: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="MembershipImport" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="MembershipImport"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMembershipImport"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Root.Namespaces.MembershipImport dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the MembershipImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the MembershipImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the MembershipImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the MembershipImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("importedMembership"u8, out var importedMembershipProperty))
+            {
+                if (importedMembershipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.ImportedMembership = Guid.Empty;
+                    logger.LogDebug($"the MembershipImport.ImportedMembership property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (importedMembershipProperty.TryGetProperty("@id"u8, out var importedMembershipExternalIdProperty))
+                    {
+                        var propertyValue = importedMembershipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.ImportedMembership = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the importedMembership Json property was not found in the MembershipImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the MembershipImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the MembershipImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImportAll"u8, out var isImportAllProperty))
+            {
+                if (isImportAllProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImportAll = isImportAllProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImportAll Json property was not found in the MembershipImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isRecursive"u8, out var isRecursiveProperty))
+            {
+                if (isRecursiveProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsRecursive = isRecursiveProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isRecursive Json property was not found in the MembershipImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the MembershipImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the MembershipImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the MembershipImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the MembershipImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the MembershipImport: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/MergeNodeDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/MergeNodeDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IMergeNode"/>
         /// </returns>
-        internal static IMergeNode DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IMergeNode DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("MergeNodeDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="MergeNode" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="MergeNode"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMergeNode"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.MergeNode dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actionDefinition"u8, out var actionDefinitionProperty))
             {
                 foreach (var arrayItem in actionDefinitionProperty.EnumerateArray())
@@ -2156,8 +2186,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the MergeNode: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="MergeNode" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="MergeNode"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMergeNode"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.MergeNode dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the MergeNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the MergeNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the MergeNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the MergeNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the MergeNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the MergeNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the MergeNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the MergeNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the MergeNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the MergeNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the MergeNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the MergeNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the MergeNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the MergeNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the MergeNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the MergeNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the MergeNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the MergeNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the MergeNode: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the MergeNode: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/MetaclassDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/MetaclassDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IMetaclass"/>
         /// </returns>
-        internal static IMetaclass DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IMetaclass DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("MetaclassDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Metaclass" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Metaclass"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMetaclass"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Metadata.Metaclass dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -985,8 +1015,152 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the Metaclass: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Metaclass" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Metaclass"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMetaclass"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Metadata.Metaclass dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Metaclass: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Metaclass: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Metaclass: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Metaclass: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the Metaclass: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Metaclass: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the Metaclass: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Metaclass: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Metaclass: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/MetadataAccessExpressionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/MetadataAccessExpressionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IMetadataAccessExpression"/>
         /// </returns>
-        internal static IMetadataAccessExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IMetadataAccessExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("MetadataAccessExpressionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="MetadataAccessExpression" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="MetadataAccessExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMetadataAccessExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.MetadataAccessExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1505,8 +1535,257 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the MetadataAccessExpression: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="MetadataAccessExpression" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="MetadataAccessExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMetadataAccessExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.MetadataAccessExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the MetadataAccessExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the MetadataAccessExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the MetadataAccessExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the MetadataAccessExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the MetadataAccessExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the MetadataAccessExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the MetadataAccessExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the MetadataAccessExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the MetadataAccessExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the MetadataAccessExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the MetadataAccessExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the MetadataAccessExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the MetadataAccessExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the MetadataAccessExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the MetadataAccessExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the MetadataAccessExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the MetadataAccessExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the MetadataAccessExpression: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/MetadataDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/MetadataDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IMetadataDefinition"/>
         /// </returns>
-        internal static IMetadataDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IMetadataDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("MetadataDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="MetadataDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="MetadataDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMetadataDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Metadata.MetadataDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1629,8 +1659,176 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the MetadataDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="MetadataDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="MetadataDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMetadataDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Metadata.MetadataDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the MetadataDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the MetadataDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the MetadataDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the MetadataDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the MetadataDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the MetadataDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the MetadataDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the MetadataDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the MetadataDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the MetadataDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the MetadataDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/MetadataFeatureDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/MetadataFeatureDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IMetadataFeature"/>
         /// </returns>
-        internal static IMetadataFeature DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IMetadataFeature DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("MetadataFeatureDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="MetadataFeature" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="MetadataFeature"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMetadataFeature"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Metadata.MetadataFeature dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1527,8 +1557,257 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the MetadataFeature: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="MetadataFeature" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="MetadataFeature"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMetadataFeature"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Metadata.MetadataFeature dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the MetadataFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the MetadataFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the MetadataFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the MetadataFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the MetadataFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the MetadataFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the MetadataFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the MetadataFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the MetadataFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the MetadataFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the MetadataFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the MetadataFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the MetadataFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the MetadataFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the MetadataFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the MetadataFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the MetadataFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the MetadataFeature: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/MetadataUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/MetadataUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IMetadataUsage"/>
         /// </returns>
-        internal static IMetadataUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IMetadataUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("MetadataUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="MetadataUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="MetadataUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMetadataUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Metadata.MetadataUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2264,8 +2294,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the MetadataUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="MetadataUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="MetadataUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMetadataUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Metadata.MetadataUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the MetadataUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the MetadataUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the MetadataUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the MetadataUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the MetadataUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the MetadataUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the MetadataUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the MetadataUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the MetadataUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the MetadataUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the MetadataUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the MetadataUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the MetadataUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the MetadataUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the MetadataUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the MetadataUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the MetadataUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the MetadataUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the MetadataUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the MetadataUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/MultiplicityDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/MultiplicityDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IMultiplicity"/>
         /// </returns>
-        internal static IMultiplicity DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IMultiplicity DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("MultiplicityDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Multiplicity" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Multiplicity"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMultiplicity"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Types.Multiplicity dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1419,8 +1449,257 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the Multiplicity: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Multiplicity" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Multiplicity"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMultiplicity"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Types.Multiplicity dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Multiplicity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Multiplicity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Multiplicity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the Multiplicity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Multiplicity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the Multiplicity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the Multiplicity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the Multiplicity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the Multiplicity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the Multiplicity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Multiplicity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the Multiplicity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the Multiplicity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the Multiplicity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the Multiplicity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the Multiplicity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Multiplicity: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Multiplicity: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/MultiplicityRangeDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/MultiplicityRangeDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IMultiplicityRange"/>
         /// </returns>
-        internal static IMultiplicityRange DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IMultiplicityRange DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("MultiplicityRangeDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="MultiplicityRange" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="MultiplicityRange"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMultiplicityRange"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Multiplicities.MultiplicityRange dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1488,8 +1518,257 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the upperBound Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="MultiplicityRange" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="MultiplicityRange"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IMultiplicityRange"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Multiplicities.MultiplicityRange dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the MultiplicityRange: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/NamespaceDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/NamespaceDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="INamespace"/>
         /// </returns>
-        internal static INamespace DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static INamespace DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("NamespaceDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Namespace" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Namespace"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="INamespace"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Root.Namespaces.Namespace dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -501,8 +531,128 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the Namespace: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Namespace" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Namespace"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="INamespace"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Root.Namespaces.Namespace dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Namespace: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Namespace: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Namespace: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Namespace: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Namespace: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Namespace: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Namespace: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/NamespaceExposeDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/NamespaceExposeDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="INamespaceExpose"/>
         /// </returns>
-        internal static INamespaceExpose DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static INamespaceExpose DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("NamespaceExposeDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="NamespaceExpose" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="NamespaceExpose"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="INamespaceExpose"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Views.NamespaceExpose dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -565,8 +595,242 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the NamespaceExpose: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="NamespaceExpose" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="NamespaceExpose"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="INamespaceExpose"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Views.NamespaceExpose dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the NamespaceExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the NamespaceExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the NamespaceExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the NamespaceExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("importedNamespace"u8, out var importedNamespaceProperty))
+            {
+                if (importedNamespaceProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.ImportedNamespace = Guid.Empty;
+                    logger.LogDebug($"the NamespaceExpose.ImportedNamespace property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (importedNamespaceProperty.TryGetProperty("@id"u8, out var importedNamespaceExternalIdProperty))
+                    {
+                        var propertyValue = importedNamespaceExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.ImportedNamespace = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the importedNamespace Json property was not found in the NamespaceExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the NamespaceExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the NamespaceExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImportAll"u8, out var isImportAllProperty))
+            {
+                if (isImportAllProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImportAll = isImportAllProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImportAll Json property was not found in the NamespaceExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isRecursive"u8, out var isRecursiveProperty))
+            {
+                if (isRecursiveProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsRecursive = isRecursiveProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isRecursive Json property was not found in the NamespaceExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the NamespaceExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the NamespaceExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the NamespaceExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the NamespaceExpose: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the NamespaceExpose: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/NamespaceImportDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/NamespaceImportDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="INamespaceImport"/>
         /// </returns>
-        internal static INamespaceImport DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static INamespaceImport DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("NamespaceImportDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="NamespaceImport" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="NamespaceImport"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="INamespaceImport"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Root.Namespaces.NamespaceImport dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -565,8 +595,242 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the NamespaceImport: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="NamespaceImport" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="NamespaceImport"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="INamespaceImport"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Root.Namespaces.NamespaceImport dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the NamespaceImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the NamespaceImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the NamespaceImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the NamespaceImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("importedNamespace"u8, out var importedNamespaceProperty))
+            {
+                if (importedNamespaceProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.ImportedNamespace = Guid.Empty;
+                    logger.LogDebug($"the NamespaceImport.ImportedNamespace property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (importedNamespaceProperty.TryGetProperty("@id"u8, out var importedNamespaceExternalIdProperty))
+                    {
+                        var propertyValue = importedNamespaceExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.ImportedNamespace = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the importedNamespace Json property was not found in the NamespaceImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the NamespaceImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the NamespaceImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImportAll"u8, out var isImportAllProperty))
+            {
+                if (isImportAllProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImportAll = isImportAllProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImportAll Json property was not found in the NamespaceImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isRecursive"u8, out var isRecursiveProperty))
+            {
+                if (isRecursiveProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsRecursive = isRecursiveProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isRecursive Json property was not found in the NamespaceImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the NamespaceImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the NamespaceImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the NamespaceImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the NamespaceImport: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the NamespaceImport: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/NullExpressionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/NullExpressionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="INullExpression"/>
         /// </returns>
-        internal static INullExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static INullExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("NullExpressionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="NullExpression" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="NullExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="INullExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.NullExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1480,8 +1510,257 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the NullExpression: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="NullExpression" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="NullExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="INullExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.NullExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the NullExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the NullExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the NullExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the NullExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the NullExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the NullExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the NullExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the NullExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the NullExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the NullExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the NullExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the NullExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the NullExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the NullExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the NullExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the NullExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the NullExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the NullExpression: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ObjectiveMembershipDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ObjectiveMembershipDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IObjectiveMembership"/>
         /// </returns>
-        internal static IObjectiveMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IObjectiveMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ObjectiveMembershipDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ObjectiveMembership" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ObjectiveMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IObjectiveMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Cases.ObjectiveMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -548,8 +578,193 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the ObjectiveMembership: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ObjectiveMembership" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ObjectiveMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IObjectiveMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Cases.ObjectiveMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ObjectiveMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ObjectiveMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ObjectiveMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ObjectiveMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the ObjectiveMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ObjectiveMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the ObjectiveMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ObjectiveMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the ObjectiveMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ObjectiveMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the ObjectiveMembership: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/OccurrenceDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/OccurrenceDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IOccurrenceDefinition"/>
         /// </returns>
-        internal static IOccurrenceDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IOccurrenceDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("OccurrenceDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="OccurrenceDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="OccurrenceDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IOccurrenceDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Occurrences.OccurrenceDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1629,8 +1659,176 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the OccurrenceDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="OccurrenceDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="OccurrenceDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IOccurrenceDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Occurrences.OccurrenceDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the OccurrenceDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the OccurrenceDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the OccurrenceDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the OccurrenceDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the OccurrenceDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the OccurrenceDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the OccurrenceDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the OccurrenceDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the OccurrenceDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the OccurrenceDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the OccurrenceDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/OccurrenceUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/OccurrenceUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IOccurrenceUsage"/>
         /// </returns>
-        internal static IOccurrenceUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IOccurrenceUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("OccurrenceUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="OccurrenceUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="OccurrenceUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IOccurrenceUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Occurrences.OccurrenceUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2156,8 +2186,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the OccurrenceUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="OccurrenceUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="OccurrenceUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IOccurrenceUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Occurrences.OccurrenceUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the OccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the OccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the OccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the OccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the OccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the OccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the OccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the OccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the OccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the OccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the OccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the OccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the OccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the OccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the OccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the OccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the OccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the OccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the OccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the OccurrenceUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/OperatorExpressionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/OperatorExpressionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IOperatorExpression"/>
         /// </returns>
-        internal static IOperatorExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IOperatorExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("OperatorExpressionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="OperatorExpression" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="OperatorExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IOperatorExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.OperatorExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1539,8 +1569,271 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the OperatorExpression: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="OperatorExpression" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="OperatorExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IOperatorExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.OperatorExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the OperatorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the OperatorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the OperatorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the OperatorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the OperatorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the OperatorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the OperatorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the OperatorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the OperatorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the OperatorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the OperatorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the OperatorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the OperatorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the OperatorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the OperatorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the OperatorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("operator"u8, out var operatorProperty))
+            {
+                var propertyValue = operatorProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.Operator = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the operator Json property was not found in the OperatorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the OperatorExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the OperatorExpression: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/OwningMembershipDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/OwningMembershipDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IOwningMembership"/>
         /// </returns>
-        internal static IOwningMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IOwningMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("OwningMembershipDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="OwningMembership" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="OwningMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IOwningMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Root.Namespaces.OwningMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -548,8 +578,193 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the OwningMembership: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="OwningMembership" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="OwningMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IOwningMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Root.Namespaces.OwningMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the OwningMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the OwningMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the OwningMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the OwningMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the OwningMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the OwningMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the OwningMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the OwningMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the OwningMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the OwningMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the OwningMembership: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/PackageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/PackageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IPackage"/>
         /// </returns>
-        internal static IPackage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IPackage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("PackageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Package" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Package"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IPackage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Packages.Package dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -521,8 +551,128 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the Package: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Package" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Package"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IPackage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Packages.Package dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Package: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Package: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Package: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Package: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Package: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Package: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Package: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ParameterMembershipDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ParameterMembershipDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IParameterMembership"/>
         /// </returns>
-        internal static IParameterMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IParameterMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ParameterMembershipDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ParameterMembership" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ParameterMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IParameterMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Behaviors.ParameterMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -548,8 +578,193 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the ParameterMembership: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ParameterMembership" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ParameterMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IParameterMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Behaviors.ParameterMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ParameterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ParameterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ParameterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ParameterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the ParameterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ParameterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the ParameterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ParameterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the ParameterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ParameterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the ParameterMembership: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/PartDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/PartDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IPartDefinition"/>
         /// </returns>
-        internal static IPartDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IPartDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("PartDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="PartDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="PartDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IPartDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Parts.PartDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1629,8 +1659,176 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the PartDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="PartDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="PartDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IPartDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Parts.PartDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the PartDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the PartDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the PartDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the PartDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the PartDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the PartDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the PartDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the PartDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the PartDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the PartDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the PartDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/PartUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/PartUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IPartUsage"/>
         /// </returns>
-        internal static IPartUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IPartUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("PartUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="PartUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="PartUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IPartUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Parts.PartUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2196,8 +2226,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the PartUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="PartUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="PartUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IPartUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Parts.PartUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the PartUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the PartUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the PartUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the PartUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the PartUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the PartUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the PartUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the PartUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the PartUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the PartUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the PartUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the PartUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the PartUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the PartUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the PartUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the PartUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the PartUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the PartUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the PartUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the PartUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/PayloadFeatureDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/PayloadFeatureDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IPayloadFeature"/>
         /// </returns>
-        internal static IPayloadFeature DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IPayloadFeature DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("PayloadFeatureDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="PayloadFeature" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="PayloadFeature"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IPayloadFeature"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Interactions.PayloadFeature dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1419,8 +1449,257 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the PayloadFeature: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="PayloadFeature" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="PayloadFeature"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IPayloadFeature"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Interactions.PayloadFeature dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the PayloadFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the PayloadFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the PayloadFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the PayloadFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the PayloadFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the PayloadFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the PayloadFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the PayloadFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the PayloadFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the PayloadFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the PayloadFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the PayloadFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the PayloadFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the PayloadFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the PayloadFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the PayloadFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the PayloadFeature: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the PayloadFeature: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/PerformActionUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/PerformActionUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IPerformActionUsage"/>
         /// </returns>
-        internal static IPerformActionUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IPerformActionUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("PerformActionUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="PerformActionUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="PerformActionUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IPerformActionUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.PerformActionUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actionDefinition"u8, out var actionDefinitionProperty))
             {
                 foreach (var arrayItem in actionDefinitionProperty.EnumerateArray())
@@ -2181,8 +2211,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the PerformActionUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="PerformActionUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="PerformActionUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IPerformActionUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.PerformActionUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the PerformActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the PerformActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the PerformActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the PerformActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the PerformActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the PerformActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the PerformActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the PerformActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the PerformActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the PerformActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the PerformActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the PerformActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the PerformActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the PerformActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the PerformActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the PerformActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the PerformActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the PerformActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the PerformActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the PerformActionUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/PortConjugationDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/PortConjugationDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IPortConjugation"/>
         /// </returns>
-        internal static IPortConjugation DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IPortConjugation DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("PortConjugationDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="PortConjugation" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="PortConjugation"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IPortConjugation"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Ports.PortConjugation dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -532,8 +562,234 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the PortConjugation: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="PortConjugation" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="PortConjugation"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IPortConjugation"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Ports.PortConjugation dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the PortConjugation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("conjugatedType"u8, out var conjugatedTypeProperty))
+            {
+                if (conjugatedTypeProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.ConjugatedType = Guid.Empty;
+                    logger.LogDebug($"the PortConjugation.ConjugatedType property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (conjugatedTypeProperty.TryGetProperty("@id"u8, out var conjugatedTypeExternalIdProperty))
+                    {
+                        var propertyValue = conjugatedTypeExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.ConjugatedType = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the conjugatedType Json property was not found in the PortConjugation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the PortConjugation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the PortConjugation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the PortConjugation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the PortConjugation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the PortConjugation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("originalPortDefinition"u8, out var originalPortDefinitionProperty))
+            {
+                if (originalPortDefinitionProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OriginalPortDefinition = Guid.Empty;
+                    logger.LogDebug($"the PortConjugation.OriginalPortDefinition property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (originalPortDefinitionProperty.TryGetProperty("@id"u8, out var originalPortDefinitionExternalIdProperty))
+                    {
+                        var propertyValue = originalPortDefinitionExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OriginalPortDefinition = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the originalPortDefinition Json property was not found in the PortConjugation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the PortConjugation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the PortConjugation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the PortConjugation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the PortConjugation: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/PortDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/PortDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IPortDefinition"/>
         /// </returns>
-        internal static IPortDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IPortDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("PortDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="PortDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="PortDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IPortDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Ports.PortDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1653,8 +1683,176 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the PortDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="PortDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="PortDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IPortDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Ports.PortDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the PortDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the PortDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the PortDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the PortDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the PortDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the PortDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the PortDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the PortDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the PortDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the PortDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the PortDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/PortUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/PortUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IPortUsage"/>
         /// </returns>
-        internal static IPortUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IPortUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("PortUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="PortUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="PortUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IPortUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Ports.PortUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2156,8 +2186,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the PortUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="PortUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="PortUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IPortUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Ports.PortUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the PortUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the PortUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the PortUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the PortUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the PortUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the PortUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the PortUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the PortUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the PortUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the PortUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the PortUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the PortUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the PortUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the PortUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the PortUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the PortUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the PortUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the PortUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the PortUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the PortUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/PredicateDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/PredicateDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IPredicate"/>
         /// </returns>
-        internal static IPredicate DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IPredicate DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("PredicateDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Predicate" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Predicate"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IPredicate"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Functions.Predicate dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1062,8 +1092,152 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the Predicate: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Predicate" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Predicate"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IPredicate"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Functions.Predicate dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Predicate: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Predicate: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Predicate: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Predicate: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the Predicate: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Predicate: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the Predicate: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Predicate: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Predicate: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/RedefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/RedefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IRedefinition"/>
         /// </returns>
-        internal static IRedefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IRedefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("RedefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Redefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Redefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IRedefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.Redefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -531,8 +561,234 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the Redefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Redefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Redefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IRedefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.Redefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Redefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Redefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Redefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Redefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the Redefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Redefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the Redefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Redefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the Redefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Redefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("redefinedFeature"u8, out var redefinedFeatureProperty))
+            {
+                if (redefinedFeatureProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.RedefinedFeature = Guid.Empty;
+                    logger.LogDebug($"the Redefinition.RedefinedFeature property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (redefinedFeatureProperty.TryGetProperty("@id"u8, out var redefinedFeatureExternalIdProperty))
+                    {
+                        var propertyValue = redefinedFeatureExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.RedefinedFeature = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the redefinedFeature Json property was not found in the Redefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("redefiningFeature"u8, out var redefiningFeatureProperty))
+            {
+                if (redefiningFeatureProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.RedefiningFeature = Guid.Empty;
+                    logger.LogDebug($"the Redefinition.RedefiningFeature property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (redefiningFeatureProperty.TryGetProperty("@id"u8, out var redefiningFeatureExternalIdProperty))
+                    {
+                        var propertyValue = redefiningFeatureExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.RedefiningFeature = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the redefiningFeature Json property was not found in the Redefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ReferenceSubsettingDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ReferenceSubsettingDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IReferenceSubsetting"/>
         /// </returns>
-        internal static IReferenceSubsetting DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IReferenceSubsetting DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ReferenceSubsettingDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ReferenceSubsetting" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ReferenceSubsetting"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IReferenceSubsetting"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.ReferenceSubsetting dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -507,8 +537,209 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the ReferenceSubsetting: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ReferenceSubsetting" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ReferenceSubsetting"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IReferenceSubsetting"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.ReferenceSubsetting dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ReferenceSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ReferenceSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ReferenceSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ReferenceSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the ReferenceSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ReferenceSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the ReferenceSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ReferenceSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the ReferenceSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ReferenceSubsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("referencedFeature"u8, out var referencedFeatureProperty))
+            {
+                if (referencedFeatureProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.ReferencedFeature = Guid.Empty;
+                    logger.LogDebug($"the ReferenceSubsetting.ReferencedFeature property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (referencedFeatureProperty.TryGetProperty("@id"u8, out var referencedFeatureExternalIdProperty))
+                    {
+                        var propertyValue = referencedFeatureExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.ReferencedFeature = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the referencedFeature Json property was not found in the ReferenceSubsetting: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ReferenceUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ReferenceUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IReferenceUsage"/>
         /// </returns>
-        internal static IReferenceUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IReferenceUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ReferenceUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ReferenceUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ReferenceUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IReferenceUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.DefinitionAndUsage.ReferenceUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2111,8 +2141,257 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the ReferenceUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ReferenceUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ReferenceUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IReferenceUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.DefinitionAndUsage.ReferenceUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ReferenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ReferenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ReferenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the ReferenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ReferenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the ReferenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the ReferenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the ReferenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the ReferenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the ReferenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ReferenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the ReferenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the ReferenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the ReferenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the ReferenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the ReferenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ReferenceUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ReferenceUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/RenderingDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/RenderingDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IRenderingDefinition"/>
         /// </returns>
-        internal static IRenderingDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IRenderingDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("RenderingDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="RenderingDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="RenderingDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IRenderingDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Views.RenderingDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1649,8 +1679,176 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the RenderingDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="RenderingDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="RenderingDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IRenderingDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Views.RenderingDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the RenderingDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the RenderingDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the RenderingDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the RenderingDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the RenderingDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the RenderingDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the RenderingDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the RenderingDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the RenderingDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the RenderingDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the RenderingDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/RenderingUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/RenderingUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IRenderingUsage"/>
         /// </returns>
-        internal static IRenderingUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IRenderingUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("RenderingUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="RenderingUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="RenderingUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IRenderingUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Views.RenderingUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2200,8 +2230,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the RenderingUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="RenderingUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="RenderingUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IRenderingUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Views.RenderingUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the RenderingUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the RenderingUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the RenderingUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the RenderingUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the RenderingUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the RenderingUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the RenderingUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the RenderingUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the RenderingUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the RenderingUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the RenderingUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the RenderingUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the RenderingUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the RenderingUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the RenderingUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the RenderingUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the RenderingUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the RenderingUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the RenderingUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the RenderingUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/RequirementConstraintMembershipDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/RequirementConstraintMembershipDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IRequirementConstraintMembership"/>
         /// </returns>
-        internal static IRequirementConstraintMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IRequirementConstraintMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("RequirementConstraintMembershipDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="RequirementConstraintMembership" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="RequirementConstraintMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IRequirementConstraintMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Requirements.RequirementConstraintMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -582,8 +612,202 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the RequirementConstraintMembership: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="RequirementConstraintMembership" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="RequirementConstraintMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IRequirementConstraintMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Requirements.RequirementConstraintMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the RequirementConstraintMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the RequirementConstraintMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the RequirementConstraintMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the RequirementConstraintMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the RequirementConstraintMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the RequirementConstraintMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("kind"u8, out var kindProperty))
+            {
+                dtoInstance.Kind = RequirementConstraintKindDeSerializer.Deserialize(kindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the kind Json property was not found in the RequirementConstraintMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the RequirementConstraintMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the RequirementConstraintMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the RequirementConstraintMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the RequirementConstraintMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the RequirementConstraintMembership: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/RequirementDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/RequirementDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IRequirementDefinition"/>
         /// </returns>
-        internal static IRequirementDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IRequirementDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("RequirementDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="RequirementDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="RequirementDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IRequirementDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Requirements.RequirementDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actorParameter"u8, out var actorParameterProperty))
             {
                 foreach (var arrayItem in actorParameterProperty.EnumerateArray())
@@ -1848,8 +1878,176 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the RequirementDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="RequirementDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="RequirementDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IRequirementDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Requirements.RequirementDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the RequirementDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the RequirementDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the RequirementDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the RequirementDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the RequirementDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the RequirementDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the RequirementDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the RequirementDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the RequirementDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the RequirementDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("reqId"u8, out var reqIdProperty))
+            {
+                dtoInstance.ReqId = reqIdProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the reqId Json property was not found in the RequirementDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/RequirementUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/RequirementUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IRequirementUsage"/>
         /// </returns>
-        internal static IRequirementUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IRequirementUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("RequirementUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="RequirementUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="RequirementUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IRequirementUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Requirements.RequirementUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actorParameter"u8, out var actorParameterProperty))
             {
                 foreach (var arrayItem in actorParameterProperty.EnumerateArray())
@@ -2359,8 +2389,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="RequirementUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="RequirementUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IRequirementUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Requirements.RequirementUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("reqId"u8, out var reqIdProperty))
+            {
+                dtoInstance.ReqId = reqIdProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the reqId Json property was not found in the RequirementUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/RequirementVerificationMembershipDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/RequirementVerificationMembershipDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IRequirementVerificationMembership"/>
         /// </returns>
-        internal static IRequirementVerificationMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IRequirementVerificationMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("RequirementVerificationMembershipDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="RequirementVerificationMembership" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="RequirementVerificationMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IRequirementVerificationMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.VerificationCases.RequirementVerificationMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -582,8 +612,202 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the RequirementVerificationMembership: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="RequirementVerificationMembership" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="RequirementVerificationMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IRequirementVerificationMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.VerificationCases.RequirementVerificationMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the RequirementVerificationMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the RequirementVerificationMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the RequirementVerificationMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the RequirementVerificationMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the RequirementVerificationMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the RequirementVerificationMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("kind"u8, out var kindProperty))
+            {
+                dtoInstance.Kind = RequirementConstraintKindDeSerializer.Deserialize(kindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the kind Json property was not found in the RequirementVerificationMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the RequirementVerificationMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the RequirementVerificationMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the RequirementVerificationMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the RequirementVerificationMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the RequirementVerificationMembership: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ResultExpressionMembershipDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ResultExpressionMembershipDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IResultExpressionMembership"/>
         /// </returns>
-        internal static IResultExpressionMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IResultExpressionMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ResultExpressionMembershipDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ResultExpressionMembership" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ResultExpressionMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IResultExpressionMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Functions.ResultExpressionMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -548,8 +578,193 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the ResultExpressionMembership: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ResultExpressionMembership" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ResultExpressionMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IResultExpressionMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Functions.ResultExpressionMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ResultExpressionMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ResultExpressionMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ResultExpressionMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ResultExpressionMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the ResultExpressionMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ResultExpressionMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the ResultExpressionMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ResultExpressionMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the ResultExpressionMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ResultExpressionMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the ResultExpressionMembership: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ReturnParameterMembershipDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ReturnParameterMembershipDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IReturnParameterMembership"/>
         /// </returns>
-        internal static IReturnParameterMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IReturnParameterMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ReturnParameterMembershipDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ReturnParameterMembership" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ReturnParameterMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IReturnParameterMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Functions.ReturnParameterMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -548,8 +578,193 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the ReturnParameterMembership: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ReturnParameterMembership" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ReturnParameterMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IReturnParameterMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Functions.ReturnParameterMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ReturnParameterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ReturnParameterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ReturnParameterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ReturnParameterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the ReturnParameterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ReturnParameterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the ReturnParameterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ReturnParameterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the ReturnParameterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ReturnParameterMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the ReturnParameterMembership: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/SatisfyRequirementUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/SatisfyRequirementUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ISatisfyRequirementUsage"/>
         /// </returns>
-        internal static ISatisfyRequirementUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ISatisfyRequirementUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("SatisfyRequirementUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="SatisfyRequirementUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="SatisfyRequirementUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISatisfyRequirementUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Requirements.SatisfyRequirementUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actorParameter"u8, out var actorParameterProperty))
             {
                 foreach (var arrayItem in actorParameterProperty.EnumerateArray())
@@ -2421,8 +2451,290 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the SatisfyRequirementUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="SatisfyRequirementUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="SatisfyRequirementUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISatisfyRequirementUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Requirements.SatisfyRequirementUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the SatisfyRequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the SatisfyRequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the SatisfyRequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the SatisfyRequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the SatisfyRequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the SatisfyRequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the SatisfyRequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the SatisfyRequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the SatisfyRequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the SatisfyRequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the SatisfyRequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isNegated"u8, out var isNegatedProperty))
+            {
+                if (isNegatedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsNegated = isNegatedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isNegated Json property was not found in the SatisfyRequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the SatisfyRequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the SatisfyRequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the SatisfyRequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the SatisfyRequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the SatisfyRequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the SatisfyRequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the SatisfyRequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the SatisfyRequirementUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("reqId"u8, out var reqIdProperty))
+            {
+                dtoInstance.ReqId = reqIdProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the reqId Json property was not found in the SatisfyRequirementUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/SelectExpressionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/SelectExpressionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ISelectExpression"/>
         /// </returns>
-        internal static ISelectExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ISelectExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("SelectExpressionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="SelectExpression" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="SelectExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISelectExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.SelectExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1539,8 +1569,271 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="SelectExpression" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="SelectExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISelectExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Expressions.SelectExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("operator"u8, out var operatorProperty))
+            {
+                var propertyValue = operatorProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.Operator = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the operator Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the SelectExpression: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/SendActionUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/SendActionUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ISendActionUsage"/>
         /// </returns>
-        internal static ISendActionUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ISendActionUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("SendActionUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="SendActionUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="SendActionUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISendActionUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.SendActionUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actionDefinition"u8, out var actionDefinitionProperty))
             {
                 foreach (var arrayItem in actionDefinitionProperty.EnumerateArray())
@@ -2229,8 +2259,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the SendActionUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="SendActionUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="SendActionUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISendActionUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.SendActionUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the SendActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the SendActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the SendActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the SendActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the SendActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the SendActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the SendActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the SendActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the SendActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the SendActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the SendActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the SendActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the SendActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the SendActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the SendActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the SendActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the SendActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the SendActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the SendActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the SendActionUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/SpecializationDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/SpecializationDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ISpecialization"/>
         /// </returns>
-        internal static ISpecialization DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ISpecialization DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("SpecializationDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Specialization" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Specialization"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISpecialization"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Types.Specialization dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -531,8 +561,234 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the Specialization: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Specialization" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Specialization"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISpecialization"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Types.Specialization dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Specialization: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Specialization: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Specialization: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Specialization: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("general"u8, out var generalProperty))
+            {
+                if (generalProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.General = Guid.Empty;
+                    logger.LogDebug($"the Specialization.General property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (generalProperty.TryGetProperty("@id"u8, out var generalExternalIdProperty))
+                    {
+                        var propertyValue = generalExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.General = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the general Json property was not found in the Specialization: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the Specialization: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Specialization: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the Specialization: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Specialization: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the Specialization: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Specialization: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("specific"u8, out var specificProperty))
+            {
+                if (specificProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.Specific = Guid.Empty;
+                    logger.LogDebug($"the Specialization.Specific property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (specificProperty.TryGetProperty("@id"u8, out var specificExternalIdProperty))
+                    {
+                        var propertyValue = specificExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.Specific = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the specific Json property was not found in the Specialization: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/StakeholderMembershipDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/StakeholderMembershipDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IStakeholderMembership"/>
         /// </returns>
-        internal static IStakeholderMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IStakeholderMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("StakeholderMembershipDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="StakeholderMembership" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="StakeholderMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IStakeholderMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Requirements.StakeholderMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -548,8 +578,193 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the StakeholderMembership: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="StakeholderMembership" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="StakeholderMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IStakeholderMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Requirements.StakeholderMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the StakeholderMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the StakeholderMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the StakeholderMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the StakeholderMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the StakeholderMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the StakeholderMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the StakeholderMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the StakeholderMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the StakeholderMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the StakeholderMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the StakeholderMembership: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/StateDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/StateDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IStateDefinition"/>
         /// </returns>
-        internal static IStateDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IStateDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("StateDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="StateDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="StateDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IStateDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.States.StateDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("action"u8, out var actionProperty))
             {
                 foreach (var arrayItem in actionProperty.EnumerateArray())
@@ -1773,8 +1803,188 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the StateDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="StateDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="StateDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IStateDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.States.StateDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the StateDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the StateDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the StateDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the StateDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the StateDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the StateDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the StateDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isParallel"u8, out var isParallelProperty))
+            {
+                if (isParallelProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsParallel = isParallelProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isParallel Json property was not found in the StateDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the StateDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the StateDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the StateDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the StateDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/StateSubactionMembershipDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/StateSubactionMembershipDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IStateSubactionMembership"/>
         /// </returns>
-        internal static IStateSubactionMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IStateSubactionMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("StateSubactionMembershipDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="StateSubactionMembership" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="StateSubactionMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IStateSubactionMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.States.StateSubactionMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("action"u8, out var actionProperty))
             {
                 if (actionProperty.ValueKind == JsonValueKind.Null)
@@ -557,8 +587,202 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the StateSubactionMembership: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="StateSubactionMembership" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="StateSubactionMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IStateSubactionMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.States.StateSubactionMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the StateSubactionMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the StateSubactionMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the StateSubactionMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the StateSubactionMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the StateSubactionMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the StateSubactionMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("kind"u8, out var kindProperty))
+            {
+                dtoInstance.Kind = StateSubactionKindDeSerializer.Deserialize(kindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the kind Json property was not found in the StateSubactionMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the StateSubactionMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the StateSubactionMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the StateSubactionMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the StateSubactionMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the StateSubactionMembership: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/StateUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/StateUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IStateUsage"/>
         /// </returns>
-        internal static IStateUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IStateUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("StateUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="StateUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="StateUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IStateUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.States.StateUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2240,8 +2270,290 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the StateUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="StateUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="StateUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IStateUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.States.StateUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the StateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the StateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the StateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the StateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the StateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the StateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the StateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the StateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the StateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the StateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the StateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the StateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the StateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isParallel"u8, out var isParallelProperty))
+            {
+                if (isParallelProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsParallel = isParallelProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isParallel Json property was not found in the StateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the StateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the StateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the StateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the StateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the StateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the StateUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the StateUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/StepDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/StepDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IStep"/>
         /// </returns>
-        internal static IStep DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IStep DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("StepDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Step" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Step"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IStep"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Behaviors.Step dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1439,8 +1469,257 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the Step: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Step" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Step"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IStep"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Behaviors.Step dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Step: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Step: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Step: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the Step: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Step: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the Step: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the Step: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the Step: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the Step: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the Step: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Step: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the Step: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the Step: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the Step: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the Step: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the Step: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Step: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Step: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/StructureDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/StructureDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IStructure"/>
         /// </returns>
-        internal static IStructure DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IStructure DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("StructureDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Structure" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Structure"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IStructure"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Structures.Structure dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -985,8 +1015,152 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the Structure: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Structure" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Structure"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IStructure"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Structures.Structure dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Structure: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Structure: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Structure: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Structure: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the Structure: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Structure: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the Structure: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Structure: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Structure: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/SubclassificationDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/SubclassificationDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ISubclassification"/>
         /// </returns>
-        internal static ISubclassification DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ISubclassification DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("SubclassificationDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Subclassification" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Subclassification"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISubclassification"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Classifiers.Subclassification dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -531,8 +561,234 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Subclassification" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Subclassification"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISubclassification"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Classifiers.Subclassification dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("subclassifier"u8, out var subclassifierProperty))
+            {
+                if (subclassifierProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.Subclassifier = Guid.Empty;
+                    logger.LogDebug($"the Subclassification.Subclassifier property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (subclassifierProperty.TryGetProperty("@id"u8, out var subclassifierExternalIdProperty))
+                    {
+                        var propertyValue = subclassifierExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.Subclassifier = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the subclassifier Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("superclassifier"u8, out var superclassifierProperty))
+            {
+                if (superclassifierProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.Superclassifier = Guid.Empty;
+                    logger.LogDebug($"the Subclassification.Superclassifier property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (superclassifierProperty.TryGetProperty("@id"u8, out var superclassifierExternalIdProperty))
+                    {
+                        var propertyValue = superclassifierExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.Superclassifier = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the superclassifier Json property was not found in the Subclassification: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/SubjectMembershipDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/SubjectMembershipDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ISubjectMembership"/>
         /// </returns>
-        internal static ISubjectMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ISubjectMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("SubjectMembershipDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="SubjectMembership" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="SubjectMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISubjectMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Requirements.SubjectMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -548,8 +578,193 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the SubjectMembership: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="SubjectMembership" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="SubjectMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISubjectMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Requirements.SubjectMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the SubjectMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the SubjectMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the SubjectMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the SubjectMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the SubjectMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the SubjectMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the SubjectMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the SubjectMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the SubjectMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the SubjectMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the SubjectMembership: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/SubsettingDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/SubsettingDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ISubsetting"/>
         /// </returns>
-        internal static ISubsetting DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ISubsetting DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("SubsettingDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Subsetting" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Subsetting"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISubsetting"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.Subsetting dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -531,8 +561,234 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the Subsetting: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Subsetting" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Subsetting"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISubsetting"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.Subsetting dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Subsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Subsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Subsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Subsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the Subsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Subsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the Subsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Subsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the Subsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Subsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("subsettedFeature"u8, out var subsettedFeatureProperty))
+            {
+                if (subsettedFeatureProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.SubsettedFeature = Guid.Empty;
+                    logger.LogDebug($"the Subsetting.SubsettedFeature property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (subsettedFeatureProperty.TryGetProperty("@id"u8, out var subsettedFeatureExternalIdProperty))
+                    {
+                        var propertyValue = subsettedFeatureExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.SubsettedFeature = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the subsettedFeature Json property was not found in the Subsetting: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("subsettingFeature"u8, out var subsettingFeatureProperty))
+            {
+                if (subsettingFeatureProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.SubsettingFeature = Guid.Empty;
+                    logger.LogDebug($"the Subsetting.SubsettingFeature property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (subsettingFeatureProperty.TryGetProperty("@id"u8, out var subsettingFeatureExternalIdProperty))
+                    {
+                        var propertyValue = subsettingFeatureExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.SubsettingFeature = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the subsettingFeature Json property was not found in the Subsetting: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/SuccessionAsUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/SuccessionAsUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ISuccessionAsUsage"/>
         /// </returns>
-        internal static ISuccessionAsUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ISuccessionAsUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("SuccessionAsUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="SuccessionAsUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="SuccessionAsUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISuccessionAsUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Connections.SuccessionAsUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2275,8 +2305,313 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the SuccessionAsUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="SuccessionAsUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="SuccessionAsUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISuccessionAsUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Connections.SuccessionAsUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the SuccessionAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the SuccessionAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the SuccessionAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the SuccessionAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the SuccessionAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the SuccessionAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the SuccessionAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the SuccessionAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the SuccessionAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the SuccessionAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the SuccessionAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the SuccessionAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the SuccessionAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the SuccessionAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the SuccessionAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the SuccessionAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the SuccessionAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the SuccessionAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the SuccessionAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the SuccessionAsUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the SuccessionAsUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/SuccessionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/SuccessionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ISuccession"/>
         /// </returns>
-        internal static ISuccession DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ISuccession DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("SuccessionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Succession" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Succession"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISuccession"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Connectors.Succession dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1563,8 +1593,313 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the Succession: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Succession" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Succession"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISuccession"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Connectors.Succession dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Succession: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Succession: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Succession: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the Succession: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Succession: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the Succession: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the Succession: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the Succession: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the Succession: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the Succession: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the Succession: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Succession: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the Succession: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the Succession: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the Succession: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the Succession: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the Succession: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the Succession: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Succession: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the Succession: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Succession: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/SuccessionFlowDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/SuccessionFlowDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ISuccessionFlow"/>
         /// </returns>
-        internal static ISuccessionFlow DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ISuccessionFlow DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("SuccessionFlowDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="SuccessionFlow" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="SuccessionFlow"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISuccessionFlow"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Interactions.SuccessionFlow dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1675,8 +1705,313 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the SuccessionFlow: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="SuccessionFlow" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="SuccessionFlow"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISuccessionFlow"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Kernel.Interactions.SuccessionFlow dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the SuccessionFlow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the SuccessionFlow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the SuccessionFlow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the SuccessionFlow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the SuccessionFlow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the SuccessionFlow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the SuccessionFlow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the SuccessionFlow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the SuccessionFlow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the SuccessionFlow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the SuccessionFlow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the SuccessionFlow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the SuccessionFlow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the SuccessionFlow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the SuccessionFlow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the SuccessionFlow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the SuccessionFlow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the SuccessionFlow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the SuccessionFlow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the SuccessionFlow: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the SuccessionFlow: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/SuccessionFlowUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/SuccessionFlowUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ISuccessionFlowUsage"/>
         /// </returns>
-        internal static ISuccessionFlowUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ISuccessionFlowUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("SuccessionFlowUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="SuccessionFlowUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="SuccessionFlowUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISuccessionFlowUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Flows.SuccessionFlowUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2412,8 +2442,334 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the SuccessionFlowUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="SuccessionFlowUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="SuccessionFlowUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ISuccessionFlowUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Flows.SuccessionFlowUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the SuccessionFlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the SuccessionFlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the SuccessionFlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the SuccessionFlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the SuccessionFlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the SuccessionFlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the SuccessionFlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the SuccessionFlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the SuccessionFlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the SuccessionFlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the SuccessionFlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the SuccessionFlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the SuccessionFlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the SuccessionFlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the SuccessionFlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the SuccessionFlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the SuccessionFlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the SuccessionFlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the SuccessionFlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the SuccessionFlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the SuccessionFlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the SuccessionFlowUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the SuccessionFlowUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/TerminateActionUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/TerminateActionUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ITerminateActionUsage"/>
         /// </returns>
-        internal static ITerminateActionUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ITerminateActionUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("TerminateActionUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="TerminateActionUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="TerminateActionUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ITerminateActionUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.TerminateActionUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actionDefinition"u8, out var actionDefinitionProperty))
             {
                 foreach (var arrayItem in actionDefinitionProperty.EnumerateArray())
@@ -2180,8 +2210,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the TerminateActionUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="TerminateActionUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="TerminateActionUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ITerminateActionUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.TerminateActionUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the TerminateActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the TerminateActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the TerminateActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the TerminateActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the TerminateActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the TerminateActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the TerminateActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the TerminateActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the TerminateActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the TerminateActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the TerminateActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the TerminateActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the TerminateActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the TerminateActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the TerminateActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the TerminateActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the TerminateActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the TerminateActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the TerminateActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the TerminateActionUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/TextualRepresentationDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/TextualRepresentationDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ITextualRepresentation"/>
         /// </returns>
-        internal static ITextualRepresentation DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ITextualRepresentation DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("TextualRepresentationDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="TextualRepresentation" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="TextualRepresentation"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ITextualRepresentation"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Root.Annotations.TextualRepresentation dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -498,8 +528,156 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the TextualRepresentation: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="TextualRepresentation" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="TextualRepresentation"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ITextualRepresentation"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Root.Annotations.TextualRepresentation dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the TextualRepresentation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("body"u8, out var bodyProperty))
+            {
+                var propertyValue = bodyProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.Body = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the body Json property was not found in the TextualRepresentation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the TextualRepresentation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the TextualRepresentation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the TextualRepresentation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the TextualRepresentation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("language"u8, out var languageProperty))
+            {
+                var propertyValue = languageProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.Language = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the language Json property was not found in the TextualRepresentation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the TextualRepresentation: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the TextualRepresentation: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/TransitionFeatureMembershipDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/TransitionFeatureMembershipDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ITransitionFeatureMembership"/>
         /// </returns>
-        internal static ITransitionFeatureMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ITransitionFeatureMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("TransitionFeatureMembershipDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="TransitionFeatureMembership" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="TransitionFeatureMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ITransitionFeatureMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.States.TransitionFeatureMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -557,8 +587,202 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the TransitionFeatureMembership: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="TransitionFeatureMembership" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="TransitionFeatureMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ITransitionFeatureMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.States.TransitionFeatureMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the TransitionFeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the TransitionFeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the TransitionFeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the TransitionFeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the TransitionFeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the TransitionFeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("kind"u8, out var kindProperty))
+            {
+                dtoInstance.Kind = TransitionFeatureKindDeSerializer.Deserialize(kindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the kind Json property was not found in the TransitionFeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the TransitionFeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the TransitionFeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the TransitionFeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the TransitionFeatureMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the TransitionFeatureMembership: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/TransitionUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/TransitionUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ITransitionUsage"/>
         /// </returns>
-        internal static ITransitionUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ITransitionUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("TransitionUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="TransitionUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="TransitionUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ITransitionUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.States.TransitionUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actionDefinition"u8, out var actionDefinitionProperty))
             {
                 foreach (var arrayItem in actionDefinitionProperty.EnumerateArray())
@@ -2291,8 +2321,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the TransitionUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="TransitionUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="TransitionUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ITransitionUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.States.TransitionUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the TransitionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the TransitionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the TransitionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the TransitionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the TransitionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the TransitionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the TransitionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the TransitionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the TransitionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the TransitionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the TransitionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the TransitionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the TransitionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the TransitionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the TransitionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the TransitionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the TransitionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the TransitionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the TransitionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the TransitionUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/TriggerInvocationExpressionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/TriggerInvocationExpressionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ITriggerInvocationExpression"/>
         /// </returns>
-        internal static ITriggerInvocationExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ITriggerInvocationExpression DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("TriggerInvocationExpressionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="TriggerInvocationExpression" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="TriggerInvocationExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ITriggerInvocationExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.TriggerInvocationExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1534,8 +1564,266 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the TriggerInvocationExpression: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="TriggerInvocationExpression" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="TriggerInvocationExpression"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ITriggerInvocationExpression"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.TriggerInvocationExpression dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the TriggerInvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the TriggerInvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the TriggerInvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the TriggerInvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the TriggerInvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the TriggerInvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the TriggerInvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the TriggerInvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the TriggerInvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the TriggerInvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the TriggerInvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the TriggerInvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the TriggerInvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the TriggerInvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the TriggerInvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariable"u8, out var isVariableProperty))
+            {
+                if (isVariableProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariable = isVariableProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariable Json property was not found in the TriggerInvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("kind"u8, out var kindProperty))
+            {
+                dtoInstance.Kind = TriggerKindDeSerializer.Deserialize(kindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the kind Json property was not found in the TriggerInvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the TriggerInvocationExpression: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the TriggerInvocationExpression: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/TypeDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/TypeDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IType"/>
         /// </returns>
-        internal static IType DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IType DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("TypeDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Type" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Type"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IType"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Types.Type dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -965,8 +995,152 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the Type: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Type" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Type"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IType"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Types.Type dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Type: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Type: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Type: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Type: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the Type: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Type: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the Type: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Type: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Type: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/TypeFeaturingDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/TypeFeaturingDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="ITypeFeaturing"/>
         /// </returns>
-        internal static ITypeFeaturing DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static ITypeFeaturing DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("TypeFeaturingDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="TypeFeaturing" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="TypeFeaturing"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ITypeFeaturing"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.TypeFeaturing dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -531,8 +561,234 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the textualRepresentation Json property was not found in the TypeFeaturing: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="TypeFeaturing" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="TypeFeaturing"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="ITypeFeaturing"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Features.TypeFeaturing dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the TypeFeaturing: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the TypeFeaturing: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the TypeFeaturing: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the TypeFeaturing: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("featureOfType"u8, out var featureOfTypeProperty))
+            {
+                if (featureOfTypeProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.FeatureOfType = Guid.Empty;
+                    logger.LogDebug($"the TypeFeaturing.FeatureOfType property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (featureOfTypeProperty.TryGetProperty("@id"u8, out var featureOfTypeExternalIdProperty))
+                    {
+                        var propertyValue = featureOfTypeExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.FeatureOfType = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the featureOfType Json property was not found in the TypeFeaturing: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("featuringType"u8, out var featuringTypeProperty))
+            {
+                if (featuringTypeProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.FeaturingType = Guid.Empty;
+                    logger.LogDebug($"the TypeFeaturing.FeaturingType property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (featuringTypeProperty.TryGetProperty("@id"u8, out var featuringTypeExternalIdProperty))
+                    {
+                        var propertyValue = featuringTypeExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.FeaturingType = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the featuringType Json property was not found in the TypeFeaturing: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the TypeFeaturing: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the TypeFeaturing: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the TypeFeaturing: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the TypeFeaturing: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the TypeFeaturing: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the TypeFeaturing: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/UnioningDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/UnioningDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IUnioning"/>
         /// </returns>
-        internal static IUnioning DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IUnioning DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("UnioningDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Unioning" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Unioning"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IUnioning"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Core.Types.Unioning dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -507,8 +537,209 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the unioningType Json property was not found in the Unioning: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Unioning" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Unioning"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IUnioning"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Core.Types.Unioning dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Unioning: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Unioning: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Unioning: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Unioning: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the Unioning: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Unioning: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the Unioning: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Unioning: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the Unioning: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Unioning: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("unioningType"u8, out var unioningTypeProperty))
+            {
+                if (unioningTypeProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.UnioningType = Guid.Empty;
+                    logger.LogDebug($"the Unioning.UnioningType property was not found in the Json. The value is set to Guid.Empty");
+                }
+                else
+                {
+                    if (unioningTypeProperty.TryGetProperty("@id"u8, out var unioningTypeExternalIdProperty))
+                    {
+                        var propertyValue = unioningTypeExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.UnioningType = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the unioningType Json property was not found in the Unioning: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/UsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/UsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IUsage"/>
         /// </returns>
-        internal static IUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("UsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="Usage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Usage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.DefinitionAndUsage.Usage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2111,8 +2141,257 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the Usage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="Usage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="Usage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.DefinitionAndUsage.Usage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the Usage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/UseCaseDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/UseCaseDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IUseCaseDefinition"/>
         /// </returns>
-        internal static IUseCaseDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IUseCaseDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("UseCaseDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="UseCaseDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="UseCaseDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IUseCaseDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.UseCases.UseCaseDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("action"u8, out var actionProperty))
             {
                 foreach (var arrayItem in actionProperty.EnumerateArray())
@@ -1835,8 +1865,176 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the UseCaseDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="UseCaseDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="UseCaseDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IUseCaseDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.UseCases.UseCaseDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the UseCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the UseCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the UseCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the UseCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the UseCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the UseCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the UseCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the UseCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the UseCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the UseCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the UseCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/UseCaseUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/UseCaseUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IUseCaseUsage"/>
         /// </returns>
-        internal static IUseCaseUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IUseCaseUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("UseCaseUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="UseCaseUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="UseCaseUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IUseCaseUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.UseCases.UseCaseUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actorParameter"u8, out var actorParameterProperty))
             {
                 foreach (var arrayItem in actorParameterProperty.EnumerateArray())
@@ -2286,8 +2316,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the variantMembership Json property was not found in the UseCaseUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="UseCaseUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="UseCaseUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IUseCaseUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.UseCases.UseCaseUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the UseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the UseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the UseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the UseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the UseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the UseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the UseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the UseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the UseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the UseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the UseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the UseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the UseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the UseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the UseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the UseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the UseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the UseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the UseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the UseCaseUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/VariantMembershipDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/VariantMembershipDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IVariantMembership"/>
         /// </returns>
-        internal static IVariantMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IVariantMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("VariantMembershipDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="VariantMembership" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="VariantMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IVariantMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.DefinitionAndUsage.VariantMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -548,8 +578,193 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the VariantMembership: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="VariantMembership" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="VariantMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IVariantMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.DefinitionAndUsage.VariantMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the VariantMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the VariantMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the VariantMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the VariantMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the VariantMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the VariantMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the VariantMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the VariantMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the VariantMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the VariantMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the VariantMembership: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/VerificationCaseDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/VerificationCaseDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IVerificationCaseDefinition"/>
         /// </returns>
-        internal static IVerificationCaseDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IVerificationCaseDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("VerificationCaseDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="VerificationCaseDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="VerificationCaseDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IVerificationCaseDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.VerificationCases.VerificationCaseDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("action"u8, out var actionProperty))
             {
                 foreach (var arrayItem in actionProperty.EnumerateArray())
@@ -1835,8 +1865,176 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the verifiedRequirement Json property was not found in the VerificationCaseDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="VerificationCaseDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="VerificationCaseDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IVerificationCaseDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.VerificationCases.VerificationCaseDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the VerificationCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the VerificationCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the VerificationCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the VerificationCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the VerificationCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the VerificationCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the VerificationCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the VerificationCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the VerificationCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the VerificationCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the VerificationCaseDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/VerificationCaseUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/VerificationCaseUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IVerificationCaseUsage"/>
         /// </returns>
-        internal static IVerificationCaseUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IVerificationCaseUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("VerificationCaseUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="VerificationCaseUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="VerificationCaseUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IVerificationCaseUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.VerificationCases.VerificationCaseUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actorParameter"u8, out var actorParameterProperty))
             {
                 foreach (var arrayItem in actorParameterProperty.EnumerateArray())
@@ -2310,8 +2340,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the verifiedRequirement Json property was not found in the VerificationCaseUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="VerificationCaseUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="VerificationCaseUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IVerificationCaseUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.VerificationCases.VerificationCaseUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the VerificationCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the VerificationCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the VerificationCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the VerificationCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the VerificationCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the VerificationCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the VerificationCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the VerificationCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the VerificationCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the VerificationCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the VerificationCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the VerificationCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the VerificationCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the VerificationCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the VerificationCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the VerificationCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the VerificationCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the VerificationCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the VerificationCaseUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the VerificationCaseUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ViewDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ViewDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IViewDefinition"/>
         /// </returns>
-        internal static IViewDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IViewDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ViewDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ViewDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ViewDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IViewDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Views.ViewDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -1713,8 +1743,176 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the viewRendering Json property was not found in the ViewDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ViewDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ViewDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IViewDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Views.ViewDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ViewDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ViewDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ViewDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ViewDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the ViewDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ViewDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the ViewDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the ViewDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the ViewDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ViewDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ViewDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ViewRenderingMembershipDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ViewRenderingMembershipDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IViewRenderingMembership"/>
         /// </returns>
-        internal static IViewRenderingMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IViewRenderingMembership DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ViewRenderingMembershipDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ViewRenderingMembership" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ViewRenderingMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IViewRenderingMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Views.ViewRenderingMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -573,8 +603,193 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the visibility Json property was not found in the ViewRenderingMembership: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ViewRenderingMembership" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ViewRenderingMembership"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IViewRenderingMembership"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Views.ViewRenderingMembership dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ViewRenderingMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ViewRenderingMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ViewRenderingMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ViewRenderingMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImplied"u8, out var isImpliedProperty))
+            {
+                if (isImpliedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImplied = isImpliedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImplied Json property was not found in the ViewRenderingMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ViewRenderingMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelatedElement"u8, out var ownedRelatedElementProperty))
+            {
+                foreach (var arrayItem in ownedRelatedElementProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelatedElement.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelatedElement Json property was not found in the ViewRenderingMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ViewRenderingMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelatedElement"u8, out var owningRelatedElementProperty))
+            {
+                if (owningRelatedElementProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelatedElement = null;
+                }
+                else
+                {
+                    if (owningRelatedElementProperty.TryGetProperty("@id"u8, out var owningRelatedElementExternalIdProperty))
+                    {
+                        var propertyValue = owningRelatedElementExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelatedElement = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelatedElement Json property was not found in the ViewRenderingMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ViewRenderingMembership: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("visibility"u8, out var visibilityProperty))
+            {
+                dtoInstance.Visibility = VisibilityKindDeSerializer.Deserialize(visibilityProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the visibility Json property was not found in the ViewRenderingMembership: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ViewUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ViewUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IViewUsage"/>
         /// </returns>
-        internal static IViewUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IViewUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ViewUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ViewUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ViewUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IViewUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Views.ViewUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
             {
                 foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
@@ -2284,8 +2314,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the viewRendering Json property was not found in the ViewUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ViewUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ViewUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IViewUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Views.ViewUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ViewUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ViewUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the ViewUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the ViewUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ViewUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the ViewUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the ViewUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the ViewUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the ViewUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the ViewUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ViewUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the ViewUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the ViewUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the ViewUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the ViewUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the ViewUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the ViewUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ViewUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ViewUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the ViewUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ViewpointDefinitionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ViewpointDefinitionDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IViewpointDefinition"/>
         /// </returns>
-        internal static IViewpointDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IViewpointDefinition DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ViewpointDefinitionDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ViewpointDefinition" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ViewpointDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IViewpointDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Views.ViewpointDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actorParameter"u8, out var actorParameterProperty))
             {
                 foreach (var arrayItem in actorParameterProperty.EnumerateArray())
@@ -1868,8 +1898,176 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the viewpointStakeholder Json property was not found in the ViewpointDefinition: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ViewpointDefinition" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ViewpointDefinition"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IViewpointDefinition"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Views.ViewpointDefinition dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ViewpointDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ViewpointDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ViewpointDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the ViewpointDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ViewpointDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the ViewpointDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the ViewpointDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the ViewpointDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ViewpointDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ViewpointDefinition: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("reqId"u8, out var reqIdProperty))
+            {
+                dtoInstance.ReqId = reqIdProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the reqId Json property was not found in the ViewpointDefinition: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ViewpointUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/ViewpointUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IViewpointUsage"/>
         /// </returns>
-        internal static IViewpointUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IViewpointUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ViewpointUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="ViewpointUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ViewpointUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IViewpointUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Views.ViewpointUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actorParameter"u8, out var actorParameterProperty))
             {
                 foreach (var arrayItem in actorParameterProperty.EnumerateArray())
@@ -2379,8 +2409,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the viewpointStakeholder Json property was not found in the ViewpointUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="ViewpointUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="ViewpointUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IViewpointUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Views.ViewpointUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the ViewpointUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the ViewpointUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the ViewpointUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the ViewpointUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the ViewpointUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the ViewpointUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the ViewpointUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the ViewpointUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the ViewpointUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the ViewpointUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the ViewpointUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the ViewpointUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the ViewpointUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the ViewpointUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the ViewpointUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the ViewpointUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the ViewpointUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the ViewpointUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the ViewpointUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("reqId"u8, out var reqIdProperty))
+            {
+                dtoInstance.ReqId = reqIdProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the reqId Json property was not found in the ViewpointUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/WhileLoopActionUsageDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/Core/AutoGenDeSerializer/WhileLoopActionUsageDeSerializer.cs
@@ -49,13 +49,16 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">
+        /// Asserts that the deserializer should deserialize derived properties if present or if they are ignored
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="IWhileLoopActionUsage"/>
         /// </returns>
-        internal static IWhileLoopActionUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static IWhileLoopActionUsage DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("WhileLoopActionUsageDeSerializer");
 
@@ -85,6 +88,33 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 }
             }
 
+            if (deserializeDerivedProperties)
+            {
+                DeserializeDtoIncludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+            else
+            {
+                DeserializeDtoExcludingDerivedProperties(dtoInstance, jsonElement, logger);
+            }
+
+            return dtoInstance;
+        }
+
+        /// <summary>
+        /// Deserializes properties of a <see cref="WhileLoopActionUsage" />
+        /// from a <see cref="JsonElement" />, including derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="WhileLoopActionUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IWhileLoopActionUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoIncludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.WhileLoopActionUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
             if (jsonElement.TryGetProperty("actionDefinition"u8, out var actionDefinitionProperty))
             {
                 foreach (var arrayItem in actionDefinitionProperty.EnumerateArray())
@@ -2230,8 +2260,278 @@ namespace SysML2.NET.Serializer.Json.Core.DTO
                 logger.LogDebug("the whileArgument Json property was not found in the WhileLoopActionUsage: { Id }", dtoInstance.Id);
             }
 
+        }
 
-            return dtoInstance;
+        /// <summary>
+        /// Deserializes properties of a <see cref="WhileLoopActionUsage" />
+        /// from a <see cref="JsonElement" />, excluding derived properties
+        /// </summary>
+        /// <param name="dtoInstance">
+        /// The <see cref="WhileLoopActionUsage"/> instance holding deserialized values
+        /// </param>
+        /// <param name="jsonElement">
+        /// The <see cref="JsonElement"/> that contains the <see cref="IWhileLoopActionUsage"/> json object
+        /// </param>
+        /// <param name="logger">
+        /// The <see cref="ILogger"/> to produce logging statement
+        /// </param>
+        private static void DeserializeDtoExcludingDerivedProperties(SysML2.NET.Core.DTO.Systems.Actions.WhileLoopActionUsage dtoInstance, JsonElement jsonElement, ILogger logger)
+        {
+            if (jsonElement.TryGetProperty("aliasIds"u8, out var aliasIdsProperty))
+            {
+                foreach (var arrayItem in aliasIdsProperty.EnumerateArray())
+                {
+                    var propertyValue = arrayItem.GetString();
+
+                    if (propertyValue != null)
+                    {
+                        dtoInstance.AliasIds.Add(propertyValue);
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the aliasIds Json property was not found in the WhileLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredName"u8, out var declaredNameProperty))
+            {
+                dtoInstance.DeclaredName = declaredNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredName Json property was not found in the WhileLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("declaredShortName"u8, out var declaredShortNameProperty))
+            {
+                dtoInstance.DeclaredShortName = declaredShortNameProperty.GetString();
+            }
+            else
+            {
+                logger.LogDebug("the declaredShortName Json property was not found in the WhileLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("direction"u8, out var directionProperty))
+            {
+                dtoInstance.Direction = FeatureDirectionKindDeSerializer.DeserializeNullable(directionProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the direction Json property was not found in the WhileLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("elementId"u8, out var elementIdProperty))
+            {
+                var propertyValue = elementIdProperty.GetString();
+
+                if (propertyValue != null)
+                {
+                    dtoInstance.ElementId = propertyValue;
+                }
+            }
+            else
+            {
+                logger.LogDebug("the elementId Json property was not found in the WhileLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isAbstract"u8, out var isAbstractProperty))
+            {
+                if (isAbstractProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsAbstract = isAbstractProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isAbstract Json property was not found in the WhileLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isComposite"u8, out var isCompositeProperty))
+            {
+                if (isCompositeProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsComposite = isCompositeProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isComposite Json property was not found in the WhileLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isConstant"u8, out var isConstantProperty))
+            {
+                if (isConstantProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsConstant = isConstantProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isConstant Json property was not found in the WhileLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isDerived"u8, out var isDerivedProperty))
+            {
+                if (isDerivedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsDerived = isDerivedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isDerived Json property was not found in the WhileLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isEnd"u8, out var isEndProperty))
+            {
+                if (isEndProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsEnd = isEndProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isEnd Json property was not found in the WhileLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isImpliedIncluded"u8, out var isImpliedIncludedProperty))
+            {
+                if (isImpliedIncludedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsImpliedIncluded = isImpliedIncludedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isImpliedIncluded Json property was not found in the WhileLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isIndividual"u8, out var isIndividualProperty))
+            {
+                if (isIndividualProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsIndividual = isIndividualProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isIndividual Json property was not found in the WhileLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isOrdered"u8, out var isOrderedProperty))
+            {
+                if (isOrderedProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsOrdered = isOrderedProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isOrdered Json property was not found in the WhileLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isPortion"u8, out var isPortionProperty))
+            {
+                if (isPortionProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsPortion = isPortionProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isPortion Json property was not found in the WhileLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isSufficient"u8, out var isSufficientProperty))
+            {
+                if (isSufficientProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsSufficient = isSufficientProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isSufficient Json property was not found in the WhileLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isUnique"u8, out var isUniqueProperty))
+            {
+                if (isUniqueProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsUnique = isUniqueProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isUnique Json property was not found in the WhileLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("isVariation"u8, out var isVariationProperty))
+            {
+                if (isVariationProperty.ValueKind != JsonValueKind.Null)
+                {
+                    dtoInstance.IsVariation = isVariationProperty.GetBoolean();
+                }
+            }
+            else
+            {
+                logger.LogDebug("the isVariation Json property was not found in the WhileLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("ownedRelationship"u8, out var ownedRelationshipProperty))
+            {
+                foreach (var arrayItem in ownedRelationshipProperty.EnumerateArray())
+                {
+                    if (arrayItem.TryGetProperty("@id"u8, out var ownedRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = ownedRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwnedRelationship.Add(Guid.Parse(propertyValue));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the ownedRelationship Json property was not found in the WhileLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("owningRelationship"u8, out var owningRelationshipProperty))
+            {
+                if (owningRelationshipProperty.ValueKind == JsonValueKind.Null)
+                {
+                    dtoInstance.OwningRelationship = null;
+                }
+                else
+                {
+                    if (owningRelationshipProperty.TryGetProperty("@id"u8, out var owningRelationshipExternalIdProperty))
+                    {
+                        var propertyValue = owningRelationshipExternalIdProperty.GetString();
+
+                        if (propertyValue != null)
+                        {
+                            dtoInstance.OwningRelationship = Guid.Parse(propertyValue);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                logger.LogDebug("the owningRelationship Json property was not found in the WhileLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
+            if (jsonElement.TryGetProperty("portionKind"u8, out var portionKindProperty))
+            {
+                dtoInstance.PortionKind = PortionKindDeSerializer.DeserializeNullable(portionKindProperty.GetString());
+            }
+            else
+            {
+                logger.LogDebug("the portionKind Json property was not found in the WhileLoopActionUsage: { Id }", dtoInstance.Id);
+            }
+
         }
     }
 }

--- a/SysML2.NET.Serializer.Json/IDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/IDeSerializer.cs
@@ -45,10 +45,11 @@ namespace SysML2.NET.Serializer.Json
         /// <param name="serializationTargetKind">
         /// The <see cref="SerializationTargetKind"/> to use
         /// </param>
+        /// <param name="deserializeDerivedProperties">Asserts that the deserializer should deserialize derived properties if present or if they are ignored</param>
         /// <returns>
         /// an <see cref="IEnumerable{IData}"/>
         /// </returns>
-        IEnumerable<IData> DeSerialize(Stream stream, SerializationModeKind serializationModeKind, SerializationTargetKind serializationTargetKind);
+        IEnumerable<IData> DeSerialize(Stream stream, SerializationModeKind serializationModeKind, SerializationTargetKind serializationTargetKind, bool deserializeDerivedProperties);
 
         /// <summary>
         /// Asynchronously deserializes the JSON stream to an <see cref="IEnumerable{IData}"/>
@@ -62,12 +63,13 @@ namespace SysML2.NET.Serializer.Json
         /// <param name="serializationTargetKind">
         /// The <see cref="SerializationTargetKind"/> to use
         /// </param>
+        /// <param name="deserializeDerivedProperties">Asserts that the deserializer should deserialize derived properties if present or if they are ignored</param>
         /// <param name="cancellationToken">
         /// The <see cref="CancellationToken"/> used to cancel the operation
         /// </param>
         /// <returns>
         /// an <see cref="IEnumerable{IData}"/>
         /// </returns>
-        Task<IEnumerable<IData>> DeSerializeAsync(Stream stream, SerializationModeKind serializationModeKind, SerializationTargetKind serializationTargetKind, CancellationToken cancellationToken);
+        Task<IEnumerable<IData>> DeSerializeAsync(Stream stream, SerializationModeKind serializationModeKind, SerializationTargetKind serializationTargetKind, bool deserializeDerivedProperties, CancellationToken cancellationToken);
     }
 }

--- a/SysML2.NET.Serializer.Json/PIM/ApiDeSerializationProvider.cs
+++ b/SysML2.NET.Serializer.Json/PIM/ApiDeSerializationProvider.cs
@@ -38,9 +38,9 @@ namespace SysML2.NET.Serializer.Json.PIM.DTO
         /// <summary>
         /// a dictionary that provides delegates for deserialization
         /// </summary>
-        private static readonly Dictionary<string, Func<JsonElement, SerializationModeKind, ILoggerFactory, IData>>
+        private static readonly Dictionary<string, Func<JsonElement, SerializationModeKind, bool, ILoggerFactory, IData>>
             DeSerializerActionMap =
-                new Dictionary<string, Func<JsonElement, SerializationModeKind, ILoggerFactory, IData>>
+                new Dictionary<string, Func<JsonElement, SerializationModeKind, bool, ILoggerFactory, IData>>
                 {
                     { "Branch", BranchDeserializer.DeSerialize },
                     { "Commit", CommitDeSerializer.DeSerialize },
@@ -50,19 +50,19 @@ namespace SysML2.NET.Serializer.Json.PIM.DTO
                 };
     
         /// <summary>
-        /// Provides the delegate <see cref="Func{JsonElement, SerializationModeKind, ILoggerFactory, IData}"/> for the
+        /// Provides the delegate <see cref="Func{JsonElement, SerializationModeKind, bool,  ILoggerFactory, IData}"/> for the
         /// <see cref="System.Type"/> that is to be deserialized
         /// </summary>
         /// <param name="typeName">
         /// The name of the subject <see cref="System.Type"/> that is to be serialized
         /// </param>
         /// <returns>
-        /// A Delegate of <see cref="Func{JsonElement, SerializationModeKind, ILoggerFactory, IData}"/>
+        /// A Delegate of <see cref="Func{JsonElement, SerializationModeKind, bool, ILoggerFactory, IData}"/>
         /// </returns>
         /// <exception cref="NotSupportedException">
         /// Thrown when the <see cref="System.Type"/> is not supported.
         /// </exception>
-        internal static Func<JsonElement, SerializationModeKind, ILoggerFactory, IData> Provide(string typeName)
+        internal static Func<JsonElement, SerializationModeKind, bool, ILoggerFactory, IData> Provide(string typeName)
         {
             if (!DeSerializerActionMap.TryGetValue(typeName, out var func))
             {

--- a/SysML2.NET.Serializer.Json/PIM/BranchDeserializer.cs
+++ b/SysML2.NET.Serializer.Json/PIM/BranchDeserializer.cs
@@ -44,13 +44,14 @@ namespace SysML2.NET.Serializer.Json.PIM.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">Asserts that the deserializer should deserialize derived properties if present or if they are ignoredAsserts that the deserializer should deserialize derived properties if present or if they are ignored</param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="Tag"/>
         /// </returns>
-        internal static Branch DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static Branch DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("BranchDeserializer");
 

--- a/SysML2.NET.Serializer.Json/PIM/CommitDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/PIM/CommitDeSerializer.cs
@@ -44,13 +44,14 @@ namespace SysML2.NET.Serializer.Json.PIM.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">Asserts that the deserializer should deserialize derived properties if present or if they are ignored</param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="Project"/>
         /// </returns>
-        internal static Commit DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static Commit DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("CommitDeSerializer");
 

--- a/SysML2.NET.Serializer.Json/PIM/DataIdentityDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/PIM/DataIdentityDeSerializer.cs
@@ -44,13 +44,14 @@ namespace SysML2.NET.Serializer.Json.PIM.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">Asserts that the deserializer should deserialize derived properties if present or if they are ignored</param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="DataIdentity"/>
         /// </returns>
-        internal static DataIdentity DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static DataIdentity DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("DataIdentityDeSerializer");
 

--- a/SysML2.NET.Serializer.Json/PIM/DataVersionDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/PIM/DataVersionDeSerializer.cs
@@ -45,13 +45,14 @@ namespace SysML2.NET.Serializer.Json.PIM.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">Asserts that the deserializer should deserialize derived properties if present or if they are ignored</param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="DataVersion"/>
         /// </returns>
-        internal static DataVersion DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static DataVersion DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("DataVersionDeSerializer");
 
@@ -107,7 +108,7 @@ namespace SysML2.NET.Serializer.Json.PIM.DTO
 
             if (jsonElement.TryGetProperty("identity"u8, out JsonElement identityObject))
             {
-                dtoInstance.Identity = DataIdentityDeSerializer.DeSerialize(identityObject, serializationModeKind, loggerFactory);
+                dtoInstance.Identity = DataIdentityDeSerializer.DeSerialize(identityObject, serializationModeKind, deserializeDerivedProperties, loggerFactory);
             }
             else
             {
@@ -121,7 +122,7 @@ namespace SysML2.NET.Serializer.Json.PIM.DTO
                     var typeName = typeElement.GetString();
 
                     var func = DeSerializationProvider.Provide(typeName);
-                    dtoInstance.Payload = func(payloadObject, serializationModeKind, loggerFactory);
+                    dtoInstance.Payload = func(payloadObject, serializationModeKind,deserializeDerivedProperties, loggerFactory);
                 }
             }
             else

--- a/SysML2.NET.Serializer.Json/PIM/ProjectDeSerializer.cs
+++ b/SysML2.NET.Serializer.Json/PIM/ProjectDeSerializer.cs
@@ -44,13 +44,14 @@ namespace SysML2.NET.Serializer.Json.PIM.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">Asserts that the deserializer should deserialize derived properties if present or if they are ignored</param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="Project"/>
         /// </returns>
-        internal static Project DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static Project DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("ProjectDeSerializer");
 

--- a/SysML2.NET.Serializer.Json/PIM/TagDeserializer.cs
+++ b/SysML2.NET.Serializer.Json/PIM/TagDeserializer.cs
@@ -44,13 +44,14 @@ namespace SysML2.NET.Serializer.Json.PIM.DTO
         /// <param name="serializationModeKind">
         /// enumeration specifying what kind of serialization shall be used
         /// </param>
+        /// <param name="deserializeDerivedProperties">Asserts that the deserializer should deserialize derived properties if present or if they are ignored</param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
         /// <returns>
         /// an instance of <see cref="Tag"/>
         /// </returns>
-        internal static Tag DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, ILoggerFactory loggerFactory = null)
+        internal static Tag DeSerialize(JsonElement jsonElement, SerializationModeKind serializationModeKind, bool deserializeDerivedProperties, ILoggerFactory loggerFactory = null)
         {
             var logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger("TagDeserializer");
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/SysML2.NET/pulls) open
- [x] I have verified that I am following the SysML2.NET [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/SysML2.NET/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #52
Deserializers have now a parameter to assert if derived properties have to be deserialized or not
<!-- Thanks for contributing to SysML2.NET! -->