### PR TITLE
CodeGen resolve-reference for POCO on XMI process

### DIFF
--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/AnnotatingElementExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/AnnotatingElementExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AnnotatingElementExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Root.Annotations.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class AnnotatingElementExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Annotations.AnnotatingElement"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Root.Annotations.AnnotatingElement poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [AnnotatingElement] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Annotations.AnnotatingElement"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Root.Annotations.AnnotatingElement poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [AnnotatingElement] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/AssociationExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/AssociationExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AssociationExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Associations.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class AssociationExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Associations.Association"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Associations.Association poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [Association] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Association] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Associations.Association"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Associations.Association poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [Association] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Association] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/DependencyExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/DependencyExtensions.cs
@@ -1,0 +1,242 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DependencyExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Root.Dependencies.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class DependencyExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Dependencies.Dependency"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Root.Dependencies.Dependency poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [Dependency] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Dependency] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Dependencies.Dependency"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Root.Dependencies.Dependency poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "client":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [client] on element type [Dependency] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement clientReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.Client.Add(clientReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [Dependency] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Dependency] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                case "supplier":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [supplier] on element type [Dependency] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement supplierReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.Supplier.Add(supplierReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/EnumerationDefinitionExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/EnumerationDefinitionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="EnumerationDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Enumerations.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class EnumerationDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Enumerations.EnumerationDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Enumerations.EnumerationDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [EnumerationDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Enumerations.EnumerationDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Enumerations.EnumerationDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [EnumerationDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/FeatureExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/FeatureExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FeatureExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Features.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class FeatureExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.Feature"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Features.Feature poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Feature] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.Feature"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Features.Feature poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Feature] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/FeatureTypingExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/FeatureTypingExtensions.cs
@@ -1,0 +1,234 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FeatureTypingExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Features.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class FeatureTypingExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.FeatureTyping"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Features.FeatureTyping poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [FeatureTyping] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [FeatureTyping] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                case "type":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [type] on element type [FeatureTyping] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Types.IType typeReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IType");
+                        }
+
+                        poco.Type = typeReference;
+                        return;
+                    }
+
+                case "typedFeature":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [typedFeature] on element type [FeatureTyping] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Features.IFeature typedFeatureReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IFeature");
+                        }
+
+                        poco.TypedFeature = typedFeatureReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.FeatureTyping"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Features.FeatureTyping poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [FeatureTyping] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [FeatureTyping] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/FlowExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/FlowExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FlowExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Interactions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class FlowExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Interactions.Flow"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Interactions.Flow poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [Flow] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Flow] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Interactions.Flow"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Interactions.Flow poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [Flow] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Flow] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/FramedConcernMembershipExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/FramedConcernMembershipExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FramedConcernMembershipExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Requirements.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class FramedConcernMembershipExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.FramedConcernMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Requirements.FramedConcernMembership poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [FramedConcernMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [FramedConcernMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.FramedConcernMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Requirements.FramedConcernMembership poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [FramedConcernMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [FramedConcernMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/LiteralIntegerExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/LiteralIntegerExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="LiteralIntegerExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Expressions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class LiteralIntegerExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.LiteralInteger"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Expressions.LiteralInteger poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [LiteralInteger] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.LiteralInteger"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Expressions.LiteralInteger poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [LiteralInteger] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/LiteralRationalExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/LiteralRationalExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="LiteralRationalExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Expressions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class LiteralRationalExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.LiteralRational"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Expressions.LiteralRational poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [LiteralRational] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.LiteralRational"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Expressions.LiteralRational poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [LiteralRational] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/MembershipExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/MembershipExtensions.cs
@@ -1,0 +1,215 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="MembershipExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Root.Namespaces.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class MembershipExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.Membership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Root.Namespaces.Membership poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "memberElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [memberElement] on element type [Membership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement memberElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.MemberElement = memberElementReference;
+                        return;
+                    }
+
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [Membership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Membership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.Membership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Root.Namespaces.Membership poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [Membership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Membership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/MultiplicityRangeExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/MultiplicityRangeExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="MultiplicityRangeExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Multiplicities.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class MultiplicityRangeExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Multiplicities.MultiplicityRange"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Multiplicities.MultiplicityRange poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [MultiplicityRange] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Multiplicities.MultiplicityRange"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Multiplicities.MultiplicityRange poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [MultiplicityRange] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/OwningMembershipExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/OwningMembershipExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="OwningMembershipExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Root.Namespaces.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class OwningMembershipExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.OwningMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Root.Namespaces.OwningMembership poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [OwningMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [OwningMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.OwningMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Root.Namespaces.OwningMembership poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [OwningMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [OwningMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/ReferenceSubsettingExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/ReferenceSubsettingExtensions.cs
@@ -1,0 +1,215 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ReferenceSubsettingExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Features.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ReferenceSubsettingExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.ReferenceSubsetting"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Features.ReferenceSubsetting poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [ReferenceSubsetting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ReferenceSubsetting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                case "referencedFeature":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [referencedFeature] on element type [ReferenceSubsetting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Features.IFeature referencedFeatureReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IFeature");
+                        }
+
+                        poco.ReferencedFeature = referencedFeatureReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.ReferenceSubsetting"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Features.ReferenceSubsetting poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [ReferenceSubsetting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ReferenceSubsetting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/RequirementUsageExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/RequirementUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="RequirementUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Requirements.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class RequirementUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.RequirementUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Requirements.RequirementUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [RequirementUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.RequirementUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Requirements.RequirementUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [RequirementUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/SelectExpressionExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/SelectExpressionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="SelectExpressionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Expressions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class SelectExpressionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.SelectExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Expressions.SelectExpression poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [SelectExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.SelectExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Expressions.SelectExpression poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [SelectExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/SubclassificationExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/SubclassificationExtensions.cs
@@ -1,0 +1,234 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="SubclassificationExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Classifiers.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class SubclassificationExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Classifiers.Subclassification"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Classifiers.Subclassification poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [Subclassification] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Subclassification] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                case "subclassifier":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [subclassifier] on element type [Subclassification] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Classifiers.IClassifier subclassifierReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IClassifier");
+                        }
+
+                        poco.Subclassifier = subclassifierReference;
+                        return;
+                    }
+
+                case "superclassifier":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [superclassifier] on element type [Subclassification] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Classifiers.IClassifier superclassifierReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IClassifier");
+                        }
+
+                        poco.Superclassifier = superclassifierReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Classifiers.Subclassification"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Classifiers.Subclassification poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [Subclassification] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Subclassification] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/TextualRepresentationExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/TextualRepresentationExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="TextualRepresentationExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Root.Annotations.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class TextualRepresentationExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Annotations.TextualRepresentation"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Root.Annotations.TextualRepresentation poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [TextualRepresentation] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Annotations.TextualRepresentation"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Root.Annotations.TextualRepresentation poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [TextualRepresentation] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/UsageExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoReferenceResolveExtension/UsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="UsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class UsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.Usage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.Usage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Usage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.Usage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.Usage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Usage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.CodeGenerator.Tests/Generators/UmlHandleBarsGenerators/UmlPocoReferenceResolveExtensionGeneratorTestFixture.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Generators/UmlHandleBarsGenerators/UmlPocoReferenceResolveExtensionGeneratorTestFixture.cs
@@ -1,0 +1,69 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="UmlPocoReferenceResolveExtensionGeneratorTestFixture.cs" company="Starion Group S.A.">
+// 
+//   Copyright 2022-2026 Starion Group S.A.
+// 
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.CodeGenerator.Tests.Generators.UmlHandleBarsGenerators
+{
+    using System.IO;
+    using System.Threading.Tasks;
+
+    using NUnit.Framework;
+
+    using SysML2.NET.CodeGenerator.Generators.UmlHandleBarsGenerators;
+    using SysML2.NET.CodeGenerator.Tests.Expected.Ecore.Core;
+
+    [TestFixture]
+    public class UmlPocoReferenceResolveExtensionGeneratorTestFixture
+    {
+        private DirectoryInfo umlPocoReferenceResolveExtensionDirectoryInfo;
+        private UmlPocoReferenceResolveExtensionGenerator umlPocoReferenceResolveExtensionGenerator;
+
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            var directoryInfo = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
+
+            var path = Path.Combine("UML", "_SysML2.NET.Serializer.Xmi.AutoGenPocoReferenceResolveExtension");
+
+            this.umlPocoReferenceResolveExtensionDirectoryInfo = directoryInfo.CreateSubdirectory(path);
+            this.umlPocoReferenceResolveExtensionGenerator = new UmlPocoReferenceResolveExtensionGenerator();
+        }
+
+        [Test]
+        public async Task VerifyPocoReferenceResolveExtensionAreGenerated()
+        {
+            await Assert.ThatAsync(() => this.umlPocoReferenceResolveExtensionGenerator.GenerateAsync(GeneratorSetupFixture.XmiReaderResult, this.umlPocoReferenceResolveExtensionDirectoryInfo), Throws.Nothing);
+        }
+        
+        [Test]
+        [TestCaseSource(typeof(ExpectedConcreteClasses))]
+        [Category("Expected")]
+        public async Task VerifyExpectedClassesMatches(string className)
+        {
+            var generatedCode = await this.umlPocoReferenceResolveExtensionGenerator.GenerateExtensionClass(GeneratorSetupFixture.XmiReaderResult,
+                this.umlPocoReferenceResolveExtensionDirectoryInfo,
+                className);
+
+            var expected = await File.ReadAllTextAsync(Path.Combine(TestContext.CurrentContext.TestDirectory,
+                $"Expected/UML/Core/AutoGenPocoReferenceResolveExtension/{className}Extensions.cs"));
+
+            Assert.That(generatedCode, Is.EqualTo(expected));
+        }
+    }
+}

--- a/SysML2.NET.CodeGenerator.Tests/SysML2.NET.CodeGenerator.Tests.csproj
+++ b/SysML2.NET.CodeGenerator.Tests/SysML2.NET.CodeGenerator.Tests.csproj
@@ -97,6 +97,82 @@
       <None Include="Expected\UML\Core\AutoGenReaders\UsageReader.cs">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
+      <Compile Remove="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\AnnotatingElementExtensions.cs" />
+      <None Include="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\AnnotatingElementExtensions.cs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <Compile Remove="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\AssociationExtensions.cs" />
+      <None Include="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\AssociationExtensions.cs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <Compile Remove="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\DependencyExtensions.cs" />
+      <None Include="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\DependencyExtensions.cs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <Compile Remove="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\EnumerationDefinitionExtensions.cs" />
+      <None Include="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\EnumerationDefinitionExtensions.cs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <Compile Remove="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\FeatureExtensions.cs" />
+      <None Include="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\FeatureExtensions.cs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <Compile Remove="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\FeatureTypingExtensions.cs" />
+      <None Include="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\FeatureTypingExtensions.cs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <Compile Remove="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\FlowExtensions.cs" />
+      <None Include="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\FlowExtensions.cs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <Compile Remove="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\FramedConcernMembershipExtensions.cs" />
+      <None Include="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\FramedConcernMembershipExtensions.cs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <Compile Remove="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\LiteralIntegerExtensions.cs" />
+      <None Include="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\LiteralIntegerExtensions.cs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <Compile Remove="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\LiteralRationalExtensions.cs" />
+      <None Include="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\LiteralRationalExtensions.cs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <Compile Remove="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\MembershipExtensions.cs" />
+      <None Include="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\MembershipExtensions.cs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <Compile Remove="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\MultiplicityRangeExtensions.cs" />
+      <None Include="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\MultiplicityRangeExtensions.cs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <Compile Remove="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\OwningMembershipExtensions.cs" />
+      <None Include="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\OwningMembershipExtensions.cs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <Compile Remove="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\ReferenceSubsettingExtensions.cs" />
+      <None Include="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\ReferenceSubsettingExtensions.cs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <Compile Remove="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\RequirementUsageExtensions.cs" />
+      <None Include="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\RequirementUsageExtensions.cs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <Compile Remove="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\SelectExpressionExtensions.cs" />
+      <None Include="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\SelectExpressionExtensions.cs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <Compile Remove="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\SubclassificationExtensions.cs" />
+      <None Include="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\SubclassificationExtensions.cs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <Compile Remove="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\TextualRepresentationExtensions.cs" />
+      <None Include="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\TextualRepresentationExtensions.cs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <Compile Remove="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\UsageExtensions.cs" />
+      <None Include="Expected\UML\Core\AutoGenPocoReferenceResolveExtension\UsageExtensions.cs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
 
     <ItemGroup>

--- a/SysML2.NET.CodeGenerator/Generators/UmlHandleBarsGenerators/UmlPocoReferenceResolveExtensionGenerator.cs
+++ b/SysML2.NET.CodeGenerator/Generators/UmlHandleBarsGenerators/UmlPocoReferenceResolveExtensionGenerator.cs
@@ -1,0 +1,254 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="UmlPocoReferenceResolveExtensionGenerator.cs" company="Starion Group S.A.">
+// 
+//   Copyright 2022-2026 Starion Group S.A.
+// 
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.CodeGenerator.Generators.UmlHandleBarsGenerators
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    using SysML2.NET.CodeGenerator.Extensions;
+
+    using uml4net.Extensions;
+    using uml4net.HandleBars;
+    using uml4net.StructuredClassifiers;
+    using uml4net.xmi.Readers;
+
+    /// <summary>
+    /// The <see cref="UmlPocoReferenceResolveExtensionGenerator"/> provides POCO extension method code generation
+    /// for reference resolve
+    /// </summary>
+    public class UmlPocoReferenceResolveExtensionGenerator: UmlHandleBarsGenerator
+    {
+        /// <summary>
+        /// Gets the name of the POCO extension template name
+        /// </summary>
+        private const string PocoExtensionTemplateName = "core-poco-reference-resolve-extension-template";
+        
+        /// <summary>
+        /// Gets the name of the POCO extension facade template name
+        /// </summary>
+        private const string PocoExtensionFacadeTemplateName = "core-poco-reference-resolve-extension-facade-template";
+        
+        /// <summary>
+        /// Register the custom helpers
+        /// </summary>
+        protected override void RegisterHelpers()
+        {
+            this.Handlebars.RegisterStringHelper();
+            this.Handlebars.RegisterPropertyHelper();
+            this.Handlebars.RegisterClassHelper();
+            SysML2.NET.CodeGenerator.HandleBarHelpers.NamedElementHelper.RegisterNamedElementHelper(this.Handlebars);
+            SysML2.NET.CodeGenerator.HandleBarHelpers.PropertyHelper.RegisterPropertyHelper(this.Handlebars);
+            SysML2.NET.CodeGenerator.HandleBarHelpers.ClassHelper.RegisterClassHelper(this.Handlebars);
+        }
+
+        /// <summary>
+        /// Register the code templates
+        /// </summary>
+        protected override void RegisterTemplates()
+        {
+            this.RegisterTemplate(PocoExtensionTemplateName);
+            this.RegisterTemplate(PocoExtensionFacadeTemplateName);
+        }
+
+        /// <summary>
+        /// Generates code specific to the concrete implementation
+        /// </summary>
+        /// <param name="xmiReaderResult">
+        /// the <see cref="XmiReaderResult"/> that contains the UML model to generate from
+        /// </param>
+        /// <param name="outputDirectory">
+        /// The target <see cref="DirectoryInfo"/>
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task GenerateAsync(XmiReaderResult xmiReaderResult, DirectoryInfo outputDirectory)
+        {
+            await this.GeneratePocoExtensionClasses(xmiReaderResult, outputDirectory);
+            await this.GeneratePocoExtensionFacadeClass(xmiReaderResult, outputDirectory);
+        }
+
+        /// <summary>
+        /// Generate poco extension facade class for each concrete classes of the UML model
+        /// </summary>
+        /// <param name="xmiReaderResult">
+        /// the <see cref="XmiReaderResult"/> that contains the UML model to generate from
+        /// </param>
+        /// <param name="outputDirectory">
+        /// The target <see cref="DirectoryInfo"/>
+        /// is null
+        /// </param>
+        /// <exception cref="ArgumentNullException">If the provided <paramref name="xmiReaderResult"/> or <paramref name="outputDirectory"/></exception>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        private Task GeneratePocoExtensionFacadeClass(XmiReaderResult xmiReaderResult, DirectoryInfo outputDirectory)
+        {
+            ArgumentNullException.ThrowIfNull(xmiReaderResult);
+            ArgumentNullException.ThrowIfNull(outputDirectory);
+            
+            return this.GeneratePocoExtensionFacadeClassInternal(outputDirectory, xmiReaderResult);
+        }
+
+        /// <summary>
+        /// Generate poco extension facade class for each concrete classes of the UML model
+        /// </summary>
+        /// <param name="xmiReaderResult">
+        /// the <see cref="XmiReaderResult"/> that contains the UML model to generate from
+        /// </param>
+        /// <param name="outputDirectory">
+        /// The target <see cref="DirectoryInfo"/>
+        /// is null
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        private async Task GeneratePocoExtensionFacadeClassInternal(DirectoryInfo outputDirectory, XmiReaderResult xmiReaderResult)
+        {
+            var template = this.Templates[PocoExtensionFacadeTemplateName];
+
+            var umlClasses = xmiReaderResult.QueryContainedAndImported("SysML")
+                .SelectMany(x => x.PackagedElement.OfType<IClass>())
+                .Where(x => !x.IsAbstract)
+                .OrderBy(x => x.Name)
+                .ToList();
+            
+            var generatedPocoExtensionFacade = template(umlClasses);
+
+            generatedPocoExtensionFacade = this.CodeCleanup(generatedPocoExtensionFacade);
+
+            await WriteAsync(generatedPocoExtensionFacade, outputDirectory, "PocoReferenceResolveExtensionsFacade.cs");
+        }
+
+        /// <summary>
+        /// Generate poco extension classes for each concrete classes of the UML model
+        /// </summary>
+        /// <param name="xmiReaderResult">
+        /// the <see cref="XmiReaderResult"/> that contains the UML model to generate from
+        /// </param>
+        /// <param name="outputDirectory">
+        /// The target <see cref="DirectoryInfo"/>
+        /// is null
+        /// </param>
+        /// <exception cref="ArgumentNullException">If the provided <paramref name="xmiReaderResult"/> or <paramref name="outputDirectory"/></exception>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        private Task GeneratePocoExtensionClasses(XmiReaderResult xmiReaderResult, DirectoryInfo outputDirectory)
+        {
+            ArgumentNullException.ThrowIfNull(xmiReaderResult);
+            ArgumentNullException.ThrowIfNull(outputDirectory);
+            
+            return this.GeneratePocoExtensionClassesInternal(xmiReaderResult, outputDirectory);
+        }
+
+        /// <summary>
+        /// Generate poco extension classes for each concrete classes of the UML model
+        /// </summary>
+        /// <param name="xmiReaderResult">
+        /// the <see cref="XmiReaderResult"/> that contains the UML model to generate from
+        /// </param>
+        /// <param name="outputDirectory">
+        /// The target <see cref="DirectoryInfo"/>
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        private async Task GeneratePocoExtensionClassesInternal(XmiReaderResult xmiReaderResult, DirectoryInfo outputDirectory)
+        {
+            var template = this.Templates[PocoExtensionTemplateName];
+
+            var umlClasses = xmiReaderResult.QueryContainedAndImported("SysML")
+                .SelectMany(x => x.PackagedElement.OfType<IClass>())
+                .Where(x => !x.IsAbstract);
+
+            foreach (var umlClass  in umlClasses)
+            {
+                var generatedPocoExtension = template(umlClass);
+
+                generatedPocoExtension = this.CodeCleanup(generatedPocoExtension);
+
+                var fileName = $"{umlClass.Name.CapitalizeFirstLetter()}Extensions.cs";
+
+                await WriteAsync(generatedPocoExtension, outputDirectory, fileName);
+            }
+        }
+
+        /// <summary>
+        /// Generate poco extension class for a specific concrete class
+        /// </summary>
+        /// <param name="xmiReaderResult">
+        /// the <see cref="XmiReaderResult"/> that contains the UML model to generate from
+        /// </param>
+        /// <param name="outputDirectory">
+        /// The target <see cref="DirectoryInfo"/>
+        /// is null
+        /// </param>
+        /// <param name="className">The name of the class to generate</param>
+        /// <exception cref="ArgumentNullException">If the provided <paramref name="xmiReaderResult"/> or <paramref name="outputDirectory"/></exception>
+        /// <exception cref="ArgumentException">If the provided <paramref name="className"/> is null or whitespace</exception>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public Task<string> GenerateExtensionClass(XmiReaderResult xmiReaderResult, DirectoryInfo outputDirectory, string className)
+        {
+            ArgumentNullException.ThrowIfNull(xmiReaderResult);
+            ArgumentNullException.ThrowIfNull(outputDirectory);
+            ArgumentException.ThrowIfNullOrWhiteSpace(className);
+            
+            return this.GenerateExtensionClassInternal(xmiReaderResult, outputDirectory, className);        
+        }
+
+        /// <summary>
+        /// Generate poco extension class for a specific concrete class
+        /// </summary>
+        /// <param name="xmiReaderResult">
+        /// the <see cref="XmiReaderResult"/> that contains the UML model to generate from
+        /// </param>
+        /// <param name="outputDirectory">
+        /// The target <see cref="DirectoryInfo"/>
+        /// is null
+        /// </param>
+        /// <param name="className">The name of the class to generate</param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        private async Task<string> GenerateExtensionClassInternal(XmiReaderResult xmiReaderResult, DirectoryInfo outputDirectory, string className)
+        {
+            var template = this.Templates[PocoExtensionTemplateName];
+
+            var umlClass = xmiReaderResult.QueryContainedAndImported("SysML")
+                .SelectMany(x => x.PackagedElement.OfType<IClass>())
+                .Single(x => x.Name == className);
+
+            var generatedPocoExtension = template(umlClass);
+
+            generatedPocoExtension = this.CodeCleanup(generatedPocoExtension);
+
+            var fileName = $"{umlClass.Name.CapitalizeFirstLetter()}Extensions.cs";
+
+            await WriteAsync(generatedPocoExtension, outputDirectory, fileName);
+            return generatedPocoExtension;
+        }
+    }
+}

--- a/SysML2.NET.CodeGenerator/SysML2.NET.CodeGenerator.csproj
+++ b/SysML2.NET.CodeGenerator/SysML2.NET.CodeGenerator.csproj
@@ -205,6 +205,12 @@
     <None Update="Templates\Uml\Partials\core-xmi-reader-partial-for-element-template.hbs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Templates\Uml\core-poco-reference-resolve-extension-template.hbs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Templates\Uml\core-poco-reference-resolve-extension-facade-template.hbs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\HtmlDocs\" />

--- a/SysML2.NET.CodeGenerator/Templates/Uml/core-poco-reference-resolve-extension-facade-template.hbs
+++ b/SysML2.NET.CodeGenerator/Templates/Uml/core-poco-reference-resolve-extension-facade-template.hbs
@@ -1,0 +1,89 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="PocoReferenceResolveExtensionsFacade.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+    
+    using Microsoft.Extensions.Logging;
+    
+    using SysML2.NET.Common;
+    
+    /// <summary>
+    /// The <see cref="PocoReferenceResolveExtensionsFacade"/> provides access to extensions method for POCO <see cref="IData"/> to resolve reference
+    /// </summary>
+    public class PocoReferenceResolveExtensionsFacade: IPocoReferenceResolveExtensionsFacade
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="data">The <see cref="IData"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public void ResolveAndAssignSingleValueReference(IData data, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            switch (data)
+            {
+                {{#each this as | class |}}
+                case SysML2.NET.Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace class }}.{{class.Name}} {{String.LowerCaseFirstLetter class.Name}}Poco:
+                    {{String.LowerCaseFirstLetter class.Name}}Poco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                {{/each}}
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(data), data, "Unsupported type");
+            }
+        }
+    
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="data">The <see cref="IData"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public void ResolveAndAssignMultipleValueReferences(IData data, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            switch (data)
+            {
+                {{#each this as | class |}}
+                    case SysML2.NET.Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace class }}.{{class.Name}} {{String.LowerCaseFirstLetter class.Name}}Poco:
+                    {{String.LowerCaseFirstLetter class.Name}}Poco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                {{/each}}
+            
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(data), data, "Unsupported type");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.CodeGenerator/Templates/Uml/core-poco-reference-resolve-extension-template.hbs
+++ b/SysML2.NET.CodeGenerator/Templates/Uml/core-poco-reference-resolve-extension-template.hbs
@@ -1,0 +1,182 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="{{this.Name}}Extensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+    
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace this }}.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class {{this.Name}}Extensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace this }}.{{this.Name}}"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace this }}.{{this.Name}} poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if(poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if(xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if(logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+            {{#with this as |class| }}
+                {{ #each (Class.QueryAllProperties this) as | property | }}
+                {{#if (Property.QueryIsReferenceProperty property)}}
+                    {{#unless (Property.QueryIsEnumerable property)}}
+                        {{#unless this.IsTransient}}
+                        {{#unless this.IsDerived}}
+                            {{#unless (Property.IsPropertyRedefinedInClass this class)}}
+                            case "{{String.LowerCaseFirstLetter property.Name}}":
+                            {
+                                if(!xmiDataCache.TryGetData(reference, out var referencedData))
+                                {
+                                    logger.LogWarning("The reference to [{Reference}] for property [{{String.LowerCaseFirstLetter property.Name}}] on element type [{{class.Name}}] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                        reference, poco.Id);
+                            
+                                    return;
+                                }
+                            
+                                if(referencedData is not SysML2.NET.Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace property.Type }}.I{{property.Type.Name}} {{String.LowerCaseFirstLetter property.Name}}Reference)
+                                {
+                                    throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an I{{property.Type.Name}}");
+                                }
+
+                            poco.{{String.CapitalizeFirstLetter property.Name }} = {{String.LowerCaseFirstLetter property.Name}}Reference;
+                                return;
+                            }
+                            
+                            {{/unless}}
+                        {{/unless}}
+                    {{/unless}}
+                    {{/unless}}
+                {{/if}}
+                {{/each}}
+            {{/with}}
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    
+    /// <summary>
+    /// Resolve and assign multiple references value for a specific property
+    /// </summary>
+    /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace this }}.{{this.Name}}"/> that should have the value of a property to be set</param>
+    /// <param name="propertyName">The name of the property</param>
+    /// <param name="references">The collection of identifier values to set</param>
+    /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+    /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+    public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace this }}.{{this.Name}} poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+    {
+        if(poco == null)
+        {
+            throw new ArgumentNullException(nameof(poco));
+        }
+
+        if(references == null)
+        {
+            throw new ArgumentNullException(nameof(references));
+        }
+
+        if(xmiDataCache == null)
+        {
+            throw new ArgumentNullException(nameof(xmiDataCache));
+        }
+
+        if(logger == null)
+        {
+            throw new ArgumentNullException(nameof(logger));
+        }
+                
+        switch (propertyName)
+        {
+        {{#with this as |class| }}
+            {{ #each (Class.QueryAllProperties this) as | property | }}
+            {{#if (Property.QueryIsReferenceProperty property)}}
+                {{#if (Property.QueryIsEnumerable property)}}
+                    {{#unless this.IsTransient}}
+                        {{#unless this.IsDerived}}
+                            {{#unless (Property.IsPropertyRedefinedInClass this class)}}
+                                    case "{{String.LowerCaseFirstLetter property.Name}}":
+                                    {
+                                        foreach(var reference in references)
+                                        {
+                                            if(!xmiDataCache.TryGetData(reference, out var referencedData))
+                                            {
+                                                logger.LogWarning("The reference to [{Reference}] for property [{{String.LowerCaseFirstLetter property.Name}}] on element type [{{class.Name}}] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                                reference, poco.Id);
+            
+                                                continue;
+                                            }
+    
+                                            if(referencedData is not SysML2.NET.Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace property.Type }}.I{{property.Type.Name}} {{String.LowerCaseFirstLetter property.Name}}Reference)
+                                            {
+                                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an I{{property.Type.Name}}");
+                                            }
+
+                                            poco.{{String.CapitalizeFirstLetter property.Name }}.Add({{String.LowerCaseFirstLetter property.Name}}Reference);
+                                        }
+                                
+                                        return;
+                                    }
+
+                            {{/unless}}
+                        {{/unless}}
+                    {{/unless}}
+                {{/if}}
+            {{/if}}
+        {{/each}}
+    {{/with}}
+            default:
+            throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi.Tests/DeSerializerTestFixture.cs
+++ b/SysML2.NET.Serializer.Xmi.Tests/DeSerializerTestFixture.cs
@@ -26,6 +26,7 @@ namespace SysML2.NET.Serializer.Xmi.Tests
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
 
+    using SysML2.NET.Serializer.Xmi.Extensions;
     using SysML2.NET.Serializer.Xmi.Readers;
 
     [TestFixture]
@@ -41,7 +42,7 @@ namespace SysML2.NET.Serializer.Xmi.Tests
                 .AddLogging(x => x.AddConsole())
                 .BuildServiceProvider();
 
-            this.xmiDataCache = new XmiDataCache(serviceProvider.GetRequiredService<ILogger<XmiDataCache>>());
+            this.xmiDataCache = new XmiDataCache(new PocoReferenceResolveExtensionsFacade(),serviceProvider.GetRequiredService<ILogger<XmiDataCache>>());
 
             this.deSerializer = new DeSerializer(new ExternalReferenceService(serviceProvider.GetRequiredService<ILogger<ExternalReferenceService>>()), new XmiDataReaderFacade(), this.xmiDataCache, serviceProvider.GetRequiredService<ILoggerFactory>());
         }

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AcceptActionUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AcceptActionUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AcceptActionUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Actions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class AcceptActionUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.AcceptActionUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Actions.AcceptActionUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [AcceptActionUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.AcceptActionUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Actions.AcceptActionUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [AcceptActionUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ActionDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ActionDefinitionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ActionDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Actions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ActionDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.ActionDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Actions.ActionDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ActionDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.ActionDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Actions.ActionDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ActionDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ActionUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ActionUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ActionUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Actions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ActionUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.ActionUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Actions.ActionUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ActionUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.ActionUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Actions.ActionUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ActionUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ActorMembershipExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ActorMembershipExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ActorMembershipExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Requirements.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ActorMembershipExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.ActorMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Requirements.ActorMembership poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [ActorMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ActorMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.ActorMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Requirements.ActorMembership poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [ActorMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ActorMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AllocationDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AllocationDefinitionExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AllocationDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Allocations.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class AllocationDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Allocations.AllocationDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Allocations.AllocationDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [AllocationDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [AllocationDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Allocations.AllocationDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Allocations.AllocationDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [AllocationDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [AllocationDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AllocationUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AllocationUsageExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AllocationUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Allocations.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class AllocationUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Allocations.AllocationUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Allocations.AllocationUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [AllocationUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [AllocationUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Allocations.AllocationUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Allocations.AllocationUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [AllocationUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [AllocationUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AnalysisCaseDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AnalysisCaseDefinitionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AnalysisCaseDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.AnalysisCases.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class AnalysisCaseDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.AnalysisCases.AnalysisCaseDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.AnalysisCases.AnalysisCaseDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [AnalysisCaseDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.AnalysisCases.AnalysisCaseDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.AnalysisCases.AnalysisCaseDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [AnalysisCaseDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AnalysisCaseUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AnalysisCaseUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AnalysisCaseUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.AnalysisCases.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class AnalysisCaseUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.AnalysisCases.AnalysisCaseUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.AnalysisCases.AnalysisCaseUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [AnalysisCaseUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.AnalysisCases.AnalysisCaseUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.AnalysisCases.AnalysisCaseUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [AnalysisCaseUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AnnotatingElementExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AnnotatingElementExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AnnotatingElementExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Root.Annotations.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class AnnotatingElementExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Annotations.AnnotatingElement"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Root.Annotations.AnnotatingElement poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [AnnotatingElement] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Annotations.AnnotatingElement"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Root.Annotations.AnnotatingElement poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [AnnotatingElement] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AnnotationExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AnnotationExtensions.cs
@@ -1,0 +1,215 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AnnotationExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Root.Annotations.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class AnnotationExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Annotations.Annotation"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Root.Annotations.Annotation poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "annotatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [annotatedElement] on element type [Annotation] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement annotatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.AnnotatedElement = annotatedElementReference;
+                        return;
+                    }
+
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [Annotation] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Annotation] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Annotations.Annotation"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Root.Annotations.Annotation poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [Annotation] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Annotation] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AssertConstraintUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AssertConstraintUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AssertConstraintUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Constraints.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class AssertConstraintUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Constraints.AssertConstraintUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Constraints.AssertConstraintUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [AssertConstraintUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Constraints.AssertConstraintUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Constraints.AssertConstraintUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [AssertConstraintUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AssignmentActionUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AssignmentActionUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AssignmentActionUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Actions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class AssignmentActionUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.AssignmentActionUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Actions.AssignmentActionUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [AssignmentActionUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.AssignmentActionUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Actions.AssignmentActionUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [AssignmentActionUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AssociationExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AssociationExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AssociationExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Associations.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class AssociationExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Associations.Association"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Associations.Association poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [Association] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Association] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Associations.Association"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Associations.Association poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [Association] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Association] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AssociationStructureExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AssociationStructureExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AssociationStructureExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Associations.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class AssociationStructureExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Associations.AssociationStructure"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Associations.AssociationStructure poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [AssociationStructure] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [AssociationStructure] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Associations.AssociationStructure"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Associations.AssociationStructure poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [AssociationStructure] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [AssociationStructure] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AttributeDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AttributeDefinitionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AttributeDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Attributes.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class AttributeDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Attributes.AttributeDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Attributes.AttributeDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [AttributeDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Attributes.AttributeDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Attributes.AttributeDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [AttributeDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AttributeUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/AttributeUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AttributeUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Attributes.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class AttributeUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Attributes.AttributeUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Attributes.AttributeUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [AttributeUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Attributes.AttributeUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Attributes.AttributeUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [AttributeUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/BehaviorExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/BehaviorExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="BehaviorExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Behaviors.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class BehaviorExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Behaviors.Behavior"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Behaviors.Behavior poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Behavior] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Behaviors.Behavior"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Behaviors.Behavior poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Behavior] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/BindingConnectorAsUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/BindingConnectorAsUsageExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="BindingConnectorAsUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Connections.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class BindingConnectorAsUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Connections.BindingConnectorAsUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Connections.BindingConnectorAsUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [BindingConnectorAsUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [BindingConnectorAsUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Connections.BindingConnectorAsUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Connections.BindingConnectorAsUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [BindingConnectorAsUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [BindingConnectorAsUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/BindingConnectorExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/BindingConnectorExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="BindingConnectorExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Connectors.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class BindingConnectorExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Connectors.BindingConnector"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Connectors.BindingConnector poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [BindingConnector] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [BindingConnector] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Connectors.BindingConnector"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Connectors.BindingConnector poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [BindingConnector] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [BindingConnector] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/BooleanExpressionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/BooleanExpressionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="BooleanExpressionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Functions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class BooleanExpressionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.BooleanExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Functions.BooleanExpression poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [BooleanExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.BooleanExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Functions.BooleanExpression poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [BooleanExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/CalculationDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/CalculationDefinitionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="CalculationDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Calculations.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class CalculationDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Calculations.CalculationDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Calculations.CalculationDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [CalculationDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Calculations.CalculationDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Calculations.CalculationDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [CalculationDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/CalculationUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/CalculationUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="CalculationUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Calculations.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class CalculationUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Calculations.CalculationUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Calculations.CalculationUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [CalculationUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Calculations.CalculationUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Calculations.CalculationUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [CalculationUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/CaseDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/CaseDefinitionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="CaseDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Cases.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class CaseDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Cases.CaseDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Cases.CaseDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [CaseDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Cases.CaseDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Cases.CaseDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [CaseDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/CaseUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/CaseUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="CaseUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Cases.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class CaseUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Cases.CaseUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Cases.CaseUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [CaseUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Cases.CaseUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Cases.CaseUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [CaseUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ClassExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ClassExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ClassExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Classes.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ClassExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Classes.Class"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Classes.Class poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Class] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Classes.Class"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Classes.Class poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Class] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ClassifierExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ClassifierExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ClassifierExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Classifiers.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ClassifierExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Classifiers.Classifier"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Classifiers.Classifier poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Classifier] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Classifiers.Classifier"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Classifiers.Classifier poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Classifier] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/CollectExpressionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/CollectExpressionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="CollectExpressionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Expressions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class CollectExpressionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.CollectExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Expressions.CollectExpression poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [CollectExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.CollectExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Expressions.CollectExpression poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [CollectExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/CommentExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/CommentExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="CommentExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Root.Annotations.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class CommentExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Annotations.Comment"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Root.Annotations.Comment poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Comment] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Annotations.Comment"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Root.Annotations.Comment poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Comment] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ConcernDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ConcernDefinitionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ConcernDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Requirements.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ConcernDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.ConcernDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Requirements.ConcernDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ConcernDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.ConcernDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Requirements.ConcernDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ConcernDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ConcernUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ConcernUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ConcernUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Requirements.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ConcernUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.ConcernUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Requirements.ConcernUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ConcernUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.ConcernUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Requirements.ConcernUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ConcernUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ConjugatedPortDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ConjugatedPortDefinitionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ConjugatedPortDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Ports.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ConjugatedPortDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Ports.ConjugatedPortDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Ports.ConjugatedPortDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ConjugatedPortDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Ports.ConjugatedPortDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Ports.ConjugatedPortDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ConjugatedPortDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ConjugatedPortTypingExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ConjugatedPortTypingExtensions.cs
@@ -1,0 +1,234 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ConjugatedPortTypingExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Ports.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ConjugatedPortTypingExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Ports.ConjugatedPortTyping"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Ports.ConjugatedPortTyping poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "conjugatedPortDefinition":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [conjugatedPortDefinition] on element type [ConjugatedPortTyping] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Systems.Ports.IConjugatedPortDefinition conjugatedPortDefinitionReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IConjugatedPortDefinition");
+                        }
+
+                        poco.ConjugatedPortDefinition = conjugatedPortDefinitionReference;
+                        return;
+                    }
+
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [ConjugatedPortTyping] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ConjugatedPortTyping] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                case "typedFeature":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [typedFeature] on element type [ConjugatedPortTyping] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Features.IFeature typedFeatureReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IFeature");
+                        }
+
+                        poco.TypedFeature = typedFeatureReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Ports.ConjugatedPortTyping"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Ports.ConjugatedPortTyping poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [ConjugatedPortTyping] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ConjugatedPortTyping] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ConjugationExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ConjugationExtensions.cs
@@ -1,0 +1,234 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ConjugationExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Types.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ConjugationExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.Conjugation"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Types.Conjugation poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "conjugatedType":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [conjugatedType] on element type [Conjugation] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Types.IType conjugatedTypeReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IType");
+                        }
+
+                        poco.ConjugatedType = conjugatedTypeReference;
+                        return;
+                    }
+
+                case "originalType":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [originalType] on element type [Conjugation] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Types.IType originalTypeReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IType");
+                        }
+
+                        poco.OriginalType = originalTypeReference;
+                        return;
+                    }
+
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [Conjugation] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Conjugation] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.Conjugation"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Types.Conjugation poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [Conjugation] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Conjugation] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ConnectionDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ConnectionDefinitionExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ConnectionDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Connections.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ConnectionDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Connections.ConnectionDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Connections.ConnectionDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [ConnectionDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ConnectionDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Connections.ConnectionDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Connections.ConnectionDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [ConnectionDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ConnectionDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ConnectionUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ConnectionUsageExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ConnectionUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Connections.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ConnectionUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Connections.ConnectionUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Connections.ConnectionUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [ConnectionUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ConnectionUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Connections.ConnectionUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Connections.ConnectionUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [ConnectionUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ConnectionUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ConnectorExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ConnectorExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ConnectorExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Connectors.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ConnectorExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Connectors.Connector"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Connectors.Connector poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [Connector] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Connector] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Connectors.Connector"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Connectors.Connector poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [Connector] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Connector] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ConstraintDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ConstraintDefinitionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ConstraintDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Constraints.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ConstraintDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Constraints.ConstraintDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Constraints.ConstraintDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ConstraintDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Constraints.ConstraintDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Constraints.ConstraintDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ConstraintDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ConstraintUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ConstraintUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ConstraintUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Constraints.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ConstraintUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Constraints.ConstraintUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Constraints.ConstraintUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ConstraintUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Constraints.ConstraintUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Constraints.ConstraintUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ConstraintUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ConstructorExpressionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ConstructorExpressionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ConstructorExpressionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Expressions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ConstructorExpressionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.ConstructorExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Expressions.ConstructorExpression poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ConstructorExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.ConstructorExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Expressions.ConstructorExpression poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ConstructorExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/CrossSubsettingExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/CrossSubsettingExtensions.cs
@@ -1,0 +1,215 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="CrossSubsettingExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Features.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class CrossSubsettingExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.CrossSubsetting"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Features.CrossSubsetting poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "crossedFeature":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [crossedFeature] on element type [CrossSubsetting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Features.IFeature crossedFeatureReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IFeature");
+                        }
+
+                        poco.CrossedFeature = crossedFeatureReference;
+                        return;
+                    }
+
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [CrossSubsetting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [CrossSubsetting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.CrossSubsetting"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Features.CrossSubsetting poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [CrossSubsetting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [CrossSubsetting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/DataTypeExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/DataTypeExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DataTypeExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.DataTypes.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class DataTypeExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.DataTypes.DataType"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.DataTypes.DataType poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [DataType] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.DataTypes.DataType"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.DataTypes.DataType poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [DataType] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/DecisionNodeExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/DecisionNodeExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DecisionNodeExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Actions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class DecisionNodeExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.DecisionNode"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Actions.DecisionNode poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [DecisionNode] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.DecisionNode"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Actions.DecisionNode poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [DecisionNode] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/DefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/DefinitionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class DefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.Definition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.Definition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Definition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.Definition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.Definition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Definition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/DependencyExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/DependencyExtensions.cs
@@ -1,0 +1,242 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DependencyExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Root.Dependencies.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class DependencyExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Dependencies.Dependency"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Root.Dependencies.Dependency poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [Dependency] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Dependency] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Dependencies.Dependency"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Root.Dependencies.Dependency poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "client":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [client] on element type [Dependency] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement clientReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.Client.Add(clientReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [Dependency] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Dependency] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                case "supplier":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [supplier] on element type [Dependency] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement supplierReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.Supplier.Add(supplierReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/DifferencingExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/DifferencingExtensions.cs
@@ -1,0 +1,215 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DifferencingExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Types.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class DifferencingExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.Differencing"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Types.Differencing poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "differencingType":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [differencingType] on element type [Differencing] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Types.IType differencingTypeReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IType");
+                        }
+
+                        poco.DifferencingType = differencingTypeReference;
+                        return;
+                    }
+
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [Differencing] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Differencing] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.Differencing"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Types.Differencing poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [Differencing] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Differencing] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/DisjoiningExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/DisjoiningExtensions.cs
@@ -1,0 +1,234 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DisjoiningExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Types.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class DisjoiningExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.Disjoining"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Types.Disjoining poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "disjoiningType":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [disjoiningType] on element type [Disjoining] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Types.IType disjoiningTypeReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IType");
+                        }
+
+                        poco.DisjoiningType = disjoiningTypeReference;
+                        return;
+                    }
+
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [Disjoining] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Disjoining] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                case "typeDisjoined":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [typeDisjoined] on element type [Disjoining] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Types.IType typeDisjoinedReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IType");
+                        }
+
+                        poco.TypeDisjoined = typeDisjoinedReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.Disjoining"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Types.Disjoining poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [Disjoining] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Disjoining] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/DocumentationExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/DocumentationExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DocumentationExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Root.Annotations.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class DocumentationExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Annotations.Documentation"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Root.Annotations.Documentation poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Documentation] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Annotations.Documentation"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Root.Annotations.Documentation poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Documentation] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ElementFilterMembershipExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ElementFilterMembershipExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ElementFilterMembershipExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Packages.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ElementFilterMembershipExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Packages.ElementFilterMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Packages.ElementFilterMembership poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [ElementFilterMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ElementFilterMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Packages.ElementFilterMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Packages.ElementFilterMembership poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [ElementFilterMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ElementFilterMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/EndFeatureMembershipExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/EndFeatureMembershipExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="EndFeatureMembershipExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Features.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class EndFeatureMembershipExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.EndFeatureMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Features.EndFeatureMembership poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [EndFeatureMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [EndFeatureMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.EndFeatureMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Features.EndFeatureMembership poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [EndFeatureMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [EndFeatureMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/EnumerationDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/EnumerationDefinitionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="EnumerationDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Enumerations.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class EnumerationDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Enumerations.EnumerationDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Enumerations.EnumerationDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [EnumerationDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Enumerations.EnumerationDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Enumerations.EnumerationDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [EnumerationDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/EnumerationUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/EnumerationUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="EnumerationUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Enumerations.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class EnumerationUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Enumerations.EnumerationUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Enumerations.EnumerationUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [EnumerationUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Enumerations.EnumerationUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Enumerations.EnumerationUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [EnumerationUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/EventOccurrenceUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/EventOccurrenceUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="EventOccurrenceUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Occurrences.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class EventOccurrenceUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Occurrences.EventOccurrenceUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Occurrences.EventOccurrenceUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [EventOccurrenceUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Occurrences.EventOccurrenceUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Occurrences.EventOccurrenceUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [EventOccurrenceUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ExhibitStateUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ExhibitStateUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ExhibitStateUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.States.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ExhibitStateUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.ExhibitStateUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.States.ExhibitStateUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ExhibitStateUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.ExhibitStateUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.States.ExhibitStateUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ExhibitStateUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ExpressionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ExpressionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ExpressionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Functions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ExpressionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.Expression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Functions.Expression poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Expression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.Expression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Functions.Expression poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Expression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FeatureChainExpressionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FeatureChainExpressionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FeatureChainExpressionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Expressions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class FeatureChainExpressionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.FeatureChainExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Expressions.FeatureChainExpression poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [FeatureChainExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.FeatureChainExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Expressions.FeatureChainExpression poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [FeatureChainExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FeatureChainingExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FeatureChainingExtensions.cs
@@ -1,0 +1,215 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FeatureChainingExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Features.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class FeatureChainingExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.FeatureChaining"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Features.FeatureChaining poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "chainingFeature":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [chainingFeature] on element type [FeatureChaining] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Features.IFeature chainingFeatureReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IFeature");
+                        }
+
+                        poco.ChainingFeature = chainingFeatureReference;
+                        return;
+                    }
+
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [FeatureChaining] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [FeatureChaining] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.FeatureChaining"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Features.FeatureChaining poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [FeatureChaining] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [FeatureChaining] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FeatureExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FeatureExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FeatureExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Features.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class FeatureExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.Feature"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Features.Feature poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Feature] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.Feature"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Features.Feature poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Feature] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FeatureInvertingExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FeatureInvertingExtensions.cs
@@ -1,0 +1,234 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FeatureInvertingExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Features.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class FeatureInvertingExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.FeatureInverting"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Features.FeatureInverting poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "featureInverted":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [featureInverted] on element type [FeatureInverting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Features.IFeature featureInvertedReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IFeature");
+                        }
+
+                        poco.FeatureInverted = featureInvertedReference;
+                        return;
+                    }
+
+                case "invertingFeature":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [invertingFeature] on element type [FeatureInverting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Features.IFeature invertingFeatureReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IFeature");
+                        }
+
+                        poco.InvertingFeature = invertingFeatureReference;
+                        return;
+                    }
+
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [FeatureInverting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [FeatureInverting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.FeatureInverting"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Features.FeatureInverting poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [FeatureInverting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [FeatureInverting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FeatureMembershipExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FeatureMembershipExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FeatureMembershipExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Types.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class FeatureMembershipExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.FeatureMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Types.FeatureMembership poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [FeatureMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [FeatureMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.FeatureMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Types.FeatureMembership poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [FeatureMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [FeatureMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FeatureReferenceExpressionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FeatureReferenceExpressionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FeatureReferenceExpressionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Expressions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class FeatureReferenceExpressionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.FeatureReferenceExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Expressions.FeatureReferenceExpression poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [FeatureReferenceExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.FeatureReferenceExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Expressions.FeatureReferenceExpression poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [FeatureReferenceExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FeatureTypingExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FeatureTypingExtensions.cs
@@ -1,0 +1,234 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FeatureTypingExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Features.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class FeatureTypingExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.FeatureTyping"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Features.FeatureTyping poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [FeatureTyping] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [FeatureTyping] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                case "type":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [type] on element type [FeatureTyping] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Types.IType typeReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IType");
+                        }
+
+                        poco.Type = typeReference;
+                        return;
+                    }
+
+                case "typedFeature":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [typedFeature] on element type [FeatureTyping] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Features.IFeature typedFeatureReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IFeature");
+                        }
+
+                        poco.TypedFeature = typedFeatureReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.FeatureTyping"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Features.FeatureTyping poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [FeatureTyping] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [FeatureTyping] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FeatureValueExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FeatureValueExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FeatureValueExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.FeatureValues.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class FeatureValueExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.FeatureValues.FeatureValue"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.FeatureValues.FeatureValue poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [FeatureValue] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [FeatureValue] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.FeatureValues.FeatureValue"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.FeatureValues.FeatureValue poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [FeatureValue] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [FeatureValue] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FlowDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FlowDefinitionExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FlowDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Flows.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class FlowDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Flows.FlowDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Flows.FlowDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [FlowDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [FlowDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Flows.FlowDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Flows.FlowDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [FlowDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [FlowDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FlowEndExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FlowEndExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FlowEndExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Interactions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class FlowEndExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Interactions.FlowEnd"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Interactions.FlowEnd poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [FlowEnd] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Interactions.FlowEnd"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Interactions.FlowEnd poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [FlowEnd] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FlowExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FlowExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FlowExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Interactions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class FlowExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Interactions.Flow"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Interactions.Flow poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [Flow] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Flow] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Interactions.Flow"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Interactions.Flow poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [Flow] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Flow] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FlowUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FlowUsageExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FlowUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Flows.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class FlowUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Flows.FlowUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Flows.FlowUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [FlowUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [FlowUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Flows.FlowUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Flows.FlowUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [FlowUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [FlowUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ForLoopActionUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ForLoopActionUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ForLoopActionUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Actions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ForLoopActionUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.ForLoopActionUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Actions.ForLoopActionUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ForLoopActionUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.ForLoopActionUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Actions.ForLoopActionUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ForLoopActionUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ForkNodeExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ForkNodeExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ForkNodeExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Actions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ForkNodeExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.ForkNode"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Actions.ForkNode poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ForkNode] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.ForkNode"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Actions.ForkNode poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ForkNode] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FramedConcernMembershipExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FramedConcernMembershipExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FramedConcernMembershipExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Requirements.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class FramedConcernMembershipExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.FramedConcernMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Requirements.FramedConcernMembership poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [FramedConcernMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [FramedConcernMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.FramedConcernMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Requirements.FramedConcernMembership poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [FramedConcernMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [FramedConcernMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FunctionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/FunctionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FunctionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Functions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class FunctionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.Function"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Functions.Function poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Function] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.Function"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Functions.Function poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Function] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/IfActionUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/IfActionUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="IfActionUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Actions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class IfActionUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IfActionUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Actions.IfActionUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [IfActionUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IfActionUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Actions.IfActionUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [IfActionUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/IncludeUseCaseUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/IncludeUseCaseUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="IncludeUseCaseUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.UseCases.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class IncludeUseCaseUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.UseCases.IncludeUseCaseUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.UseCases.IncludeUseCaseUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [IncludeUseCaseUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.UseCases.IncludeUseCaseUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.UseCases.IncludeUseCaseUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [IncludeUseCaseUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/IndexExpressionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/IndexExpressionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="IndexExpressionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Expressions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class IndexExpressionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.IndexExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Expressions.IndexExpression poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [IndexExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.IndexExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Expressions.IndexExpression poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [IndexExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/InteractionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/InteractionExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="InteractionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Interactions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class InteractionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Interactions.Interaction"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Interactions.Interaction poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [Interaction] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Interaction] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Interactions.Interaction"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Interactions.Interaction poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [Interaction] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Interaction] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/InterfaceDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/InterfaceDefinitionExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="InterfaceDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Interfaces.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class InterfaceDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Interfaces.InterfaceDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Interfaces.InterfaceDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [InterfaceDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [InterfaceDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Interfaces.InterfaceDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Interfaces.InterfaceDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [InterfaceDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [InterfaceDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/InterfaceUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/InterfaceUsageExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="InterfaceUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Interfaces.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class InterfaceUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Interfaces.InterfaceUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Interfaces.InterfaceUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [InterfaceUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [InterfaceUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Interfaces.InterfaceUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Interfaces.InterfaceUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [InterfaceUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [InterfaceUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/IntersectingExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/IntersectingExtensions.cs
@@ -1,0 +1,215 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="IntersectingExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Types.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class IntersectingExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.Intersecting"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Types.Intersecting poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "intersectingType":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [intersectingType] on element type [Intersecting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Types.IType intersectingTypeReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IType");
+                        }
+
+                        poco.IntersectingType = intersectingTypeReference;
+                        return;
+                    }
+
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [Intersecting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Intersecting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.Intersecting"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Types.Intersecting poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [Intersecting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Intersecting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/InvariantExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/InvariantExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="InvariantExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Functions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class InvariantExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.Invariant"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Functions.Invariant poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Invariant] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.Invariant"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Functions.Invariant poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Invariant] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/InvocationExpressionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/InvocationExpressionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="InvocationExpressionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Expressions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class InvocationExpressionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.InvocationExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Expressions.InvocationExpression poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [InvocationExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.InvocationExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Expressions.InvocationExpression poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [InvocationExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ItemDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ItemDefinitionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ItemDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Items.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ItemDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Items.ItemDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Items.ItemDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ItemDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Items.ItemDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Items.ItemDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ItemDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ItemUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ItemUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ItemUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Items.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ItemUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Items.ItemUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Items.ItemUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ItemUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Items.ItemUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Items.ItemUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ItemUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/JoinNodeExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/JoinNodeExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="JoinNodeExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Actions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class JoinNodeExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.JoinNode"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Actions.JoinNode poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [JoinNode] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.JoinNode"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Actions.JoinNode poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [JoinNode] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/LibraryPackageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/LibraryPackageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="LibraryPackageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Packages.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class LibraryPackageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Packages.LibraryPackage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Packages.LibraryPackage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [LibraryPackage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Packages.LibraryPackage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Packages.LibraryPackage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [LibraryPackage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/LiteralBooleanExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/LiteralBooleanExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="LiteralBooleanExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Expressions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class LiteralBooleanExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.LiteralBoolean"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Expressions.LiteralBoolean poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [LiteralBoolean] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.LiteralBoolean"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Expressions.LiteralBoolean poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [LiteralBoolean] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/LiteralExpressionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/LiteralExpressionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="LiteralExpressionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Expressions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class LiteralExpressionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.LiteralExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Expressions.LiteralExpression poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [LiteralExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.LiteralExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Expressions.LiteralExpression poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [LiteralExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/LiteralInfinityExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/LiteralInfinityExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="LiteralInfinityExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Expressions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class LiteralInfinityExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.LiteralInfinity"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Expressions.LiteralInfinity poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [LiteralInfinity] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.LiteralInfinity"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Expressions.LiteralInfinity poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [LiteralInfinity] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/LiteralIntegerExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/LiteralIntegerExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="LiteralIntegerExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Expressions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class LiteralIntegerExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.LiteralInteger"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Expressions.LiteralInteger poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [LiteralInteger] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.LiteralInteger"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Expressions.LiteralInteger poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [LiteralInteger] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/LiteralRationalExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/LiteralRationalExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="LiteralRationalExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Expressions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class LiteralRationalExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.LiteralRational"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Expressions.LiteralRational poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [LiteralRational] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.LiteralRational"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Expressions.LiteralRational poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [LiteralRational] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/LiteralStringExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/LiteralStringExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="LiteralStringExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Expressions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class LiteralStringExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.LiteralString"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Expressions.LiteralString poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [LiteralString] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.LiteralString"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Expressions.LiteralString poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [LiteralString] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/MembershipExposeExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/MembershipExposeExtensions.cs
@@ -1,0 +1,215 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="MembershipExposeExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Views.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class MembershipExposeExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.MembershipExpose"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Views.MembershipExpose poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "importedMembership":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [importedMembership] on element type [MembershipExpose] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Namespaces.IMembership importedMembershipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IMembership");
+                        }
+
+                        poco.ImportedMembership = importedMembershipReference;
+                        return;
+                    }
+
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [MembershipExpose] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [MembershipExpose] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.MembershipExpose"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Views.MembershipExpose poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [MembershipExpose] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [MembershipExpose] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/MembershipExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/MembershipExtensions.cs
@@ -1,0 +1,215 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="MembershipExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Root.Namespaces.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class MembershipExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.Membership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Root.Namespaces.Membership poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "memberElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [memberElement] on element type [Membership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement memberElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.MemberElement = memberElementReference;
+                        return;
+                    }
+
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [Membership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Membership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.Membership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Root.Namespaces.Membership poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [Membership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Membership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/MembershipImportExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/MembershipImportExtensions.cs
@@ -1,0 +1,215 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="MembershipImportExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Root.Namespaces.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class MembershipImportExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.MembershipImport"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Root.Namespaces.MembershipImport poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "importedMembership":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [importedMembership] on element type [MembershipImport] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Namespaces.IMembership importedMembershipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IMembership");
+                        }
+
+                        poco.ImportedMembership = importedMembershipReference;
+                        return;
+                    }
+
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [MembershipImport] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [MembershipImport] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.MembershipImport"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Root.Namespaces.MembershipImport poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [MembershipImport] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [MembershipImport] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/MergeNodeExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/MergeNodeExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="MergeNodeExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Actions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class MergeNodeExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.MergeNode"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Actions.MergeNode poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [MergeNode] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.MergeNode"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Actions.MergeNode poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [MergeNode] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/MetaclassExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/MetaclassExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="MetaclassExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Metadata.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class MetaclassExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Metadata.Metaclass"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Metadata.Metaclass poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Metaclass] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Metadata.Metaclass"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Metadata.Metaclass poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Metaclass] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/MetadataAccessExpressionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/MetadataAccessExpressionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="MetadataAccessExpressionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Expressions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class MetadataAccessExpressionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.MetadataAccessExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Expressions.MetadataAccessExpression poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [MetadataAccessExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.MetadataAccessExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Expressions.MetadataAccessExpression poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [MetadataAccessExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/MetadataDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/MetadataDefinitionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="MetadataDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Metadata.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class MetadataDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Metadata.MetadataDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Metadata.MetadataDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [MetadataDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Metadata.MetadataDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Metadata.MetadataDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [MetadataDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/MetadataFeatureExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/MetadataFeatureExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="MetadataFeatureExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Metadata.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class MetadataFeatureExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Metadata.MetadataFeature"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Metadata.MetadataFeature poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [MetadataFeature] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Metadata.MetadataFeature"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Metadata.MetadataFeature poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [MetadataFeature] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/MetadataUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/MetadataUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="MetadataUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Metadata.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class MetadataUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Metadata.MetadataUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Metadata.MetadataUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [MetadataUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Metadata.MetadataUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Metadata.MetadataUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [MetadataUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/MultiplicityExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/MultiplicityExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="MultiplicityExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Types.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class MultiplicityExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.Multiplicity"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Types.Multiplicity poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Multiplicity] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.Multiplicity"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Types.Multiplicity poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Multiplicity] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/MultiplicityRangeExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/MultiplicityRangeExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="MultiplicityRangeExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Multiplicities.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class MultiplicityRangeExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Multiplicities.MultiplicityRange"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Multiplicities.MultiplicityRange poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [MultiplicityRange] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Multiplicities.MultiplicityRange"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Multiplicities.MultiplicityRange poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [MultiplicityRange] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/NamespaceExposeExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/NamespaceExposeExtensions.cs
@@ -1,0 +1,215 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="NamespaceExposeExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Views.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class NamespaceExposeExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.NamespaceExpose"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Views.NamespaceExpose poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "importedNamespace":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [importedNamespace] on element type [NamespaceExpose] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Namespaces.INamespace importedNamespaceReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an INamespace");
+                        }
+
+                        poco.ImportedNamespace = importedNamespaceReference;
+                        return;
+                    }
+
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [NamespaceExpose] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [NamespaceExpose] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.NamespaceExpose"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Views.NamespaceExpose poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [NamespaceExpose] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [NamespaceExpose] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/NamespaceExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/NamespaceExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="NamespaceExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Root.Namespaces.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class NamespaceExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.Namespace"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Root.Namespaces.Namespace poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Namespace] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.Namespace"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Root.Namespaces.Namespace poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Namespace] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/NamespaceImportExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/NamespaceImportExtensions.cs
@@ -1,0 +1,215 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="NamespaceImportExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Root.Namespaces.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class NamespaceImportExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.NamespaceImport"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Root.Namespaces.NamespaceImport poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "importedNamespace":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [importedNamespace] on element type [NamespaceImport] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Namespaces.INamespace importedNamespaceReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an INamespace");
+                        }
+
+                        poco.ImportedNamespace = importedNamespaceReference;
+                        return;
+                    }
+
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [NamespaceImport] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [NamespaceImport] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.NamespaceImport"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Root.Namespaces.NamespaceImport poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [NamespaceImport] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [NamespaceImport] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/NullExpressionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/NullExpressionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="NullExpressionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Expressions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class NullExpressionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.NullExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Expressions.NullExpression poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [NullExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.NullExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Expressions.NullExpression poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [NullExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ObjectiveMembershipExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ObjectiveMembershipExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ObjectiveMembershipExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Cases.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ObjectiveMembershipExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Cases.ObjectiveMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Cases.ObjectiveMembership poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [ObjectiveMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ObjectiveMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Cases.ObjectiveMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Cases.ObjectiveMembership poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [ObjectiveMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ObjectiveMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/OccurrenceDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/OccurrenceDefinitionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="OccurrenceDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Occurrences.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class OccurrenceDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Occurrences.OccurrenceDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Occurrences.OccurrenceDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [OccurrenceDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Occurrences.OccurrenceDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Occurrences.OccurrenceDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [OccurrenceDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/OccurrenceUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/OccurrenceUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="OccurrenceUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Occurrences.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class OccurrenceUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Occurrences.OccurrenceUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Occurrences.OccurrenceUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [OccurrenceUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Occurrences.OccurrenceUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Occurrences.OccurrenceUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [OccurrenceUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/OperatorExpressionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/OperatorExpressionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="OperatorExpressionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Expressions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class OperatorExpressionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.OperatorExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Expressions.OperatorExpression poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [OperatorExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.OperatorExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Expressions.OperatorExpression poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [OperatorExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/OwningMembershipExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/OwningMembershipExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="OwningMembershipExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Root.Namespaces.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class OwningMembershipExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.OwningMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Root.Namespaces.OwningMembership poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [OwningMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [OwningMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.OwningMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Root.Namespaces.OwningMembership poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [OwningMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [OwningMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/PackageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/PackageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="PackageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Packages.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class PackageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Packages.Package"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Packages.Package poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Package] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Packages.Package"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Packages.Package poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Package] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ParameterMembershipExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ParameterMembershipExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ParameterMembershipExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Behaviors.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ParameterMembershipExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Behaviors.ParameterMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Behaviors.ParameterMembership poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [ParameterMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ParameterMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Behaviors.ParameterMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Behaviors.ParameterMembership poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [ParameterMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ParameterMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/PartDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/PartDefinitionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="PartDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Parts.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class PartDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Parts.PartDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Parts.PartDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [PartDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Parts.PartDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Parts.PartDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [PartDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/PartUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/PartUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="PartUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Parts.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class PartUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Parts.PartUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Parts.PartUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [PartUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Parts.PartUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Parts.PartUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [PartUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/PayloadFeatureExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/PayloadFeatureExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="PayloadFeatureExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Interactions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class PayloadFeatureExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Interactions.PayloadFeature"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Interactions.PayloadFeature poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [PayloadFeature] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Interactions.PayloadFeature"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Interactions.PayloadFeature poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [PayloadFeature] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/PerformActionUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/PerformActionUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="PerformActionUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Actions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class PerformActionUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.PerformActionUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Actions.PerformActionUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [PerformActionUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.PerformActionUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Actions.PerformActionUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [PerformActionUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/PocoReferenceResolveExtensionsFacade.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/PocoReferenceResolveExtensionsFacade.cs
@@ -1,0 +1,1081 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="PocoReferenceResolveExtensionsFacade.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// The <see cref="PocoReferenceResolveExtensionsFacade"/> provides access to extensions method for POCO <see cref="IData"/> to resolve reference
+    /// </summary>
+    public class PocoReferenceResolveExtensionsFacade : IPocoReferenceResolveExtensionsFacade
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="data">The <see cref="IData"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public void ResolveAndAssignSingleValueReference(IData data, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            switch (data)
+            {
+                case SysML2.NET.Core.POCO.Systems.Actions.AcceptActionUsage acceptActionUsagePoco:
+                    acceptActionUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.ActionDefinition actionDefinitionPoco:
+                    actionDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.ActionUsage actionUsagePoco:
+                    actionUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Requirements.ActorMembership actorMembershipPoco:
+                    actorMembershipPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Allocations.AllocationDefinition allocationDefinitionPoco:
+                    allocationDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Allocations.AllocationUsage allocationUsagePoco:
+                    allocationUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.AnalysisCases.AnalysisCaseDefinition analysisCaseDefinitionPoco:
+                    analysisCaseDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.AnalysisCases.AnalysisCaseUsage analysisCaseUsagePoco:
+                    analysisCaseUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Root.Annotations.AnnotatingElement annotatingElementPoco:
+                    annotatingElementPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Root.Annotations.Annotation annotationPoco:
+                    annotationPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Constraints.AssertConstraintUsage assertConstraintUsagePoco:
+                    assertConstraintUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.AssignmentActionUsage assignmentActionUsagePoco:
+                    assignmentActionUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Associations.Association associationPoco:
+                    associationPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Associations.AssociationStructure associationStructurePoco:
+                    associationStructurePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Attributes.AttributeDefinition attributeDefinitionPoco:
+                    attributeDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Attributes.AttributeUsage attributeUsagePoco:
+                    attributeUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Behaviors.Behavior behaviorPoco:
+                    behaviorPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Connectors.BindingConnector bindingConnectorPoco:
+                    bindingConnectorPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Connections.BindingConnectorAsUsage bindingConnectorAsUsagePoco:
+                    bindingConnectorAsUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Functions.BooleanExpression booleanExpressionPoco:
+                    booleanExpressionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Calculations.CalculationDefinition calculationDefinitionPoco:
+                    calculationDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Calculations.CalculationUsage calculationUsagePoco:
+                    calculationUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Cases.CaseDefinition caseDefinitionPoco:
+                    caseDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Cases.CaseUsage caseUsagePoco:
+                    caseUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Classes.Class classPoco:
+                    classPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Classifiers.Classifier classifierPoco:
+                    classifierPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.CollectExpression collectExpressionPoco:
+                    collectExpressionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Root.Annotations.Comment commentPoco:
+                    commentPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Requirements.ConcernDefinition concernDefinitionPoco:
+                    concernDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Requirements.ConcernUsage concernUsagePoco:
+                    concernUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Ports.ConjugatedPortDefinition conjugatedPortDefinitionPoco:
+                    conjugatedPortDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Ports.ConjugatedPortTyping conjugatedPortTypingPoco:
+                    conjugatedPortTypingPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Types.Conjugation conjugationPoco:
+                    conjugationPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Connections.ConnectionDefinition connectionDefinitionPoco:
+                    connectionDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Connections.ConnectionUsage connectionUsagePoco:
+                    connectionUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Connectors.Connector connectorPoco:
+                    connectorPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Constraints.ConstraintDefinition constraintDefinitionPoco:
+                    constraintDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Constraints.ConstraintUsage constraintUsagePoco:
+                    constraintUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.ConstructorExpression constructorExpressionPoco:
+                    constructorExpressionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Features.CrossSubsetting crossSubsettingPoco:
+                    crossSubsettingPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.DataTypes.DataType dataTypePoco:
+                    dataTypePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.DecisionNode decisionNodePoco:
+                    decisionNodePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.Definition definitionPoco:
+                    definitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Root.Dependencies.Dependency dependencyPoco:
+                    dependencyPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Types.Differencing differencingPoco:
+                    differencingPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Types.Disjoining disjoiningPoco:
+                    disjoiningPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Root.Annotations.Documentation documentationPoco:
+                    documentationPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Packages.ElementFilterMembership elementFilterMembershipPoco:
+                    elementFilterMembershipPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Features.EndFeatureMembership endFeatureMembershipPoco:
+                    endFeatureMembershipPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Enumerations.EnumerationDefinition enumerationDefinitionPoco:
+                    enumerationDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Enumerations.EnumerationUsage enumerationUsagePoco:
+                    enumerationUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Occurrences.EventOccurrenceUsage eventOccurrenceUsagePoco:
+                    eventOccurrenceUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.States.ExhibitStateUsage exhibitStateUsagePoco:
+                    exhibitStateUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Functions.Expression expressionPoco:
+                    expressionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Features.Feature featurePoco:
+                    featurePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.FeatureChainExpression featureChainExpressionPoco:
+                    featureChainExpressionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Features.FeatureChaining featureChainingPoco:
+                    featureChainingPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Features.FeatureInverting featureInvertingPoco:
+                    featureInvertingPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Types.FeatureMembership featureMembershipPoco:
+                    featureMembershipPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.FeatureReferenceExpression featureReferenceExpressionPoco:
+                    featureReferenceExpressionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Features.FeatureTyping featureTypingPoco:
+                    featureTypingPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.FeatureValues.FeatureValue featureValuePoco:
+                    featureValuePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Interactions.Flow flowPoco:
+                    flowPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Flows.FlowDefinition flowDefinitionPoco:
+                    flowDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Interactions.FlowEnd flowEndPoco:
+                    flowEndPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Flows.FlowUsage flowUsagePoco:
+                    flowUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.ForkNode forkNodePoco:
+                    forkNodePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.ForLoopActionUsage forLoopActionUsagePoco:
+                    forLoopActionUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Requirements.FramedConcernMembership framedConcernMembershipPoco:
+                    framedConcernMembershipPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Functions.Function functionPoco:
+                    functionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.IfActionUsage ifActionUsagePoco:
+                    ifActionUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.UseCases.IncludeUseCaseUsage includeUseCaseUsagePoco:
+                    includeUseCaseUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.IndexExpression indexExpressionPoco:
+                    indexExpressionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Interactions.Interaction interactionPoco:
+                    interactionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Interfaces.InterfaceDefinition interfaceDefinitionPoco:
+                    interfaceDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Interfaces.InterfaceUsage interfaceUsagePoco:
+                    interfaceUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Types.Intersecting intersectingPoco:
+                    intersectingPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Functions.Invariant invariantPoco:
+                    invariantPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.InvocationExpression invocationExpressionPoco:
+                    invocationExpressionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Items.ItemDefinition itemDefinitionPoco:
+                    itemDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Items.ItemUsage itemUsagePoco:
+                    itemUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.JoinNode joinNodePoco:
+                    joinNodePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Packages.LibraryPackage libraryPackagePoco:
+                    libraryPackagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.LiteralBoolean literalBooleanPoco:
+                    literalBooleanPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.LiteralExpression literalExpressionPoco:
+                    literalExpressionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.LiteralInfinity literalInfinityPoco:
+                    literalInfinityPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.LiteralInteger literalIntegerPoco:
+                    literalIntegerPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.LiteralRational literalRationalPoco:
+                    literalRationalPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.LiteralString literalStringPoco:
+                    literalStringPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Root.Namespaces.Membership membershipPoco:
+                    membershipPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Views.MembershipExpose membershipExposePoco:
+                    membershipExposePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Root.Namespaces.MembershipImport membershipImportPoco:
+                    membershipImportPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.MergeNode mergeNodePoco:
+                    mergeNodePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Metadata.Metaclass metaclassPoco:
+                    metaclassPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.MetadataAccessExpression metadataAccessExpressionPoco:
+                    metadataAccessExpressionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Metadata.MetadataDefinition metadataDefinitionPoco:
+                    metadataDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Metadata.MetadataFeature metadataFeaturePoco:
+                    metadataFeaturePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Metadata.MetadataUsage metadataUsagePoco:
+                    metadataUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Types.Multiplicity multiplicityPoco:
+                    multiplicityPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Multiplicities.MultiplicityRange multiplicityRangePoco:
+                    multiplicityRangePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Root.Namespaces.Namespace namespacePoco:
+                    namespacePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Views.NamespaceExpose namespaceExposePoco:
+                    namespaceExposePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Root.Namespaces.NamespaceImport namespaceImportPoco:
+                    namespaceImportPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.NullExpression nullExpressionPoco:
+                    nullExpressionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Cases.ObjectiveMembership objectiveMembershipPoco:
+                    objectiveMembershipPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Occurrences.OccurrenceDefinition occurrenceDefinitionPoco:
+                    occurrenceDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Occurrences.OccurrenceUsage occurrenceUsagePoco:
+                    occurrenceUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.OperatorExpression operatorExpressionPoco:
+                    operatorExpressionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Root.Namespaces.OwningMembership owningMembershipPoco:
+                    owningMembershipPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Packages.Package packagePoco:
+                    packagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Behaviors.ParameterMembership parameterMembershipPoco:
+                    parameterMembershipPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Parts.PartDefinition partDefinitionPoco:
+                    partDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Parts.PartUsage partUsagePoco:
+                    partUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Interactions.PayloadFeature payloadFeaturePoco:
+                    payloadFeaturePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.PerformActionUsage performActionUsagePoco:
+                    performActionUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Ports.PortConjugation portConjugationPoco:
+                    portConjugationPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Ports.PortDefinition portDefinitionPoco:
+                    portDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Ports.PortUsage portUsagePoco:
+                    portUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Functions.Predicate predicatePoco:
+                    predicatePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Features.Redefinition redefinitionPoco:
+                    redefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Features.ReferenceSubsetting referenceSubsettingPoco:
+                    referenceSubsettingPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.ReferenceUsage referenceUsagePoco:
+                    referenceUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Views.RenderingDefinition renderingDefinitionPoco:
+                    renderingDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Views.RenderingUsage renderingUsagePoco:
+                    renderingUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Requirements.RequirementConstraintMembership requirementConstraintMembershipPoco:
+                    requirementConstraintMembershipPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Requirements.RequirementDefinition requirementDefinitionPoco:
+                    requirementDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Requirements.RequirementUsage requirementUsagePoco:
+                    requirementUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.VerificationCases.RequirementVerificationMembership requirementVerificationMembershipPoco:
+                    requirementVerificationMembershipPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Functions.ResultExpressionMembership resultExpressionMembershipPoco:
+                    resultExpressionMembershipPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Functions.ReturnParameterMembership returnParameterMembershipPoco:
+                    returnParameterMembershipPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Requirements.SatisfyRequirementUsage satisfyRequirementUsagePoco:
+                    satisfyRequirementUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.SelectExpression selectExpressionPoco:
+                    selectExpressionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.SendActionUsage sendActionUsagePoco:
+                    sendActionUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Types.Specialization specializationPoco:
+                    specializationPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Requirements.StakeholderMembership stakeholderMembershipPoco:
+                    stakeholderMembershipPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.States.StateDefinition stateDefinitionPoco:
+                    stateDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.States.StateSubactionMembership stateSubactionMembershipPoco:
+                    stateSubactionMembershipPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.States.StateUsage stateUsagePoco:
+                    stateUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Behaviors.Step stepPoco:
+                    stepPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Structures.Structure structurePoco:
+                    structurePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Classifiers.Subclassification subclassificationPoco:
+                    subclassificationPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Requirements.SubjectMembership subjectMembershipPoco:
+                    subjectMembershipPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Features.Subsetting subsettingPoco:
+                    subsettingPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Connectors.Succession successionPoco:
+                    successionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Connections.SuccessionAsUsage successionAsUsagePoco:
+                    successionAsUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Interactions.SuccessionFlow successionFlowPoco:
+                    successionFlowPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Flows.SuccessionFlowUsage successionFlowUsagePoco:
+                    successionFlowUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.TerminateActionUsage terminateActionUsagePoco:
+                    terminateActionUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Root.Annotations.TextualRepresentation textualRepresentationPoco:
+                    textualRepresentationPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.States.TransitionFeatureMembership transitionFeatureMembershipPoco:
+                    transitionFeatureMembershipPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.States.TransitionUsage transitionUsagePoco:
+                    transitionUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.TriggerInvocationExpression triggerInvocationExpressionPoco:
+                    triggerInvocationExpressionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Types.Type typePoco:
+                    typePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Features.TypeFeaturing typeFeaturingPoco:
+                    typeFeaturingPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Types.Unioning unioningPoco:
+                    unioningPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.Usage usagePoco:
+                    usagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.UseCases.UseCaseDefinition useCaseDefinitionPoco:
+                    useCaseDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.UseCases.UseCaseUsage useCaseUsagePoco:
+                    useCaseUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.VariantMembership variantMembershipPoco:
+                    variantMembershipPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.VerificationCases.VerificationCaseDefinition verificationCaseDefinitionPoco:
+                    verificationCaseDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.VerificationCases.VerificationCaseUsage verificationCaseUsagePoco:
+                    verificationCaseUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Views.ViewDefinition viewDefinitionPoco:
+                    viewDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Views.ViewpointDefinition viewpointDefinitionPoco:
+                    viewpointDefinitionPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Views.ViewpointUsage viewpointUsagePoco:
+                    viewpointUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Views.ViewRenderingMembership viewRenderingMembershipPoco:
+                    viewRenderingMembershipPoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Views.ViewUsage viewUsagePoco:
+                    viewUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.WhileLoopActionUsage whileLoopActionUsagePoco:
+                    whileLoopActionUsagePoco.ResolveAndAssignSingleValueReference(propertyName, reference, xmiDataCache, logger);
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(data), data, "Unsupported type");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="data">The <see cref="IData"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public void ResolveAndAssignMultipleValueReferences(IData data, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            switch (data)
+            {
+                case SysML2.NET.Core.POCO.Systems.Actions.AcceptActionUsage acceptActionUsagePoco:
+                    acceptActionUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.ActionDefinition actionDefinitionPoco:
+                    actionDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.ActionUsage actionUsagePoco:
+                    actionUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Requirements.ActorMembership actorMembershipPoco:
+                    actorMembershipPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Allocations.AllocationDefinition allocationDefinitionPoco:
+                    allocationDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Allocations.AllocationUsage allocationUsagePoco:
+                    allocationUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.AnalysisCases.AnalysisCaseDefinition analysisCaseDefinitionPoco:
+                    analysisCaseDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.AnalysisCases.AnalysisCaseUsage analysisCaseUsagePoco:
+                    analysisCaseUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Root.Annotations.AnnotatingElement annotatingElementPoco:
+                    annotatingElementPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Root.Annotations.Annotation annotationPoco:
+                    annotationPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Constraints.AssertConstraintUsage assertConstraintUsagePoco:
+                    assertConstraintUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.AssignmentActionUsage assignmentActionUsagePoco:
+                    assignmentActionUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Associations.Association associationPoco:
+                    associationPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Associations.AssociationStructure associationStructurePoco:
+                    associationStructurePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Attributes.AttributeDefinition attributeDefinitionPoco:
+                    attributeDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Attributes.AttributeUsage attributeUsagePoco:
+                    attributeUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Behaviors.Behavior behaviorPoco:
+                    behaviorPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Connectors.BindingConnector bindingConnectorPoco:
+                    bindingConnectorPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Connections.BindingConnectorAsUsage bindingConnectorAsUsagePoco:
+                    bindingConnectorAsUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Functions.BooleanExpression booleanExpressionPoco:
+                    booleanExpressionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Calculations.CalculationDefinition calculationDefinitionPoco:
+                    calculationDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Calculations.CalculationUsage calculationUsagePoco:
+                    calculationUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Cases.CaseDefinition caseDefinitionPoco:
+                    caseDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Cases.CaseUsage caseUsagePoco:
+                    caseUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Classes.Class classPoco:
+                    classPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Classifiers.Classifier classifierPoco:
+                    classifierPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.CollectExpression collectExpressionPoco:
+                    collectExpressionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Root.Annotations.Comment commentPoco:
+                    commentPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Requirements.ConcernDefinition concernDefinitionPoco:
+                    concernDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Requirements.ConcernUsage concernUsagePoco:
+                    concernUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Ports.ConjugatedPortDefinition conjugatedPortDefinitionPoco:
+                    conjugatedPortDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Ports.ConjugatedPortTyping conjugatedPortTypingPoco:
+                    conjugatedPortTypingPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Types.Conjugation conjugationPoco:
+                    conjugationPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Connections.ConnectionDefinition connectionDefinitionPoco:
+                    connectionDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Connections.ConnectionUsage connectionUsagePoco:
+                    connectionUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Connectors.Connector connectorPoco:
+                    connectorPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Constraints.ConstraintDefinition constraintDefinitionPoco:
+                    constraintDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Constraints.ConstraintUsage constraintUsagePoco:
+                    constraintUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.ConstructorExpression constructorExpressionPoco:
+                    constructorExpressionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Features.CrossSubsetting crossSubsettingPoco:
+                    crossSubsettingPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.DataTypes.DataType dataTypePoco:
+                    dataTypePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.DecisionNode decisionNodePoco:
+                    decisionNodePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.Definition definitionPoco:
+                    definitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Root.Dependencies.Dependency dependencyPoco:
+                    dependencyPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Types.Differencing differencingPoco:
+                    differencingPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Types.Disjoining disjoiningPoco:
+                    disjoiningPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Root.Annotations.Documentation documentationPoco:
+                    documentationPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Packages.ElementFilterMembership elementFilterMembershipPoco:
+                    elementFilterMembershipPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Features.EndFeatureMembership endFeatureMembershipPoco:
+                    endFeatureMembershipPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Enumerations.EnumerationDefinition enumerationDefinitionPoco:
+                    enumerationDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Enumerations.EnumerationUsage enumerationUsagePoco:
+                    enumerationUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Occurrences.EventOccurrenceUsage eventOccurrenceUsagePoco:
+                    eventOccurrenceUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.States.ExhibitStateUsage exhibitStateUsagePoco:
+                    exhibitStateUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Functions.Expression expressionPoco:
+                    expressionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Features.Feature featurePoco:
+                    featurePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.FeatureChainExpression featureChainExpressionPoco:
+                    featureChainExpressionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Features.FeatureChaining featureChainingPoco:
+                    featureChainingPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Features.FeatureInverting featureInvertingPoco:
+                    featureInvertingPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Types.FeatureMembership featureMembershipPoco:
+                    featureMembershipPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.FeatureReferenceExpression featureReferenceExpressionPoco:
+                    featureReferenceExpressionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Features.FeatureTyping featureTypingPoco:
+                    featureTypingPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.FeatureValues.FeatureValue featureValuePoco:
+                    featureValuePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Interactions.Flow flowPoco:
+                    flowPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Flows.FlowDefinition flowDefinitionPoco:
+                    flowDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Interactions.FlowEnd flowEndPoco:
+                    flowEndPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Flows.FlowUsage flowUsagePoco:
+                    flowUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.ForkNode forkNodePoco:
+                    forkNodePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.ForLoopActionUsage forLoopActionUsagePoco:
+                    forLoopActionUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Requirements.FramedConcernMembership framedConcernMembershipPoco:
+                    framedConcernMembershipPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Functions.Function functionPoco:
+                    functionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.IfActionUsage ifActionUsagePoco:
+                    ifActionUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.UseCases.IncludeUseCaseUsage includeUseCaseUsagePoco:
+                    includeUseCaseUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.IndexExpression indexExpressionPoco:
+                    indexExpressionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Interactions.Interaction interactionPoco:
+                    interactionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Interfaces.InterfaceDefinition interfaceDefinitionPoco:
+                    interfaceDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Interfaces.InterfaceUsage interfaceUsagePoco:
+                    interfaceUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Types.Intersecting intersectingPoco:
+                    intersectingPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Functions.Invariant invariantPoco:
+                    invariantPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.InvocationExpression invocationExpressionPoco:
+                    invocationExpressionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Items.ItemDefinition itemDefinitionPoco:
+                    itemDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Items.ItemUsage itemUsagePoco:
+                    itemUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.JoinNode joinNodePoco:
+                    joinNodePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Packages.LibraryPackage libraryPackagePoco:
+                    libraryPackagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.LiteralBoolean literalBooleanPoco:
+                    literalBooleanPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.LiteralExpression literalExpressionPoco:
+                    literalExpressionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.LiteralInfinity literalInfinityPoco:
+                    literalInfinityPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.LiteralInteger literalIntegerPoco:
+                    literalIntegerPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.LiteralRational literalRationalPoco:
+                    literalRationalPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.LiteralString literalStringPoco:
+                    literalStringPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Root.Namespaces.Membership membershipPoco:
+                    membershipPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Views.MembershipExpose membershipExposePoco:
+                    membershipExposePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Root.Namespaces.MembershipImport membershipImportPoco:
+                    membershipImportPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.MergeNode mergeNodePoco:
+                    mergeNodePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Metadata.Metaclass metaclassPoco:
+                    metaclassPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.MetadataAccessExpression metadataAccessExpressionPoco:
+                    metadataAccessExpressionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Metadata.MetadataDefinition metadataDefinitionPoco:
+                    metadataDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Metadata.MetadataFeature metadataFeaturePoco:
+                    metadataFeaturePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Metadata.MetadataUsage metadataUsagePoco:
+                    metadataUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Types.Multiplicity multiplicityPoco:
+                    multiplicityPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Multiplicities.MultiplicityRange multiplicityRangePoco:
+                    multiplicityRangePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Root.Namespaces.Namespace namespacePoco:
+                    namespacePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Views.NamespaceExpose namespaceExposePoco:
+                    namespaceExposePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Root.Namespaces.NamespaceImport namespaceImportPoco:
+                    namespaceImportPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.NullExpression nullExpressionPoco:
+                    nullExpressionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Cases.ObjectiveMembership objectiveMembershipPoco:
+                    objectiveMembershipPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Occurrences.OccurrenceDefinition occurrenceDefinitionPoco:
+                    occurrenceDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Occurrences.OccurrenceUsage occurrenceUsagePoco:
+                    occurrenceUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.OperatorExpression operatorExpressionPoco:
+                    operatorExpressionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Root.Namespaces.OwningMembership owningMembershipPoco:
+                    owningMembershipPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Packages.Package packagePoco:
+                    packagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Behaviors.ParameterMembership parameterMembershipPoco:
+                    parameterMembershipPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Parts.PartDefinition partDefinitionPoco:
+                    partDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Parts.PartUsage partUsagePoco:
+                    partUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Interactions.PayloadFeature payloadFeaturePoco:
+                    payloadFeaturePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.PerformActionUsage performActionUsagePoco:
+                    performActionUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Ports.PortConjugation portConjugationPoco:
+                    portConjugationPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Ports.PortDefinition portDefinitionPoco:
+                    portDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Ports.PortUsage portUsagePoco:
+                    portUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Functions.Predicate predicatePoco:
+                    predicatePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Features.Redefinition redefinitionPoco:
+                    redefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Features.ReferenceSubsetting referenceSubsettingPoco:
+                    referenceSubsettingPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.ReferenceUsage referenceUsagePoco:
+                    referenceUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Views.RenderingDefinition renderingDefinitionPoco:
+                    renderingDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Views.RenderingUsage renderingUsagePoco:
+                    renderingUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Requirements.RequirementConstraintMembership requirementConstraintMembershipPoco:
+                    requirementConstraintMembershipPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Requirements.RequirementDefinition requirementDefinitionPoco:
+                    requirementDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Requirements.RequirementUsage requirementUsagePoco:
+                    requirementUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.VerificationCases.RequirementVerificationMembership requirementVerificationMembershipPoco:
+                    requirementVerificationMembershipPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Functions.ResultExpressionMembership resultExpressionMembershipPoco:
+                    resultExpressionMembershipPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Functions.ReturnParameterMembership returnParameterMembershipPoco:
+                    returnParameterMembershipPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Requirements.SatisfyRequirementUsage satisfyRequirementUsagePoco:
+                    satisfyRequirementUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Expressions.SelectExpression selectExpressionPoco:
+                    selectExpressionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.SendActionUsage sendActionUsagePoco:
+                    sendActionUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Types.Specialization specializationPoco:
+                    specializationPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Requirements.StakeholderMembership stakeholderMembershipPoco:
+                    stakeholderMembershipPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.States.StateDefinition stateDefinitionPoco:
+                    stateDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.States.StateSubactionMembership stateSubactionMembershipPoco:
+                    stateSubactionMembershipPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.States.StateUsage stateUsagePoco:
+                    stateUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Behaviors.Step stepPoco:
+                    stepPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Structures.Structure structurePoco:
+                    structurePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Classifiers.Subclassification subclassificationPoco:
+                    subclassificationPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Requirements.SubjectMembership subjectMembershipPoco:
+                    subjectMembershipPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Features.Subsetting subsettingPoco:
+                    subsettingPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Connectors.Succession successionPoco:
+                    successionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Connections.SuccessionAsUsage successionAsUsagePoco:
+                    successionAsUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Kernel.Interactions.SuccessionFlow successionFlowPoco:
+                    successionFlowPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Flows.SuccessionFlowUsage successionFlowUsagePoco:
+                    successionFlowUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.TerminateActionUsage terminateActionUsagePoco:
+                    terminateActionUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Root.Annotations.TextualRepresentation textualRepresentationPoco:
+                    textualRepresentationPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.States.TransitionFeatureMembership transitionFeatureMembershipPoco:
+                    transitionFeatureMembershipPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.States.TransitionUsage transitionUsagePoco:
+                    transitionUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.TriggerInvocationExpression triggerInvocationExpressionPoco:
+                    triggerInvocationExpressionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Types.Type typePoco:
+                    typePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Features.TypeFeaturing typeFeaturingPoco:
+                    typeFeaturingPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Core.Types.Unioning unioningPoco:
+                    unioningPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.Usage usagePoco:
+                    usagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.UseCases.UseCaseDefinition useCaseDefinitionPoco:
+                    useCaseDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.UseCases.UseCaseUsage useCaseUsagePoco:
+                    useCaseUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.VariantMembership variantMembershipPoco:
+                    variantMembershipPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.VerificationCases.VerificationCaseDefinition verificationCaseDefinitionPoco:
+                    verificationCaseDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.VerificationCases.VerificationCaseUsage verificationCaseUsagePoco:
+                    verificationCaseUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Views.ViewDefinition viewDefinitionPoco:
+                    viewDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Views.ViewpointDefinition viewpointDefinitionPoco:
+                    viewpointDefinitionPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Views.ViewpointUsage viewpointUsagePoco:
+                    viewpointUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Views.ViewRenderingMembership viewRenderingMembershipPoco:
+                    viewRenderingMembershipPoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Views.ViewUsage viewUsagePoco:
+                    viewUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.Actions.WhileLoopActionUsage whileLoopActionUsagePoco:
+                    whileLoopActionUsagePoco.ResolveAndAssignMultipleValueReferences(propertyName, references, xmiDataCache, logger);
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(data), data, "Unsupported type");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/PortConjugationExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/PortConjugationExtensions.cs
@@ -1,0 +1,234 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="PortConjugationExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Ports.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class PortConjugationExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Ports.PortConjugation"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Ports.PortConjugation poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "conjugatedType":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [conjugatedType] on element type [PortConjugation] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Types.IType conjugatedTypeReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IType");
+                        }
+
+                        poco.ConjugatedType = conjugatedTypeReference;
+                        return;
+                    }
+
+                case "originalPortDefinition":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [originalPortDefinition] on element type [PortConjugation] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Systems.Ports.IPortDefinition originalPortDefinitionReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IPortDefinition");
+                        }
+
+                        poco.OriginalPortDefinition = originalPortDefinitionReference;
+                        return;
+                    }
+
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [PortConjugation] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [PortConjugation] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Ports.PortConjugation"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Ports.PortConjugation poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [PortConjugation] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [PortConjugation] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/PortDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/PortDefinitionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="PortDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Ports.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class PortDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Ports.PortDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Ports.PortDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [PortDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Ports.PortDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Ports.PortDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [PortDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/PortUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/PortUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="PortUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Ports.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class PortUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Ports.PortUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Ports.PortUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [PortUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Ports.PortUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Ports.PortUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [PortUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/PredicateExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/PredicateExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="PredicateExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Functions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class PredicateExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.Predicate"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Functions.Predicate poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Predicate] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.Predicate"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Functions.Predicate poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Predicate] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/RedefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/RedefinitionExtensions.cs
@@ -1,0 +1,234 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="RedefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Features.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class RedefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.Redefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Features.Redefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [Redefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Redefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                case "redefinedFeature":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [redefinedFeature] on element type [Redefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Features.IFeature redefinedFeatureReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IFeature");
+                        }
+
+                        poco.RedefinedFeature = redefinedFeatureReference;
+                        return;
+                    }
+
+                case "redefiningFeature":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [redefiningFeature] on element type [Redefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Features.IFeature redefiningFeatureReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IFeature");
+                        }
+
+                        poco.RedefiningFeature = redefiningFeatureReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.Redefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Features.Redefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [Redefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Redefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ReferenceSubsettingExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ReferenceSubsettingExtensions.cs
@@ -1,0 +1,215 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ReferenceSubsettingExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Features.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ReferenceSubsettingExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.ReferenceSubsetting"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Features.ReferenceSubsetting poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [ReferenceSubsetting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ReferenceSubsetting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                case "referencedFeature":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [referencedFeature] on element type [ReferenceSubsetting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Features.IFeature referencedFeatureReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IFeature");
+                        }
+
+                        poco.ReferencedFeature = referencedFeatureReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.ReferenceSubsetting"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Features.ReferenceSubsetting poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [ReferenceSubsetting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ReferenceSubsetting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ReferenceUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ReferenceUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ReferenceUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ReferenceUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.ReferenceUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.ReferenceUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ReferenceUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.ReferenceUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.ReferenceUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ReferenceUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/RenderingDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/RenderingDefinitionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="RenderingDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Views.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class RenderingDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.RenderingDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Views.RenderingDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [RenderingDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.RenderingDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Views.RenderingDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [RenderingDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/RenderingUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/RenderingUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="RenderingUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Views.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class RenderingUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.RenderingUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Views.RenderingUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [RenderingUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.RenderingUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Views.RenderingUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [RenderingUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/RequirementConstraintMembershipExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/RequirementConstraintMembershipExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="RequirementConstraintMembershipExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Requirements.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class RequirementConstraintMembershipExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.RequirementConstraintMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Requirements.RequirementConstraintMembership poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [RequirementConstraintMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [RequirementConstraintMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.RequirementConstraintMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Requirements.RequirementConstraintMembership poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [RequirementConstraintMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [RequirementConstraintMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/RequirementDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/RequirementDefinitionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="RequirementDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Requirements.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class RequirementDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.RequirementDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Requirements.RequirementDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [RequirementDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.RequirementDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Requirements.RequirementDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [RequirementDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/RequirementUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/RequirementUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="RequirementUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Requirements.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class RequirementUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.RequirementUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Requirements.RequirementUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [RequirementUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.RequirementUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Requirements.RequirementUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [RequirementUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/RequirementVerificationMembershipExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/RequirementVerificationMembershipExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="RequirementVerificationMembershipExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.VerificationCases.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class RequirementVerificationMembershipExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.VerificationCases.RequirementVerificationMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.VerificationCases.RequirementVerificationMembership poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [RequirementVerificationMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [RequirementVerificationMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.VerificationCases.RequirementVerificationMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.VerificationCases.RequirementVerificationMembership poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [RequirementVerificationMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [RequirementVerificationMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ResultExpressionMembershipExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ResultExpressionMembershipExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ResultExpressionMembershipExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Functions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ResultExpressionMembershipExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.ResultExpressionMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Functions.ResultExpressionMembership poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [ResultExpressionMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ResultExpressionMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.ResultExpressionMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Functions.ResultExpressionMembership poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [ResultExpressionMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ResultExpressionMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ReturnParameterMembershipExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ReturnParameterMembershipExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ReturnParameterMembershipExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Functions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ReturnParameterMembershipExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.ReturnParameterMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Functions.ReturnParameterMembership poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [ReturnParameterMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ReturnParameterMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.ReturnParameterMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Functions.ReturnParameterMembership poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [ReturnParameterMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ReturnParameterMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/SatisfyRequirementUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/SatisfyRequirementUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="SatisfyRequirementUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Requirements.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class SatisfyRequirementUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.SatisfyRequirementUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Requirements.SatisfyRequirementUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [SatisfyRequirementUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.SatisfyRequirementUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Requirements.SatisfyRequirementUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [SatisfyRequirementUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/SelectExpressionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/SelectExpressionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="SelectExpressionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Expressions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class SelectExpressionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.SelectExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Expressions.SelectExpression poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [SelectExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.SelectExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Expressions.SelectExpression poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [SelectExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/SendActionUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/SendActionUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="SendActionUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Actions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class SendActionUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.SendActionUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Actions.SendActionUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [SendActionUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.SendActionUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Actions.SendActionUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [SendActionUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/SpecializationExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/SpecializationExtensions.cs
@@ -1,0 +1,234 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="SpecializationExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Types.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class SpecializationExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.Specialization"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Types.Specialization poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "general":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [general] on element type [Specialization] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Types.IType generalReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IType");
+                        }
+
+                        poco.General = generalReference;
+                        return;
+                    }
+
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [Specialization] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Specialization] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                case "specific":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [specific] on element type [Specialization] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Types.IType specificReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IType");
+                        }
+
+                        poco.Specific = specificReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.Specialization"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Types.Specialization poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [Specialization] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Specialization] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/StakeholderMembershipExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/StakeholderMembershipExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="StakeholderMembershipExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Requirements.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class StakeholderMembershipExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.StakeholderMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Requirements.StakeholderMembership poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [StakeholderMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [StakeholderMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.StakeholderMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Requirements.StakeholderMembership poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [StakeholderMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [StakeholderMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/StateDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/StateDefinitionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="StateDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.States.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class StateDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.StateDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.States.StateDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [StateDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.StateDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.States.StateDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [StateDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/StateSubactionMembershipExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/StateSubactionMembershipExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="StateSubactionMembershipExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.States.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class StateSubactionMembershipExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.StateSubactionMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.States.StateSubactionMembership poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [StateSubactionMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [StateSubactionMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.StateSubactionMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.States.StateSubactionMembership poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [StateSubactionMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [StateSubactionMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/StateUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/StateUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="StateUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.States.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class StateUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.StateUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.States.StateUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [StateUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.StateUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.States.StateUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [StateUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/StepExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/StepExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="StepExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Behaviors.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class StepExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Behaviors.Step"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Behaviors.Step poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Step] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Behaviors.Step"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Behaviors.Step poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Step] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/StructureExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/StructureExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="StructureExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Structures.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class StructureExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Structures.Structure"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Structures.Structure poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Structure] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Structures.Structure"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Structures.Structure poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Structure] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/SubclassificationExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/SubclassificationExtensions.cs
@@ -1,0 +1,234 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="SubclassificationExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Classifiers.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class SubclassificationExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Classifiers.Subclassification"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Classifiers.Subclassification poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [Subclassification] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Subclassification] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                case "subclassifier":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [subclassifier] on element type [Subclassification] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Classifiers.IClassifier subclassifierReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IClassifier");
+                        }
+
+                        poco.Subclassifier = subclassifierReference;
+                        return;
+                    }
+
+                case "superclassifier":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [superclassifier] on element type [Subclassification] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Classifiers.IClassifier superclassifierReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IClassifier");
+                        }
+
+                        poco.Superclassifier = superclassifierReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Classifiers.Subclassification"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Classifiers.Subclassification poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [Subclassification] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Subclassification] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/SubjectMembershipExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/SubjectMembershipExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="SubjectMembershipExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Requirements.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class SubjectMembershipExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.SubjectMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Requirements.SubjectMembership poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [SubjectMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [SubjectMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.SubjectMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Requirements.SubjectMembership poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [SubjectMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [SubjectMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/SubsettingExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/SubsettingExtensions.cs
@@ -1,0 +1,234 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="SubsettingExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Features.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class SubsettingExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.Subsetting"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Features.Subsetting poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [Subsetting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Subsetting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                case "subsettedFeature":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [subsettedFeature] on element type [Subsetting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Features.IFeature subsettedFeatureReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IFeature");
+                        }
+
+                        poco.SubsettedFeature = subsettedFeatureReference;
+                        return;
+                    }
+
+                case "subsettingFeature":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [subsettingFeature] on element type [Subsetting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Features.IFeature subsettingFeatureReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IFeature");
+                        }
+
+                        poco.SubsettingFeature = subsettingFeatureReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.Subsetting"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Features.Subsetting poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [Subsetting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Subsetting] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/SuccessionAsUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/SuccessionAsUsageExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="SuccessionAsUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Connections.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class SuccessionAsUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Connections.SuccessionAsUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Connections.SuccessionAsUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [SuccessionAsUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [SuccessionAsUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Connections.SuccessionAsUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Connections.SuccessionAsUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [SuccessionAsUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [SuccessionAsUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/SuccessionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/SuccessionExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="SuccessionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Connectors.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class SuccessionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Connectors.Succession"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Connectors.Succession poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [Succession] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Succession] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Connectors.Succession"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Connectors.Succession poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [Succession] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Succession] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/SuccessionFlowExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/SuccessionFlowExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="SuccessionFlowExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Kernel.Interactions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class SuccessionFlowExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Interactions.SuccessionFlow"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Kernel.Interactions.SuccessionFlow poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [SuccessionFlow] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [SuccessionFlow] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Interactions.SuccessionFlow"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Kernel.Interactions.SuccessionFlow poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [SuccessionFlow] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [SuccessionFlow] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/SuccessionFlowUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/SuccessionFlowUsageExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="SuccessionFlowUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Flows.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class SuccessionFlowUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Flows.SuccessionFlowUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Flows.SuccessionFlowUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [SuccessionFlowUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [SuccessionFlowUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Flows.SuccessionFlowUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Flows.SuccessionFlowUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [SuccessionFlowUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [SuccessionFlowUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/TerminateActionUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/TerminateActionUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="TerminateActionUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Actions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class TerminateActionUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.TerminateActionUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Actions.TerminateActionUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [TerminateActionUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.TerminateActionUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Actions.TerminateActionUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [TerminateActionUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/TextualRepresentationExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/TextualRepresentationExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="TextualRepresentationExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Root.Annotations.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class TextualRepresentationExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Annotations.TextualRepresentation"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Root.Annotations.TextualRepresentation poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [TextualRepresentation] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Annotations.TextualRepresentation"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Root.Annotations.TextualRepresentation poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [TextualRepresentation] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/TransitionFeatureMembershipExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/TransitionFeatureMembershipExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="TransitionFeatureMembershipExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.States.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class TransitionFeatureMembershipExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.TransitionFeatureMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.States.TransitionFeatureMembership poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [TransitionFeatureMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [TransitionFeatureMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.TransitionFeatureMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.States.TransitionFeatureMembership poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [TransitionFeatureMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [TransitionFeatureMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/TransitionUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/TransitionUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="TransitionUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.States.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class TransitionUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.TransitionUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.States.TransitionUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [TransitionUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.TransitionUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.States.TransitionUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [TransitionUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/TriggerInvocationExpressionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/TriggerInvocationExpressionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="TriggerInvocationExpressionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Actions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class TriggerInvocationExpressionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.TriggerInvocationExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Actions.TriggerInvocationExpression poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [TriggerInvocationExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.TriggerInvocationExpression"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Actions.TriggerInvocationExpression poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [TriggerInvocationExpression] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/TypeExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/TypeExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="TypeExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Types.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class TypeExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.Type"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Types.Type poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Type] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.Type"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Types.Type poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Type] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/TypeFeaturingExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/TypeFeaturingExtensions.cs
@@ -1,0 +1,234 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="TypeFeaturingExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Features.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class TypeFeaturingExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.TypeFeaturing"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Features.TypeFeaturing poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "featureOfType":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [featureOfType] on element type [TypeFeaturing] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Features.IFeature featureOfTypeReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IFeature");
+                        }
+
+                        poco.FeatureOfType = featureOfTypeReference;
+                        return;
+                    }
+
+                case "featuringType":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [featuringType] on element type [TypeFeaturing] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Types.IType featuringTypeReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IType");
+                        }
+
+                        poco.FeaturingType = featuringTypeReference;
+                        return;
+                    }
+
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [TypeFeaturing] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [TypeFeaturing] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.TypeFeaturing"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Features.TypeFeaturing poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [TypeFeaturing] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [TypeFeaturing] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/UnioningExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/UnioningExtensions.cs
@@ -1,0 +1,215 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="UnioningExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Core.Types.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class UnioningExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.Unioning"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Core.Types.Unioning poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [Unioning] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Unioning] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                case "unioningType":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [unioningType] on element type [Unioning] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Core.Types.IType unioningTypeReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IType");
+                        }
+
+                        poco.UnioningType = unioningTypeReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.Unioning"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Core.Types.Unioning poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [Unioning] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Unioning] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/UsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/UsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="UsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class UsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.Usage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.Usage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [Usage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.Usage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.Usage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [Usage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/UseCaseDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/UseCaseDefinitionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="UseCaseDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.UseCases.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class UseCaseDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.UseCases.UseCaseDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.UseCases.UseCaseDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [UseCaseDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.UseCases.UseCaseDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.UseCases.UseCaseDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [UseCaseDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/UseCaseUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/UseCaseUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="UseCaseUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.UseCases.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class UseCaseUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.UseCases.UseCaseUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.UseCases.UseCaseUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [UseCaseUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.UseCases.UseCaseUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.UseCases.UseCaseUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [UseCaseUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/VariantMembershipExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/VariantMembershipExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="VariantMembershipExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class VariantMembershipExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.VariantMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.VariantMembership poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [VariantMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [VariantMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.VariantMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.VariantMembership poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [VariantMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [VariantMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/VerificationCaseDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/VerificationCaseDefinitionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="VerificationCaseDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.VerificationCases.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class VerificationCaseDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.VerificationCases.VerificationCaseDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.VerificationCases.VerificationCaseDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [VerificationCaseDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.VerificationCases.VerificationCaseDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.VerificationCases.VerificationCaseDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [VerificationCaseDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/VerificationCaseUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/VerificationCaseUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="VerificationCaseUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.VerificationCases.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class VerificationCaseUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.VerificationCases.VerificationCaseUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.VerificationCases.VerificationCaseUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [VerificationCaseUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.VerificationCases.VerificationCaseUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.VerificationCases.VerificationCaseUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [VerificationCaseUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ViewDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ViewDefinitionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ViewDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Views.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ViewDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.ViewDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Views.ViewDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ViewDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.ViewDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Views.ViewDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ViewDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ViewRenderingMembershipExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ViewRenderingMembershipExtensions.cs
@@ -1,0 +1,196 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ViewRenderingMembershipExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Views.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ViewRenderingMembershipExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.ViewRenderingMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Views.ViewRenderingMembership poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelatedElement":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelatedElement] on element type [ViewRenderingMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement owningRelatedElementReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                        }
+
+                        poco.OwningRelatedElement = owningRelatedElementReference;
+                        return;
+                    }
+
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ViewRenderingMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.ViewRenderingMembership"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Views.ViewRenderingMembership poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelatedElement":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelatedElement] on element type [ViewRenderingMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IElement ownedRelatedElementReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IElement");
+                            }
+
+                            poco.OwnedRelatedElement.Add(ownedRelatedElementReference);
+                        }
+
+                        return;
+                    }
+
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ViewRenderingMembership] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ViewUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ViewUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ViewUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Views.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ViewUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.ViewUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Views.ViewUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ViewUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.ViewUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Views.ViewUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ViewUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ViewpointDefinitionExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ViewpointDefinitionExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ViewpointDefinitionExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Views.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ViewpointDefinitionExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.ViewpointDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Views.ViewpointDefinition poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ViewpointDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.ViewpointDefinition"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Views.ViewpointDefinition poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ViewpointDefinition] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ViewpointUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/ViewpointUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ViewpointUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Views.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class ViewpointUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.ViewpointUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Views.ViewpointUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [ViewpointUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.ViewpointUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Views.ViewpointUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [ViewpointUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/WhileLoopActionUsageExtensions.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/AutoGenPocoReferenceResolveExtension/WhileLoopActionUsageExtensions.cs
@@ -1,0 +1,154 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="WhileLoopActionUsageExtensions.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// Provides extensions methods for the <see cref="{SysML2.NET.Core.POCO.Systems.Actions.{this.Name}}"/> to help resolve reference for properties
+    /// </summary>
+    public static class WhileLoopActionUsageExtensions
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.WhileLoopActionUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignSingleValueReference(this SysML2.NET.Core.POCO.Systems.Actions.WhileLoopActionUsage poco, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "owningRelationship":
+                    {
+                        if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                        {
+                            logger.LogWarning("The reference to [{Reference}] for property [owningRelationship] on element type [WhileLoopActionUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                            return;
+                        }
+
+                        if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship owningRelationshipReference)
+                        {
+                            throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                        }
+
+                        poco.OwningRelationship = owningRelationshipReference;
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.WhileLoopActionUsage"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        public static void ResolveAndAssignMultipleValueReferences(this SysML2.NET.Core.POCO.Systems.Actions.WhileLoopActionUsage poco, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger)
+        {
+            if (poco == null)
+            {
+                throw new ArgumentNullException(nameof(poco));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (xmiDataCache == null)
+            {
+                throw new ArgumentNullException(nameof(xmiDataCache));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            switch (propertyName)
+            {
+                case "ownedRelationship":
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (!xmiDataCache.TryGetData(reference, out var referencedData))
+                            {
+                                logger.LogWarning("The reference to [{Reference}] for property [ownedRelationship] on element type [WhileLoopActionUsage] with id [{Id}] was not found in the cache, probably because its type is not supported.",
+                                reference, poco.Id);
+
+                                continue;
+                            }
+
+                            if (referencedData is not SysML2.NET.Core.POCO.Root.Elements.IRelationship ownedRelationshipReference)
+                            {
+                                throw new InvalidOperationException($"The referenced element with the id [{reference}] is a {referencedData.GetType().Name}, expected type: an IRelationship");
+                            }
+
+                            poco.OwnedRelationship.Add(ownedRelationshipReference);
+                        }
+
+                        return;
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(propertyName), propertyName, "Unknown property name");
+            }
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/SysML2.NET.Serializer.Xmi/Extensions/IPocoReferenceResolveExtensionsFacade.cs
+++ b/SysML2.NET.Serializer.Xmi/Extensions/IPocoReferenceResolveExtensionsFacade.cs
@@ -1,0 +1,55 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="IPocoReferenceResolveExtensionsFacade.cs" company="Starion Group S.A.">
+// 
+//   Copyright 2022-2026 Starion Group S.A.
+// 
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.Xmi.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.Extensions.Logging;
+
+    using SysML2.NET.Common;
+
+    /// <summary>
+    /// The <see cref="IPocoReferenceResolveExtensionsFacade"/> provides access to extensions method for POCO <see cref="IData"/> to resolve reference
+    /// </summary>
+    public interface IPocoReferenceResolveExtensionsFacade
+    {
+        /// <summary>
+        /// Resolve and assign single reference value for a specific property
+        /// </summary>
+        /// <param name="data">The <see cref="IData"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="reference">The identifier of the <see cref="IData"/> value to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        void ResolveAndAssignSingleValueReference(IData data, string propertyName, Guid reference, IXmiDataCache xmiDataCache, ILogger logger);
+        
+        /// <summary>
+        /// Resolve and assign multiple references value for a specific property
+        /// </summary>
+        /// <param name="data">The <see cref="IData"/> that should have the value of a property to be set</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <param name="references">The collection of identifier values to set</param>
+        /// <param name="xmiDataCache">The <see cref="IXmiDataCache"/></param>
+        /// <param name="logger">The <see cref="ILogger" /> used to produce log statement</param>
+        void ResolveAndAssignMultipleValueReferences(IData data, string propertyName, IReadOnlyCollection<Guid> references, IXmiDataCache xmiDataCache, ILogger logger);
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/SysML2.NET/pulls) open
- [x] I have verified that I am following the SysML2.NET [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/SysML2.NET/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #71 

Removes reflexion during reference resolve during XMI synchronize process by codegen extension methods
<!-- Thanks for contributing to SysML2.NET! -->