### PR TITLE
POCO interface defines operation

### DIFF
--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/AnnotatingElement.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/AnnotatingElement.cs
@@ -182,7 +182,7 @@ namespace SysML2.NET.Core.POCO.Root.Annotations
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/Association.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/Association.cs
@@ -429,7 +429,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Associations
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -440,7 +440,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Associations
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/Dependency.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/Dependency.cs
@@ -177,7 +177,7 @@ namespace SysML2.NET.Core.POCO.Root.Dependencies
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -188,7 +188,7 @@ namespace SysML2.NET.Core.POCO.Root.Dependencies
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/EnumerationDefinition.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/EnumerationDefinition.cs
@@ -615,7 +615,7 @@ namespace SysML2.NET.Core.POCO.Systems.Enumerations
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/Feature.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/Feature.cs
@@ -590,7 +590,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/FeatureTyping.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/FeatureTyping.cs
@@ -185,7 +185,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -196,7 +196,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/Flow.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/Flow.cs
@@ -650,7 +650,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Interactions
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -661,7 +661,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Interactions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/FramedConcernMembership.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/FramedConcernMembership.cs
@@ -312,7 +312,7 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -323,7 +323,7 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/IElement.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/IElement.cs
@@ -124,7 +124,7 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// </summary>
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
-        IReadOnlyCollection<IRelationship> OwnedRelationship { get; }
+        IReadOnlyList<IRelationship> OwnedRelationship { get; }
 
         /// <summary>
         /// The owner of this Element, derived as the owningRelatedElement of the owningRelationship of this
@@ -184,6 +184,55 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1543092869879_112608_17278")]
         List<ITextualRepresentation> textualRepresentation { get; }
 
+        /// <summary>
+        /// Return name, if that is not null, otherwise the shortName, if that is not null, otherwise null. If
+        /// the returned value is non-null, it is returned as-is if it has the form of a basic name, or,
+        /// otherwise, represented as a restricted name according to the lexical structure of the KerML textual
+        /// notation (i.e., surrounded by single quote characters and with special characters escaped).
+        /// </summary>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        string EscapedName() => this.ComputeEscapedNameOperation();
+
+        /// <summary>
+        /// Return an effective shortName for this Element. By default this is the same as its
+        /// declaredShortName.
+        /// </summary>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        string EffectiveShortName() => this.ComputeEffectiveShortNameOperation();
+
+        /// <summary>
+        /// Return an effective name for this Element. By default this is the same as its declaredName.
+        /// </summary>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        string EffectiveName() => this.ComputeEffectiveNameOperation();
+
+        /// <summary>
+        /// By default, return the library Namespace of the owningRelationship of this Element, if it has one.
+        /// </summary>
+        /// <returns>
+        /// The expected INamespace
+        /// </returns>
+        INamespace LibraryNamespace() => this.ComputeLibraryNamespaceOperation();
+
+        /// <summary>
+        /// Return a unique description of the location of this Element in the containment structure rooted in a
+        /// root Namespace. If the Element has a non-null qualifiedName, then return that. Otherwise, if it has
+        /// an owningRelationship, then return the string constructed by appending to the path of it's
+        /// owningRelationship the character / followed by the string representation of its position in the list
+        /// of ownedRelatedElements of the owningRelationship (indexed starting at 1). Otherwise, return the
+        /// empty string.                            (Note that this operation is overridden for Relationships
+        /// to use owningRelatedElement when appropriate.)
+        /// </summary>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        string Path() => this.ComputePathOperation();
     }
 }
 

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/IFeature.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/IFeature.cs
@@ -262,6 +262,208 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1533160674969_376003_43216", aggregation: AggregationKind.None, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: true, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         List<IType> type { get; }
 
+        /// <summary>
+        /// Return the directionOf this Feature relative to the given type.
+        /// </summary>
+        /// <param name="type">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected FeatureDirectionKind
+        /// </returns>
+        FeatureDirectionKind DirectionFor(IType type) => this.ComputeDirectionForOperation(type);
+
+        /// <summary>
+        /// If a Feature has no declaredShortName or declaredName, then its effective shortName is given by the
+        /// effective shortName of the Feature returned by the namingFeature() operation, if any.
+        /// </summary>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        new string EffectiveShortName() => this.ComputeRedefinedEffectiveShortNameOperation();
+
+        /// <summary>
+        /// If a Feature has no declaredName or declaredShortName                            , then its
+        /// effective name is given by the effective name of the Feature returned by the namingFeature()
+        /// operation, if any.
+        /// </summary>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        new string EffectiveName() => this.ComputeRedefinedEffectiveNameOperation();
+
+        /// <summary>
+        /// By default, the naming Feature of a Feature is given by its first redefinedFeature of its first
+        /// ownedRedefinition, if any.
+        /// </summary>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        IFeature NamingFeature() => this.ComputeNamingFeatureOperation();
+
+        /// <summary>
+        /// </summary>
+        /// <param name="excludeImplied">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IType
+        /// </returns>
+        new IType Supertypes(bool excludeImplied) => this.ComputeRedefinedSupertypesOperation(excludeImplied);
+
+        /// <summary>
+        /// Check whether this Feature directly redefines the given redefinedFeature.
+        /// </summary>
+        /// <param name="redefinedFeature">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool Redefines(IFeature redefinedFeature) => this.ComputeRedefinesOperation(redefinedFeature);
+
+        /// <summary>
+        /// Check whether this Feature directly redefines the named library Feature. libraryFeatureName must
+        /// conform to the syntax of a KerML qualified name and must resolve to a Feature in global scope.
+        /// </summary>
+        /// <param name="libraryFeatureName">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool RedefinesFromLibrary(string libraryFeatureName) => this.ComputeRedefinesFromLibraryOperation(libraryFeatureName);
+
+        /// <summary>
+        /// Check whether this Feature directly or indirectly specializes a Feature whose last two
+        /// chainingFeatures are the given Features first and second.
+        /// </summary>
+        /// <param name="first">
+        /// No documentation provided
+        /// </param>
+        /// <param name="second">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool SubsetsChain(IFeature first, IFeature second) => this.ComputeSubsetsChainOperation(first, second);
+
+        /// <summary>
+        /// A Feature is compatible with an otherType if it either directly or indirectly specializes the
+        /// otherType or if the otherType is also a Feature and all of the following are true.                  
+        ///          <ol>                            <li>Neither this Feature or the otherType have any
+        /// ownedFeatures.</li>                            <li>This Feature directly or indirectly redefines a
+        /// Feature that is also directly or indirectly redefined by the otherType.</li>                        
+        /// <li>This Feature can access the otherType.                            </li></ol>
+        /// </summary>
+        /// <param name="otherType">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        new bool IsCompatibleWith(IType otherType) => this.ComputeRedefinedIsCompatibleWithOperation(otherType);
+
+        /// <summary>
+        /// Return the Features used to determine the types of this Feature (other than this Feature itself). If
+        /// this Feature is not conjugated, then the typingFeatures consist of all subsetted Features, except
+        /// from CrossSubsetting, and the last chainingFeature (if any). If this Feature is conjugated, then the
+        /// typingFeatures are only its originalType (if the originalType is a Feature).                        
+        ///    <strong>Note.</strong> CrossSubsetting is excluded from the determination of the type of a
+        /// Feature in order to avoid circularity in the construction of implied CrossSubsetting relationships.
+        /// The validateFeatureCrossFeatureType requires that the crossFeature of a Feature have the same type
+        /// as the Feature.
+        /// </summary>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        IFeature TypingFeatures() => this.ComputeTypingFeaturesOperation();
+
+        /// <summary>
+        /// If isCartesianProduct is true, then return the list of Types whose Cartesian product can be
+        /// represented by this Feature. (If isCartesianProduct is not true, the operation will still return a
+        /// valid value, it will just not represent anything useful.)
+        /// </summary>
+        /// <returns>
+        /// The expected IType
+        /// </returns>
+        IType AsCartesianProduct() => this.ComputeAsCartesianProductOperation();
+
+        /// <summary>
+        /// Check whether this Feature can be used to represent a Cartesian product of Types.
+        /// </summary>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool IsCartesianProduct() => this.ComputeIsCartesianProductOperation();
+
+        /// <summary>
+        /// Return whether this Feature is an owned cross Feature of an end Feature.
+        /// </summary>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool IsOwnedCrossFeature() => this.ComputeIsOwnedCrossFeatureOperation();
+
+        /// <summary>
+        /// If this Feature is an end Feature of its owningType, then return the first ownedMember of the
+        /// Feature that is a Feature, but not a Multiplicity or a MetadataFeature, and whose owningMembership
+        /// is not a FeatureMembership. If this exists, it is the crossFeature of the end Feature.
+        /// </summary>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        IFeature OwnedCrossFeature() => this.ComputeOwnedCrossFeatureOperation();
+
+        /// <summary>
+        /// Return this Feature and all the Features that are directly or indirectly Redefined by this Feature.
+        /// </summary>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        IFeature AllRedefinedFeatures() => this.ComputeAllRedefinedFeaturesOperation();
+
+        /// <summary>
+        /// Return if the featuringTypes of this Feature are compatible with the given type. If type is null,
+        /// then check if this Feature is explicitly or implicitly featured by Base::Anything. If this Feature
+        /// has isVariable = true, then also consider it to be featured within its owningType. If this Feature
+        /// is a feature chain whose first chainingFeature has isVariable = true, then also consider it to be
+        /// featured within the owningType of its first chainingFeature.
+        /// </summary>
+        /// <param name="type">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool IsFeaturedWithin(IType type) => this.ComputeIsFeaturedWithinOperation(type);
+
+        /// <summary>
+        /// A Feature can access another feature if the other feature is featured within one of the direct or
+        /// indirect featuringTypes of this Feature.
+        /// </summary>
+        /// <param name="feature">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool CanAccess(IFeature feature) => this.ComputeCanAccessOperation(feature);
+
+        /// <summary>
+        /// Return whether the given type must be a featuringType of this Feature. If this Feature has
+        /// isVariable = false, then return true if the type is the owningType of the Feature. If isVariable =
+        /// true, then return true if the type is a Feature representing the snapshots of the owningType of this
+        /// Feature.
+        /// </summary>
+        /// <param name="type">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool IsFeaturingType(IType type) => this.ComputeIsFeaturingTypeOperation(type);
     }
 }
 

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/IMembership.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/IMembership.cs
@@ -88,6 +88,20 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         [Property(xmiId: "_18_5_3_12e503d9_1533160674964_42975_43193", aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: "public")]
         VisibilityKind Visibility { get; set; }
 
+        /// <summary>
+        /// Whether this Membership is distinguishable from a given other Membership. By default, this is true
+        /// if this Membership has no memberShortName or memberName; or each of the memberShortName and
+        /// memberName are different than both of those of the other Membership; or neither of the metaclasses
+        /// of the memberElement of this Membership and the memberElement of the other Membership conform to the
+        /// other. But this may be overridden in specializations of Membership.
+        /// </summary>
+        /// <param name="other">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool IsDistinguishableFrom(IMembership other) => this.ComputeIsDistinguishableFromOperation(other);
     }
 }
 

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/IMultiplicityRange.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/IMultiplicityRange.cs
@@ -74,6 +74,32 @@ namespace SysML2.NET.Core.POCO.Kernel.Multiplicities
         [SubsettedProperty(propertyName: "_19_0_2_12e503d9_1573095221994_519580_5095")]
         IExpression upperBound { get; }
 
+        /// <summary>
+        /// Check whether this MultiplicityRange represents the range bounded by the given values lower and
+        /// upper, presuming the lowerBound and upperBound Expressions are model-level evaluable.
+        /// </summary>
+        /// <param name="lower">
+        /// No documentation provided
+        /// </param>
+        /// <param name="upper">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool HasBounds(int lower, string upper) => this.ComputeHasBoundsOperation(lower, upper);
+
+        /// <summary>
+        /// Evaluate the given bound Expression (at model level) and return the result represented as a MOF
+        /// UnlimitedNatural value.
+        /// </summary>
+        /// <param name="bound">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        string ValueOf(IExpression bound) => this.ComputeValueOfOperation(bound);
     }
 }
 

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/IOwningMembership.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/IOwningMembership.cs
@@ -71,6 +71,15 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         [RedefinedProperty(propertyName: "_19_0_4_12e503d9_1651721174176_601088_238")]
         string ownedMemberShortName { get; }
 
+        /// <summary>
+        /// If the ownedMemberElement of this OwningMembership has a non-null qualifiedName, then return the
+        /// string constructed by appending to that qualifiedName the string "/owningMembership". Otherwise,
+        /// return the path of the OwningMembership as specified for a Relationship in general.
+        /// </summary>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        new string Path() => this.ComputeRedefinedPathOperation();
     }
 }
 

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/IRelationship.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/IRelationship.cs
@@ -62,7 +62,7 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// </summary>
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
-        IReadOnlyCollection<IElement> OwnedRelatedElement { get; }
+        IReadOnlyList<IElement> OwnedRelatedElement { get; }
 
         /// <summary>
         /// The relatedElement of this Relationship that owns the Relationship, if any.
@@ -92,6 +92,25 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         List<IElement> Target { get; set; }
 
+        /// <summary>
+        /// Return whether this Relationship has either an owningRelatedElement or owningRelationship that is a
+        /// library element.
+        /// </summary>
+        /// <returns>
+        /// The expected INamespace
+        /// </returns>
+        new INamespace LibraryNamespace() => this.ComputeRedefinedLibraryNamespaceOperation();
+
+        /// <summary>
+        /// If the owningRelationship of the Relationship is null but its owningRelatedElement is non-null,
+        /// construct the path using the position of the Relationship in the list of ownedRelationships of its
+        /// owningRelatedElement. Otherwise, return the path of the Relationship as specified for an Element in
+        /// general.
+        /// </summary>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        new string Path() => this.ComputeRedefinedPathOperation();
     }
 }
 

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/IUsage.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/IUsage.cs
@@ -341,6 +341,23 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674979_190614_43269")]
         List<IVariantMembership> variantMembership { get; }
 
+        /// <summary>
+        /// If this Usage is a variant, then its naming Feature is the referencedFeature of its
+        /// ownedReferenceSubsetting.
+        /// </summary>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        new IFeature NamingFeature() => this.ComputeRedefinedNamingFeatureOperation();
+
+        /// <summary>
+        /// If ownedReferenceSubsetting is not null, return the featureTarget of the referencedFeature of the
+        /// ownedReferenceSubsetting.
+        /// </summary>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        IFeature ReferencedFeatureTarget() => this.ComputeReferencedFeatureTargetOperation();
     }
 }
 

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/LiteralInteger.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/LiteralInteger.cs
@@ -605,7 +605,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/LiteralRational.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/LiteralRational.cs
@@ -605,7 +605,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/Membership.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/Membership.cs
@@ -211,7 +211,7 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -222,7 +222,7 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/MultiplicityRange.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/MultiplicityRange.cs
@@ -602,7 +602,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Multiplicities
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/OwningMembership.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/OwningMembership.cs
@@ -255,7 +255,7 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -266,7 +266,7 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/ReferenceSubsetting.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/ReferenceSubsetting.cs
@@ -190,7 +190,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -201,7 +201,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/RequirementUsage.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/RequirementUsage.cs
@@ -971,7 +971,7 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/SelectExpression.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/SelectExpression.cs
@@ -646,7 +646,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/Subclassification.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/Subclassification.cs
@@ -186,7 +186,7 @@ namespace SysML2.NET.Core.POCO.Core.Classifiers
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -197,7 +197,7 @@ namespace SysML2.NET.Core.POCO.Core.Classifiers
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/TextualRepresentation.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/TextualRepresentation.cs
@@ -222,7 +222,7 @@ namespace SysML2.NET.Core.POCO.Root.Annotations
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/Usage.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPoco/Usage.cs
@@ -874,7 +874,7 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/AnnotatingElementExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/AnnotatingElementExtensions.cs
@@ -35,14 +35,14 @@ namespace SysML2.NET.Core.POCO.Root.Annotations
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="annotatingElement">
+        /// <param name="annotatingElementSubject">
         /// The subject <see cref="IAnnotatingElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IElement> ComputeAnnotatedElement(this IAnnotatingElement annotatingElement)
+        internal static List<IElement> ComputeAnnotatedElement(this IAnnotatingElement annotatingElementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -50,14 +50,14 @@ namespace SysML2.NET.Core.POCO.Root.Annotations
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="annotatingElement">
+        /// <param name="annotatingElementSubject">
         /// The subject <see cref="IAnnotatingElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IAnnotation> ComputeAnnotation(this IAnnotatingElement annotatingElement)
+        internal static List<IAnnotation> ComputeAnnotation(this IAnnotatingElement annotatingElementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -65,14 +65,14 @@ namespace SysML2.NET.Core.POCO.Root.Annotations
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="annotatingElement">
+        /// <param name="annotatingElementSubject">
         /// The subject <see cref="IAnnotatingElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IAnnotation> ComputeOwnedAnnotatingRelationship(this IAnnotatingElement annotatingElement)
+        internal static List<IAnnotation> ComputeOwnedAnnotatingRelationship(this IAnnotatingElement annotatingElementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -80,14 +80,14 @@ namespace SysML2.NET.Core.POCO.Root.Annotations
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="annotatingElement">
+        /// <param name="annotatingElementSubject">
         /// The subject <see cref="IAnnotatingElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IAnnotation ComputeOwningAnnotatingRelationship(this IAnnotatingElement annotatingElement)
+        internal static IAnnotation ComputeOwningAnnotatingRelationship(this IAnnotatingElement annotatingElementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/AssociationExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/AssociationExtensions.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Associations
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="association">
+        /// <param name="associationSubject">
         /// The subject <see cref="IAssociation"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeature> ComputeAssociationEnd(this IAssociation association)
+        internal static List<IFeature> ComputeAssociationEnd(this IAssociation associationSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -54,14 +54,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Associations
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="association">
+        /// <param name="associationSubject">
         /// The subject <see cref="IAssociation"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IType> ComputeRelatedType(this IAssociation association)
+        internal static List<IType> ComputeRelatedType(this IAssociation associationSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -69,14 +69,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Associations
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="association">
+        /// <param name="associationSubject">
         /// The subject <see cref="IAssociation"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IType ComputeSourceType(this IAssociation association)
+        internal static IType ComputeSourceType(this IAssociation associationSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -84,14 +84,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Associations
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="association">
+        /// <param name="associationSubject">
         /// The subject <see cref="IAssociation"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IType> ComputeTargetType(this IAssociation association)
+        internal static List<IType> ComputeTargetType(this IAssociation associationSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/ElementExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/ElementExtensions.cs
@@ -35,14 +35,14 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="element">
+        /// <param name="elementSubject">
         /// The subject <see cref="IElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IDocumentation> ComputeDocumentation(this IElement element)
+        internal static List<IDocumentation> ComputeDocumentation(this IElement elementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -50,14 +50,14 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="element">
+        /// <param name="elementSubject">
         /// The subject <see cref="IElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static bool ComputeIsLibraryElement(this IElement element)
+        internal static bool ComputeIsLibraryElement(this IElement elementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -65,14 +65,14 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="element">
+        /// <param name="elementSubject">
         /// The subject <see cref="IElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static string ComputeName(this IElement element)
+        internal static string ComputeName(this IElement elementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -80,14 +80,14 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="element">
+        /// <param name="elementSubject">
         /// The subject <see cref="IElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IAnnotation> ComputeOwnedAnnotation(this IElement element)
+        internal static List<IAnnotation> ComputeOwnedAnnotation(this IElement elementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -95,14 +95,14 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="element">
+        /// <param name="elementSubject">
         /// The subject <see cref="IElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IElement> ComputeOwnedElement(this IElement element)
+        internal static List<IElement> ComputeOwnedElement(this IElement elementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -110,14 +110,14 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="element">
+        /// <param name="elementSubject">
         /// The subject <see cref="IElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IElement ComputeOwner(this IElement element)
+        internal static IElement ComputeOwner(this IElement elementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -125,14 +125,14 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="element">
+        /// <param name="elementSubject">
         /// The subject <see cref="IElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IOwningMembership ComputeOwningMembership(this IElement element)
+        internal static IOwningMembership ComputeOwningMembership(this IElement elementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -140,14 +140,14 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="element">
+        /// <param name="elementSubject">
         /// The subject <see cref="IElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static INamespace ComputeOwningNamespace(this IElement element)
+        internal static INamespace ComputeOwningNamespace(this IElement elementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -155,14 +155,14 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="element">
+        /// <param name="elementSubject">
         /// The subject <see cref="IElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static string ComputeQualifiedName(this IElement element)
+        internal static string ComputeQualifiedName(this IElement elementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -170,14 +170,14 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="element">
+        /// <param name="elementSubject">
         /// The subject <see cref="IElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static string ComputeShortName(this IElement element)
+        internal static string ComputeShortName(this IElement elementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -185,17 +185,101 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="element">
+        /// <param name="elementSubject">
         /// The subject <see cref="IElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<ITextualRepresentation> ComputeTextualRepresentation(this IElement element)
+        internal static List<ITextualRepresentation> ComputeTextualRepresentation(this IElement elementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// Return name, if that is not null, otherwise the shortName, if that is not null, otherwise null. If
+        /// the returned value is non-null, it is returned as-is if it has the form of a basic name, or,
+        /// otherwise, represented as a restricted name according to the lexical structure of the KerML textual
+        /// notation (i.e., surrounded by single quote characters and with special characters escaped).
+        /// </summary>
+        /// <param name="elementSubject">
+        /// The subject <see cref="IElement"/>
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static string ComputeEscapedNameOperation(this IElement elementSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return an effective shortName for this Element. By default this is the same as its
+        /// declaredShortName.
+        /// </summary>
+        /// <param name="elementSubject">
+        /// The subject <see cref="IElement"/>
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static string ComputeEffectiveShortNameOperation(this IElement elementSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return an effective name for this Element. By default this is the same as its declaredName.
+        /// </summary>
+        /// <param name="elementSubject">
+        /// The subject <see cref="IElement"/>
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static string ComputeEffectiveNameOperation(this IElement elementSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// By default, return the library Namespace of the owningRelationship of this Element, if it has one.
+        /// </summary>
+        /// <param name="elementSubject">
+        /// The subject <see cref="IElement"/>
+        /// </param>
+        /// <returns>
+        /// The expected INamespace
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static INamespace ComputeLibraryNamespaceOperation(this IElement elementSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return a unique description of the location of this Element in the containment structure rooted in a
+        /// root Namespace. If the Element has a non-null qualifiedName, then return that. Otherwise, if it has
+        /// an owningRelationship, then return the string constructed by appending to the path of it's
+        /// owningRelationship the character / followed by the string representation of its position in the list
+        /// of ownedRelatedElements of the owningRelationship (indexed starting at 1). Otherwise, return the
+        /// empty string.                            (Note that this operation is overridden for Relationships
+        /// to use owningRelatedElement when appropriate.)
+        /// </summary>
+        /// <param name="elementSubject">
+        /// The subject <see cref="IElement"/>
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static string ComputePathOperation(this IElement elementSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/EnumerationDefinitionExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/EnumerationDefinitionExtensions.cs
@@ -60,14 +60,14 @@ namespace SysML2.NET.Core.POCO.Systems.Enumerations
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="enumerationDefinition">
+        /// <param name="enumerationDefinitionSubject">
         /// The subject <see cref="IEnumerationDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IEnumerationUsage> ComputeEnumeratedValue(this IEnumerationDefinition enumerationDefinition)
+        internal static List<IEnumerationUsage> ComputeEnumeratedValue(this IEnumerationDefinition enumerationDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/FeatureExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/FeatureExtensions.cs
@@ -38,14 +38,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeature> ComputeChainingFeature(this IFeature feature)
+        internal static List<IFeature> ComputeChainingFeature(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -53,14 +53,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeCrossFeature(this IFeature feature)
+        internal static IFeature ComputeCrossFeature(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -68,14 +68,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IType ComputeEndOwningType(this IFeature feature)
+        internal static IType ComputeEndOwningType(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -83,14 +83,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeFeatureTarget(this IFeature feature)
+        internal static IFeature ComputeFeatureTarget(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -98,14 +98,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IType> ComputeFeaturingType(this IFeature feature)
+        internal static List<IType> ComputeFeaturingType(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -113,14 +113,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static ICrossSubsetting ComputeOwnedCrossSubsetting(this IFeature feature)
+        internal static ICrossSubsetting ComputeOwnedCrossSubsetting(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -128,14 +128,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeatureChaining> ComputeOwnedFeatureChaining(this IFeature feature)
+        internal static List<IFeatureChaining> ComputeOwnedFeatureChaining(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -143,14 +143,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeatureInverting> ComputeOwnedFeatureInverting(this IFeature feature)
+        internal static List<IFeatureInverting> ComputeOwnedFeatureInverting(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -158,14 +158,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IRedefinition> ComputeOwnedRedefinition(this IFeature feature)
+        internal static List<IRedefinition> ComputeOwnedRedefinition(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -173,14 +173,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IReferenceSubsetting ComputeOwnedReferenceSubsetting(this IFeature feature)
+        internal static IReferenceSubsetting ComputeOwnedReferenceSubsetting(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -188,14 +188,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<ISubsetting> ComputeOwnedSubsetting(this IFeature feature)
+        internal static List<ISubsetting> ComputeOwnedSubsetting(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -203,14 +203,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<ITypeFeaturing> ComputeOwnedTypeFeaturing(this IFeature feature)
+        internal static List<ITypeFeaturing> ComputeOwnedTypeFeaturing(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -218,14 +218,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeatureTyping> ComputeOwnedTyping(this IFeature feature)
+        internal static List<IFeatureTyping> ComputeOwnedTyping(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -233,14 +233,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeatureMembership ComputeOwningFeatureMembership(this IFeature feature)
+        internal static IFeatureMembership ComputeOwningFeatureMembership(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -248,14 +248,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IType ComputeOwningType(this IFeature feature)
+        internal static IType ComputeOwningType(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -263,17 +263,345 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IType> ComputeType(this IFeature feature)
+        internal static List<IType> ComputeType(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// Return the directionOf this Feature relative to the given type.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <param name="type">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected FeatureDirectionKind
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static FeatureDirectionKind ComputeDirectionForOperation(this IFeature featureSubject, IType type)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// If a Feature has no declaredShortName or declaredName, then its effective shortName is given by the
+        /// effective shortName of the Feature returned by the namingFeature() operation, if any.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static string ComputeRedefinedEffectiveShortNameOperation(this IFeature featureSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// If a Feature has no declaredName or declaredShortName                            , then its
+        /// effective name is given by the effective name of the Feature returned by the namingFeature()
+        /// operation, if any.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static string ComputeRedefinedEffectiveNameOperation(this IFeature featureSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// By default, the naming Feature of a Feature is given by its first redefinedFeature of its first
+        /// ownedRedefinition, if any.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IFeature ComputeNamingFeatureOperation(this IFeature featureSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <param name="excludeImplied">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IType
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IType ComputeRedefinedSupertypesOperation(this IFeature featureSubject, bool excludeImplied)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Check whether this Feature directly redefines the given redefinedFeature.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <param name="redefinedFeature">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeRedefinesOperation(this IFeature featureSubject, IFeature redefinedFeature)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Check whether this Feature directly redefines the named library Feature. libraryFeatureName must
+        /// conform to the syntax of a KerML qualified name and must resolve to a Feature in global scope.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <param name="libraryFeatureName">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeRedefinesFromLibraryOperation(this IFeature featureSubject, string libraryFeatureName)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Check whether this Feature directly or indirectly specializes a Feature whose last two
+        /// chainingFeatures are the given Features first and second.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <param name="first">
+        /// No documentation provided
+        /// </param>
+        /// <param name="second">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeSubsetsChainOperation(this IFeature featureSubject, IFeature first, IFeature second)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// A Feature is compatible with an otherType if it either directly or indirectly specializes the
+        /// otherType or if the otherType is also a Feature and all of the following are true.                  
+        ///          <ol>                            <li>Neither this Feature or the otherType have any
+        /// ownedFeatures.</li>                            <li>This Feature directly or indirectly redefines a
+        /// Feature that is also directly or indirectly redefined by the otherType.</li>                        
+        /// <li>This Feature can access the otherType.                            </li></ol>
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <param name="otherType">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeRedefinedIsCompatibleWithOperation(this IFeature featureSubject, IType otherType)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return the Features used to determine the types of this Feature (other than this Feature itself). If
+        /// this Feature is not conjugated, then the typingFeatures consist of all subsetted Features, except
+        /// from CrossSubsetting, and the last chainingFeature (if any). If this Feature is conjugated, then the
+        /// typingFeatures are only its originalType (if the originalType is a Feature).                        
+        ///    <strong>Note.</strong> CrossSubsetting is excluded from the determination of the type of a
+        /// Feature in order to avoid circularity in the construction of implied CrossSubsetting relationships.
+        /// The validateFeatureCrossFeatureType requires that the crossFeature of a Feature have the same type
+        /// as the Feature.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IFeature ComputeTypingFeaturesOperation(this IFeature featureSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// If isCartesianProduct is true, then return the list of Types whose Cartesian product can be
+        /// represented by this Feature. (If isCartesianProduct is not true, the operation will still return a
+        /// valid value, it will just not represent anything useful.)
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <returns>
+        /// The expected IType
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IType ComputeAsCartesianProductOperation(this IFeature featureSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Check whether this Feature can be used to represent a Cartesian product of Types.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeIsCartesianProductOperation(this IFeature featureSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return whether this Feature is an owned cross Feature of an end Feature.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeIsOwnedCrossFeatureOperation(this IFeature featureSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// If this Feature is an end Feature of its owningType, then return the first ownedMember of the
+        /// Feature that is a Feature, but not a Multiplicity or a MetadataFeature, and whose owningMembership
+        /// is not a FeatureMembership. If this exists, it is the crossFeature of the end Feature.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IFeature ComputeOwnedCrossFeatureOperation(this IFeature featureSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return this Feature and all the Features that are directly or indirectly Redefined by this Feature.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IFeature ComputeAllRedefinedFeaturesOperation(this IFeature featureSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return if the featuringTypes of this Feature are compatible with the given type. If type is null,
+        /// then check if this Feature is explicitly or implicitly featured by Base::Anything. If this Feature
+        /// has isVariable = true, then also consider it to be featured within its owningType. If this Feature
+        /// is a feature chain whose first chainingFeature has isVariable = true, then also consider it to be
+        /// featured within the owningType of its first chainingFeature.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <param name="type">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeIsFeaturedWithinOperation(this IFeature featureSubject, IType type)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// A Feature can access another feature if the other feature is featured within one of the direct or
+        /// indirect featuringTypes of this Feature.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <param name="feature">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeCanAccessOperation(this IFeature featureSubject, IFeature feature)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return whether the given type must be a featuringType of this Feature. If this Feature has
+        /// isVariable = false, then return true if the type is the owningType of the Feature. If isVariable =
+        /// true, then return true if the type is a Feature representing the snapshots of the owningType of this
+        /// Feature.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <param name="type">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeIsFeaturingTypeOperation(this IFeature featureSubject, IType type)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/FeatureTypingExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/FeatureTypingExtensions.cs
@@ -37,14 +37,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="featureTyping">
+        /// <param name="featureTypingSubject">
         /// The subject <see cref="IFeatureTyping"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeOwningFeature(this IFeatureTyping featureTyping)
+        internal static IFeature ComputeOwningFeature(this IFeatureTyping featureTypingSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/FlowExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/FlowExtensions.cs
@@ -43,14 +43,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Interactions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="flow">
+        /// <param name="flowSubject">
         /// The subject <see cref="IFlow"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFlowEnd> ComputeFlowEnd(this IFlow flow)
+        internal static List<IFlowEnd> ComputeFlowEnd(this IFlow flowSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -58,14 +58,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Interactions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="flow">
+        /// <param name="flowSubject">
         /// The subject <see cref="IFlow"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IInteraction> ComputeInteraction(this IFlow flow)
+        internal static List<IInteraction> ComputeInteraction(this IFlow flowSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -73,14 +73,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Interactions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="flow">
+        /// <param name="flowSubject">
         /// The subject <see cref="IFlow"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IPayloadFeature ComputePayloadFeature(this IFlow flow)
+        internal static IPayloadFeature ComputePayloadFeature(this IFlow flowSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -88,14 +88,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Interactions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="flow">
+        /// <param name="flowSubject">
         /// The subject <see cref="IFlow"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IClassifier> ComputePayloadType(this IFlow flow)
+        internal static List<IClassifier> ComputePayloadType(this IFlow flowSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -103,14 +103,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Interactions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="flow">
+        /// <param name="flowSubject">
         /// The subject <see cref="IFlow"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeSourceOutputFeature(this IFlow flow)
+        internal static IFeature ComputeSourceOutputFeature(this IFlow flowSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -118,14 +118,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Interactions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="flow">
+        /// <param name="flowSubject">
         /// The subject <see cref="IFlow"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeTargetInputFeature(this IFlow flow)
+        internal static IFeature ComputeTargetInputFeature(this IFlow flowSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/FramedConcernMembershipExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/FramedConcernMembershipExtensions.cs
@@ -41,14 +41,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="framedConcernMembership">
+        /// <param name="framedConcernMembershipSubject">
         /// The subject <see cref="IFramedConcernMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IConcernUsage ComputeOwnedConcern(this IFramedConcernMembership framedConcernMembership)
+        internal static IConcernUsage ComputeOwnedConcern(this IFramedConcernMembership framedConcernMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -56,14 +56,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="framedConcernMembership">
+        /// <param name="framedConcernMembershipSubject">
         /// The subject <see cref="IFramedConcernMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IConcernUsage ComputeReferencedConcern(this IFramedConcernMembership framedConcernMembership)
+        internal static IConcernUsage ComputeReferencedConcern(this IFramedConcernMembership framedConcernMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/MembershipExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/MembershipExtensions.cs
@@ -36,14 +36,14 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="membership">
+        /// <param name="membershipSubject">
         /// The subject <see cref="IMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static string ComputeMemberElementId(this IMembership membership)
+        internal static string ComputeMemberElementId(this IMembership membershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -51,17 +51,38 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="membership">
+        /// <param name="membershipSubject">
         /// The subject <see cref="IMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static INamespace ComputeMembershipOwningNamespace(this IMembership membership)
+        internal static INamespace ComputeMembershipOwningNamespace(this IMembership membershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// Whether this Membership is distinguishable from a given other Membership. By default, this is true
+        /// if this Membership has no memberShortName or memberName; or each of the memberShortName and
+        /// memberName are different than both of those of the other Membership; or neither of the metaclasses
+        /// of the memberElement of this Membership and the memberElement of the other Membership conform to the
+        /// other. But this may be overridden in specializations of Membership.
+        /// </summary>
+        /// <param name="membershipSubject">
+        /// The subject <see cref="IMembership"/>
+        /// </param>
+        /// <param name="other">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeIsDistinguishableFromOperation(this IMembership membershipSubject, IMembership other)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/MultiplicityRangeExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/MultiplicityRangeExtensions.cs
@@ -40,14 +40,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Multiplicities
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="multiplicityRange">
+        /// <param name="multiplicityRangeSubject">
         /// The subject <see cref="IMultiplicityRange"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IExpression> ComputeBound(this IMultiplicityRange multiplicityRange)
+        internal static List<IExpression> ComputeBound(this IMultiplicityRange multiplicityRangeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -55,14 +55,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Multiplicities
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="multiplicityRange">
+        /// <param name="multiplicityRangeSubject">
         /// The subject <see cref="IMultiplicityRange"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IExpression ComputeLowerBound(this IMultiplicityRange multiplicityRange)
+        internal static IExpression ComputeLowerBound(this IMultiplicityRange multiplicityRangeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -70,17 +70,57 @@ namespace SysML2.NET.Core.POCO.Kernel.Multiplicities
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="multiplicityRange">
+        /// <param name="multiplicityRangeSubject">
         /// The subject <see cref="IMultiplicityRange"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IExpression ComputeUpperBound(this IMultiplicityRange multiplicityRange)
+        internal static IExpression ComputeUpperBound(this IMultiplicityRange multiplicityRangeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// Check whether this MultiplicityRange represents the range bounded by the given values lower and
+        /// upper, presuming the lowerBound and upperBound Expressions are model-level evaluable.
+        /// </summary>
+        /// <param name="multiplicityRangeSubject">
+        /// The subject <see cref="IMultiplicityRange"/>
+        /// </param>
+        /// <param name="lower">
+        /// No documentation provided
+        /// </param>
+        /// <param name="upper">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeHasBoundsOperation(this IMultiplicityRange multiplicityRangeSubject, int lower, string upper)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Evaluate the given bound Expression (at model level) and return the result represented as a MOF
+        /// UnlimitedNatural value.
+        /// </summary>
+        /// <param name="multiplicityRangeSubject">
+        /// The subject <see cref="IMultiplicityRange"/>
+        /// </param>
+        /// <param name="bound">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static string ComputeValueOfOperation(this IMultiplicityRange multiplicityRangeSubject, IExpression bound)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/OwningMembershipExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/OwningMembershipExtensions.cs
@@ -36,14 +36,14 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="owningMembership">
+        /// <param name="owningMembershipSubject">
         /// The subject <see cref="IOwningMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IElement ComputeOwnedMemberElement(this IOwningMembership owningMembership)
+        internal static IElement ComputeOwnedMemberElement(this IOwningMembership owningMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -51,14 +51,14 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="owningMembership">
+        /// <param name="owningMembershipSubject">
         /// The subject <see cref="IOwningMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static string ComputeOwnedMemberElementId(this IOwningMembership owningMembership)
+        internal static string ComputeOwnedMemberElementId(this IOwningMembership owningMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -66,14 +66,14 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="owningMembership">
+        /// <param name="owningMembershipSubject">
         /// The subject <see cref="IOwningMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static string ComputeOwnedMemberName(this IOwningMembership owningMembership)
+        internal static string ComputeOwnedMemberName(this IOwningMembership owningMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -81,17 +81,33 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="owningMembership">
+        /// <param name="owningMembershipSubject">
         /// The subject <see cref="IOwningMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static string ComputeOwnedMemberShortName(this IOwningMembership owningMembership)
+        internal static string ComputeOwnedMemberShortName(this IOwningMembership owningMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// If the ownedMemberElement of this OwningMembership has a non-null qualifiedName, then return the
+        /// string constructed by appending to that qualifiedName the string "/owningMembership". Otherwise,
+        /// return the path of the OwningMembership as specified for a Relationship in general.
+        /// </summary>
+        /// <param name="owningMembershipSubject">
+        /// The subject <see cref="IOwningMembership"/>
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static string ComputeRedefinedPathOperation(this IOwningMembership owningMembershipSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/ReferenceSubsettingExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/ReferenceSubsettingExtensions.cs
@@ -37,14 +37,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="referenceSubsetting">
+        /// <param name="referenceSubsettingSubject">
         /// The subject <see cref="IReferenceSubsetting"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeReferencingFeature(this IReferenceSubsetting referenceSubsetting)
+        internal static IFeature ComputeReferencingFeature(this IReferenceSubsetting referenceSubsettingSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/RelationshipExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/RelationshipExtensions.cs
@@ -35,17 +35,50 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="relationship">
+        /// <param name="relationshipSubject">
         /// The subject <see cref="IRelationship"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IElement> ComputeRelatedElement(this IRelationship relationship)
+        internal static List<IElement> ComputeRelatedElement(this IRelationship relationshipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// Return whether this Relationship has either an owningRelatedElement or owningRelationship that is a
+        /// library element.
+        /// </summary>
+        /// <param name="relationshipSubject">
+        /// The subject <see cref="IRelationship"/>
+        /// </param>
+        /// <returns>
+        /// The expected INamespace
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static INamespace ComputeRedefinedLibraryNamespaceOperation(this IRelationship relationshipSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// If the owningRelationship of the Relationship is null but its owningRelatedElement is non-null,
+        /// construct the path using the position of the Relationship in the list of ownedRelationships of its
+        /// owningRelatedElement. Otherwise, return the path of the Relationship as specified for an Element in
+        /// general.
+        /// </summary>
+        /// <param name="relationshipSubject">
+        /// The subject <see cref="IRelationship"/>
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static string ComputeRedefinedPathOperation(this IRelationship relationshipSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/RequirementUsageExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/RequirementUsageExtensions.cs
@@ -65,14 +65,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementUsage">
+        /// <param name="requirementUsageSubject">
         /// The subject <see cref="IRequirementUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IPartUsage> ComputeActorParameter(this IRequirementUsage requirementUsage)
+        internal static List<IPartUsage> ComputeActorParameter(this IRequirementUsage requirementUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -80,14 +80,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementUsage">
+        /// <param name="requirementUsageSubject">
         /// The subject <see cref="IRequirementUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IConstraintUsage> ComputeAssumedConstraint(this IRequirementUsage requirementUsage)
+        internal static List<IConstraintUsage> ComputeAssumedConstraint(this IRequirementUsage requirementUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -95,14 +95,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementUsage">
+        /// <param name="requirementUsageSubject">
         /// The subject <see cref="IRequirementUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IConcernUsage> ComputeFramedConcern(this IRequirementUsage requirementUsage)
+        internal static List<IConcernUsage> ComputeFramedConcern(this IRequirementUsage requirementUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -110,14 +110,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementUsage">
+        /// <param name="requirementUsageSubject">
         /// The subject <see cref="IRequirementUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IConstraintUsage> ComputeRequiredConstraint(this IRequirementUsage requirementUsage)
+        internal static List<IConstraintUsage> ComputeRequiredConstraint(this IRequirementUsage requirementUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -125,14 +125,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementUsage">
+        /// <param name="requirementUsageSubject">
         /// The subject <see cref="IRequirementUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IRequirementDefinition ComputeRequirementDefinition(this IRequirementUsage requirementUsage)
+        internal static IRequirementDefinition ComputeRequirementDefinition(this IRequirementUsage requirementUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -140,14 +140,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementUsage">
+        /// <param name="requirementUsageSubject">
         /// The subject <see cref="IRequirementUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IPartUsage> ComputeStakeholderParameter(this IRequirementUsage requirementUsage)
+        internal static List<IPartUsage> ComputeStakeholderParameter(this IRequirementUsage requirementUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -155,14 +155,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementUsage">
+        /// <param name="requirementUsageSubject">
         /// The subject <see cref="IRequirementUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IUsage ComputeSubjectParameter(this IRequirementUsage requirementUsage)
+        internal static IUsage ComputeSubjectParameter(this IRequirementUsage requirementUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -170,14 +170,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementUsage">
+        /// <param name="requirementUsageSubject">
         /// The subject <see cref="IRequirementUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<string> ComputeText(this IRequirementUsage requirementUsage)
+        internal static List<string> ComputeText(this IRequirementUsage requirementUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/SubclassificationExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/SubclassificationExtensions.cs
@@ -37,14 +37,14 @@ namespace SysML2.NET.Core.POCO.Core.Classifiers
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="subclassification">
+        /// <param name="subclassificationSubject">
         /// The subject <see cref="ISubclassification"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IClassifier ComputeOwningClassifier(this ISubclassification subclassification)
+        internal static IClassifier ComputeOwningClassifier(this ISubclassification subclassificationSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/TextualRepresentationExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/TextualRepresentationExtensions.cs
@@ -35,14 +35,14 @@ namespace SysML2.NET.Core.POCO.Root.Annotations
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="textualRepresentation">
+        /// <param name="textualRepresentationSubject">
         /// The subject <see cref="ITextualRepresentation"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IElement ComputeRepresentedElement(this ITextualRepresentation textualRepresentation)
+        internal static IElement ComputeRepresentedElement(this ITextualRepresentation textualRepresentationSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/UsageExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtend/UsageExtensions.cs
@@ -61,14 +61,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IClassifier> ComputeDefinition(this IUsage usage)
+        internal static List<IClassifier> ComputeDefinition(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -76,14 +76,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IUsage> ComputeDirectedUsage(this IUsage usage)
+        internal static List<IUsage> ComputeDirectedUsage(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -91,14 +91,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static bool ComputeIsReference(this IUsage usage)
+        internal static bool ComputeIsReference(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -106,14 +106,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static bool ComputeMayTimeVary(this IUsage usage)
+        internal static bool ComputeMayTimeVary(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -121,14 +121,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IActionUsage> ComputeNestedAction(this IUsage usage)
+        internal static List<IActionUsage> ComputeNestedAction(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -136,14 +136,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IAllocationUsage> ComputeNestedAllocation(this IUsage usage)
+        internal static List<IAllocationUsage> ComputeNestedAllocation(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -151,14 +151,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IAnalysisCaseUsage> ComputeNestedAnalysisCase(this IUsage usage)
+        internal static List<IAnalysisCaseUsage> ComputeNestedAnalysisCase(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -166,14 +166,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IAttributeUsage> ComputeNestedAttribute(this IUsage usage)
+        internal static List<IAttributeUsage> ComputeNestedAttribute(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -181,14 +181,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<ICalculationUsage> ComputeNestedCalculation(this IUsage usage)
+        internal static List<ICalculationUsage> ComputeNestedCalculation(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -196,14 +196,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<ICaseUsage> ComputeNestedCase(this IUsage usage)
+        internal static List<ICaseUsage> ComputeNestedCase(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -211,14 +211,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IConcernUsage> ComputeNestedConcern(this IUsage usage)
+        internal static List<IConcernUsage> ComputeNestedConcern(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -226,14 +226,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IConnectorAsUsage> ComputeNestedConnection(this IUsage usage)
+        internal static List<IConnectorAsUsage> ComputeNestedConnection(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -241,14 +241,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IConstraintUsage> ComputeNestedConstraint(this IUsage usage)
+        internal static List<IConstraintUsage> ComputeNestedConstraint(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -256,14 +256,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IEnumerationUsage> ComputeNestedEnumeration(this IUsage usage)
+        internal static List<IEnumerationUsage> ComputeNestedEnumeration(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -271,14 +271,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFlowUsage> ComputeNestedFlow(this IUsage usage)
+        internal static List<IFlowUsage> ComputeNestedFlow(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -286,14 +286,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IInterfaceUsage> ComputeNestedInterface(this IUsage usage)
+        internal static List<IInterfaceUsage> ComputeNestedInterface(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -301,14 +301,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IItemUsage> ComputeNestedItem(this IUsage usage)
+        internal static List<IItemUsage> ComputeNestedItem(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -316,14 +316,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IMetadataUsage> ComputeNestedMetadata(this IUsage usage)
+        internal static List<IMetadataUsage> ComputeNestedMetadata(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -331,14 +331,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IOccurrenceUsage> ComputeNestedOccurrence(this IUsage usage)
+        internal static List<IOccurrenceUsage> ComputeNestedOccurrence(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -346,14 +346,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IPartUsage> ComputeNestedPart(this IUsage usage)
+        internal static List<IPartUsage> ComputeNestedPart(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -361,14 +361,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IPortUsage> ComputeNestedPort(this IUsage usage)
+        internal static List<IPortUsage> ComputeNestedPort(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -376,14 +376,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IReferenceUsage> ComputeNestedReference(this IUsage usage)
+        internal static List<IReferenceUsage> ComputeNestedReference(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -391,14 +391,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IRenderingUsage> ComputeNestedRendering(this IUsage usage)
+        internal static List<IRenderingUsage> ComputeNestedRendering(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -406,14 +406,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IRequirementUsage> ComputeNestedRequirement(this IUsage usage)
+        internal static List<IRequirementUsage> ComputeNestedRequirement(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -421,14 +421,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IStateUsage> ComputeNestedState(this IUsage usage)
+        internal static List<IStateUsage> ComputeNestedState(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -436,14 +436,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<ITransitionUsage> ComputeNestedTransition(this IUsage usage)
+        internal static List<ITransitionUsage> ComputeNestedTransition(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -451,14 +451,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IUsage> ComputeNestedUsage(this IUsage usage)
+        internal static List<IUsage> ComputeNestedUsage(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -466,14 +466,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IUseCaseUsage> ComputeNestedUseCase(this IUsage usage)
+        internal static List<IUseCaseUsage> ComputeNestedUseCase(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -481,14 +481,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IVerificationCaseUsage> ComputeNestedVerificationCase(this IUsage usage)
+        internal static List<IVerificationCaseUsage> ComputeNestedVerificationCase(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -496,14 +496,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IViewUsage> ComputeNestedView(this IUsage usage)
+        internal static List<IViewUsage> ComputeNestedView(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -511,14 +511,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IViewpointUsage> ComputeNestedViewpoint(this IUsage usage)
+        internal static List<IViewpointUsage> ComputeNestedViewpoint(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -526,14 +526,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IDefinition ComputeOwningDefinition(this IUsage usage)
+        internal static IDefinition ComputeOwningDefinition(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -541,14 +541,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IUsage ComputeOwningUsage(this IUsage usage)
+        internal static IUsage ComputeOwningUsage(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -556,14 +556,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IUsage> ComputeUsage(this IUsage usage)
+        internal static List<IUsage> ComputeUsage(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -571,14 +571,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IUsage> ComputeVariant(this IUsage usage)
+        internal static List<IUsage> ComputeVariant(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -586,17 +586,48 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IVariantMembership> ComputeVariantMembership(this IUsage usage)
+        internal static List<IVariantMembership> ComputeVariantMembership(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// If this Usage is a variant, then its naming Feature is the referencedFeature of its
+        /// ownedReferenceSubsetting.
+        /// </summary>
+        /// <param name="usageSubject">
+        /// The subject <see cref="IUsage"/>
+        /// </param>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IFeature ComputeRedefinedNamingFeatureOperation(this IUsage usageSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// If ownedReferenceSubsetting is not null, return the featureTarget of the referencedFeature of the
+        /// ownedReferenceSubsetting.
+        /// </summary>
+        /// <param name="usageSubject">
+        /// The subject <see cref="IUsage"/>
+        /// </param>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IFeature ComputeReferencedFeatureTargetOperation(this IUsage usageSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET.CodeGenerator/Extensions/TypeExtensions.cs
+++ b/SysML2.NET.CodeGenerator/Extensions/TypeExtensions.cs
@@ -1,0 +1,54 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="TypeExtensions.cs" company="Starion Group S.A.">
+// 
+//   Copyright 2022-2026 Starion Group S.A.
+// 
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.CodeGenerator.Extensions
+{
+    using uml4net.Classification;
+    using uml4net.CommonStructure;
+    using uml4net.StructuredClassifiers;
+
+    /// <summary>
+    /// Extension methods for the <see cref="IType"/> interface
+    /// </summary>
+    public static class TypeExtensions
+    {
+        /// <summary>
+        /// Queries the C# Type name of the <see cref="IType"/>
+        /// </summary>
+        /// <param name="type">
+        /// The <see cref="IType"/> for which the C# Type name is to be queried
+        /// </param>
+        /// <param name="shouldTargetInterface">Asserts that the type name should target the interface name in case of an <see cref="IClassifier"/></param>
+        /// <returns>
+        /// a string representation of the C# Type name
+        /// </returns>
+        public static string QueryCSharpTypeName(this IType type, bool shouldTargetInterface)
+        {
+            var typeName = uml4net.Extensions.TypeExtensions.QueryCSharpTypeName(type);
+
+            if (shouldTargetInterface && type is IClass)
+            {
+                typeName = $"I{typeName}";
+            }
+
+            return typeName;
+        }
+    }
+}

--- a/SysML2.NET.CodeGenerator/Generators/UmlHandleBarsGenerators/UmlCorePocoGenerator.cs
+++ b/SysML2.NET.CodeGenerator/Generators/UmlHandleBarsGenerators/UmlCorePocoGenerator.cs
@@ -26,6 +26,7 @@ namespace SysML2.NET.CodeGenerator.Generators.UmlHandleBarsGenerators
     using System.Threading.Tasks;
 
     using SysML2.NET.CodeGenerator.Extensions;
+    using SysML2.NET.CodeGenerator.HandleBarHelpers;
     using SysML2.NET.CodeGenerator.UmlHandleBarHelpers;
 
     using uml4net.Extensions;
@@ -138,13 +139,14 @@ namespace SysML2.NET.CodeGenerator.Generators.UmlHandleBarsGenerators
         {
             this.Handlebars.RegisterStringHelper();
             this.Handlebars.RegisterEnumerableHelper();
-            this.Handlebars.RegisterClassHelper();
-            this.Handlebars.RegisterPropertyHelper();
+            uml4net.HandleBars.ClassHelper.RegisterClassHelper(this.Handlebars);
+            uml4net.HandleBars.PropertyHelper.RegisterPropertyHelper(this.Handlebars);
             this.Handlebars.RegisterGeneralizationHelper();
             this.Handlebars.RegisterDocumentationHelper();
             this.Handlebars.RegisterEnumHelper();
             this.Handlebars.RegisterDecoratorHelper();
-            this.Handlebars.RegisterNamedElementHelper();
+            uml4net.HandleBars.NamedElementHelper.RegisterNamedElementHelper(this.Handlebars);
+            this.Handlebars.RegisterOperationHelper();
 
             EnumerationLiteralHelper.RegisterTypeNameHelper(this.Handlebars);
             ClassHelper.RegisterClassHelper(this.Handlebars);

--- a/SysML2.NET.CodeGenerator/Generators/UmlHandleBarsGenerators/UmlPocoClassExtensionsGenerator.cs
+++ b/SysML2.NET.CodeGenerator/Generators/UmlHandleBarsGenerators/UmlPocoClassExtensionsGenerator.cs
@@ -26,6 +26,7 @@ namespace SysML2.NET.CodeGenerator.Generators.UmlHandleBarsGenerators
     using System.Threading.Tasks;
 
     using SysML2.NET.CodeGenerator.Extensions;
+    using SysML2.NET.CodeGenerator.HandleBarHelpers;
     using SysML2.NET.CodeGenerator.UmlHandleBarHelpers;
 
     using uml4net.Extensions;
@@ -95,7 +96,7 @@ namespace SysML2.NET.CodeGenerator.Generators.UmlHandleBarsGenerators
 
             var classes = xmiReaderResult.QueryContainedAndImported("SysML")
                 .SelectMany(x => x.PackagedElement.OfType<IClass>())
-                .Where(x => x.OwnedAttribute.Select(y => y.IsDerived || y.IsDerivedUnion).Any())
+                .Where(x => x.OwnedAttribute.Select(y => y.IsDerived || y.IsDerivedUnion).Any() || x.OwnedOperation.Count != 0)
                 .ToList();
 
             foreach (var @class in classes)
@@ -163,14 +164,15 @@ namespace SysML2.NET.CodeGenerator.Generators.UmlHandleBarsGenerators
         {
             this.Handlebars.RegisterStringHelper();
             this.Handlebars.RegisterEnumerableHelper();
-            this.Handlebars.RegisterClassHelper();
-            this.Handlebars.RegisterPropertyHelper();
+            uml4net.HandleBars.ClassHelper.RegisterClassHelper(this.Handlebars);
+            uml4net.HandleBars.PropertyHelper.RegisterPropertyHelper(this.Handlebars);
             this.Handlebars.RegisterGeneralizationHelper();
             this.Handlebars.RegisterDocumentationHelper();
             this.Handlebars.RegisterEnumHelper();
             this.Handlebars.RegisterDecoratorHelper();
-            this.Handlebars.RegisterNamedElementHelper();
+            uml4net.HandleBars.NamedElementHelper.RegisterNamedElementHelper(this.Handlebars);
 
+            OperationHelper.RegisterOperationHelper(this.Handlebars);
             EnumerationLiteralHelper.RegisterTypeNameHelper(this.Handlebars);
             ClassHelper.RegisterClassHelper(this.Handlebars);
             NamedElementHelper.RegisterNamedElementHelper(this.Handlebars);

--- a/SysML2.NET.CodeGenerator/HandleBarHelpers/ClassHelper.cs
+++ b/SysML2.NET.CodeGenerator/HandleBarHelpers/ClassHelper.cs
@@ -62,6 +62,13 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                     uniqueNamespaces.Add(Extensions.NamedElementExtensions.QueryNamespace(prop.Type));
                 }
 
+                var parameters = @class.OwnedOperation.SelectMany(x => x.OwnedParameter);
+
+                foreach (var enumeration in parameters.Where(x => x.Type is IEnumeration).Select(x => x.Type as IEnumeration))
+                {
+                    uniqueNamespaces.Add(Extensions.NamedElementExtensions.QueryNamespace(enumeration));
+                }
+
                 var orderedNamespaces = uniqueNamespaces.Order().ToList();
 
                 foreach (var orderedNamespace in orderedNamespaces)
@@ -125,8 +132,16 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                             uniqueNamespaces.Add(@namespace);
                         }
                     }
+                    
+                    foreach (var operation in @class.OwnedOperation)
+                    {
+                        foreach (var parameterType in operation.OwnedParameter.Where(x => x.Type is IClass).Select(x => x.Type as IClass))
+                        {
+                            uniqueNamespaces.Add(Extensions.NamedElementExtensions.QueryNamespace(parameterType));
+                        }
+                    }
                 }
-
+                
                 uniqueNamespaces.Remove(Extensions.NamedElementExtensions.QueryNamespace(@class));
                 var orderedNamespaces = uniqueNamespaces.Order().ToList();
 

--- a/SysML2.NET.CodeGenerator/HandleBarHelpers/OperationHelper.cs
+++ b/SysML2.NET.CodeGenerator/HandleBarHelpers/OperationHelper.cs
@@ -1,0 +1,189 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="OperationHelper.cs" company="Starion Group S.A.">
+// 
+//   Copyright 2022-2026 Starion Group S.A.
+// 
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.CodeGenerator.HandleBarHelpers
+{
+    using System;
+    using System.Linq;
+    using System.Text;
+
+    using HandlebarsDotNet;
+
+    using SysML2.NET.CodeGenerator.Extensions;
+
+    using uml4net.Classification;
+    using uml4net.Extensions;
+    using uml4net.StructuredClassifiers;
+
+    /// <summary>
+    /// A handlebars block helper for the <see cref="IOperation"/> interface
+    /// </summary>
+    public static class OperationHelper
+    {
+        /// <summary>
+        /// Registers the <see cref="OperationHelper"/>
+        /// </summary>
+        /// <param name="handlebars">
+        /// The <see cref="IHandlebars"/> context with which the helper needs to be registered
+        /// </param>
+        public static void RegisterOperationHelper(this IHandlebars handlebars)
+        {
+            handlebars.RegisterHelper("Operation.WriteForPOCOInterface", (writer, _, arguments) =>
+            {
+                if (arguments.Length != 1)
+                {
+                    throw new ArgumentException("Operation.WriteForPOCOInterface requires exactly one argument");
+                }
+
+                if (arguments[0] is not IOperation operation)
+                {
+                    throw new ArgumentException("Operation.WriteForPOCOInterface argument must be an IOperation");
+                }
+
+                if (operation.RedefinedOperation.Any(x => x.Name == operation.Name))
+                {
+                    writer.WriteSafeString("new ");
+                }
+
+                var returnParameter = operation.OwnedParameter.SingleOrDefault(x => x.Direction == ParameterDirectionKind.Return);
+
+                writer.WriteSafeString(returnParameter?.Type == null ? "void" : $"{returnParameter.Type.QueryCSharpTypeName(true)}");
+
+                var methodName = operation.RedefinedOperation.Any(x => x.Name == operation.Name) ? $"ComputeRedefined{operation.Name.CapitalizeFirstLetter()}Operation" : $"Compute{operation.Name.CapitalizeFirstLetter()}Operation";
+                writer.WriteSafeString($" {operation.Name.CapitalizeFirstLetter()}("); 
+                var inputParameters = operation.OwnedParameter.Where(x => x.Direction != ParameterDirectionKind.Return).ToList();
+
+                writer.WriteSafeString(string.Join(", ", inputParameters.Select(x => $"{x.Type.QueryCSharpTypeName(true)} {x.Name.LowerCaseFirstLetter()}")));
+                writer.WriteSafeString($") => this.{methodName}(");
+                writer.WriteSafeString(string.Join(", ", inputParameters.Select(x => $"{x.Name.LowerCaseFirstLetter()}")));
+                writer.WriteSafeString($");{Environment.NewLine}");
+            });
+            
+            handlebars.RegisterHelper("ParameterDocumentation", (writer, _, arguments) =>
+            {
+                if (arguments.Length != 1)
+                {
+                    throw new ArgumentException("ParameterDocumentation requires exactly one argument");
+                }
+
+                if (arguments[0] is not IOperation operation)
+                {
+                    throw new ArgumentException("ParameterDocumentation argument must be an IOperation");
+                }
+                
+                var inputParameters = operation.OwnedParameter.Where(x => x.Direction != ParameterDirectionKind.Return).ToList();
+
+                foreach (var inputParameter in inputParameters)
+                {
+                    writer.WriteSafeString(ComputeInputParameterDocumentation(inputParameter));
+                }
+                
+                var returnParameter = operation.OwnedParameter.SingleOrDefault(x => x.Direction == ParameterDirectionKind.Return);
+
+                if (returnParameter?.Type != null)
+                {
+                    writer.WriteSafeString(ComputeReturnParameterDocumentation(returnParameter));
+                }
+            });
+            
+            handlebars.RegisterHelper("Operation.WriteForPOCOExtend", (writer, _, arguments) =>
+            {
+                if (arguments.Length != 1)
+                {
+                    throw new ArgumentException("Operation.WriteForPOCOExtend requires exactly one argument");
+                }
+
+                if (arguments[0] is not IOperation operation)
+                {
+                    throw new ArgumentException("Operation.WriteForPOCOExtend argument must be an IOperation");
+                }
+                
+                writer.WriteSafeString("internal static ");
+                
+                var returnParameter = operation.OwnedParameter.SingleOrDefault(x => x.Direction == ParameterDirectionKind.Return);
+
+                writer.WriteSafeString(returnParameter?.Type == null ? "void" : $"{returnParameter.Type.QueryCSharpTypeName(true)}");
+
+                var methodName = operation.RedefinedOperation.Any(x => x.Name == operation.Name) ? $"ComputeRedefined{operation.Name.CapitalizeFirstLetter()}Operation" : $"Compute{operation.Name.CapitalizeFirstLetter()}Operation";
+                var owner = (IClass)operation.Owner;
+                writer.WriteSafeString($" {methodName}(this I{owner.Name.CapitalizeFirstLetter()} {owner.Name.LowerCaseFirstLetter()}Subject");
+                
+                var inputParameters = operation.OwnedParameter.Where(x => x.Direction != ParameterDirectionKind.Return).ToList();
+
+                if (inputParameters.Count > 0)
+                {
+                    var parametersDefinition = string.Join(", ", inputParameters.Select(x => $"{x.Type.QueryCSharpTypeName(true)} {x.Name.LowerCaseFirstLetter()}"));
+                    writer.WriteSafeString($", {parametersDefinition}");
+                }
+                
+                writer.WriteSafeString($"){Environment.NewLine}");
+            });
+        }
+
+        /// <summary>
+        /// Compute the documentation for an input <see cref="IParameter"/>
+        /// </summary>
+        /// <param name="parameter">The <see cref="IParameter"/> that needs to have the documentation built</param>
+        /// <returns>The built documentation</returns>
+        private static string ComputeInputParameterDocumentation(IParameter parameter)
+        {
+            var stringBuilder = new StringBuilder();
+            stringBuilder.AppendLine($"/// <param name=\"{parameter.Name.LowerCaseFirstLetter()}\">");
+
+            var documentation = parameter.QueryDocumentation().ToList();
+
+            if (documentation.Count != 0)
+            {
+                stringBuilder.Append(string.Join("/// ", documentation.Select(x => $"{x} {Environment.NewLine}")));
+            }
+            else
+            {
+                stringBuilder.AppendLine("/// No documentation provided");
+            }
+
+            stringBuilder.AppendLine("/// </param>");
+            return stringBuilder.ToString();
+        }
+
+        /// <summary>
+        /// Compute the documentation for a return <see cref="IParameter"/>
+        /// </summary>
+        /// <param name="parameter">The <see cref="IParameter"/> that needs to have the documentation built</param>
+        /// <returns>The built documentation</returns>
+        private static string ComputeReturnParameterDocumentation(IParameter parameter)
+        {
+            var stringBuilder = new StringBuilder();
+            stringBuilder.AppendLine("/// <returns>");
+            var documentation = parameter.QueryDocumentation().ToList();
+
+            if (documentation.Count != 0)
+            {
+                stringBuilder.Append(string.Join("/// ", documentation.Select(x => $"{x} {Environment.NewLine}")));
+            }
+            else
+            {
+                stringBuilder.AppendLine($"/// The expected {parameter.Type.QueryCSharpTypeName(true)}");
+            }
+
+            stringBuilder.AppendLine("/// </returns>");
+            return stringBuilder.ToString();
+        }
+    }
+}

--- a/SysML2.NET.CodeGenerator/HandleBarHelpers/PropertyHelper.cs
+++ b/SysML2.NET.CodeGenerator/HandleBarHelpers/PropertyHelper.cs
@@ -300,7 +300,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                 {
                     if (property.QueryPropertyIsPartOfNonDerivedCompositeAggregation())
                     {
-                        sb.Append($"IReadOnlyCollection<{typeName}> ");
+                        sb.Append($"IReadOnlyList<{typeName}> ");
                     }
                     else
                     {
@@ -378,7 +378,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                 {
                     if (property.QueryPropertyIsPartOfNonDerivedCompositeAggregation())
                     {
-                        sb.Append($"IReadOnlyCollection<{typeName}> ");
+                        sb.Append($"IReadOnlyList<{typeName}> ");
                     }
                     else
                     {

--- a/SysML2.NET.CodeGenerator/Templates/Uml/core-poco-extend-uml-template.hbs
+++ b/SysML2.NET.CodeGenerator/Templates/Uml/core-poco-extend-uml-template.hbs
@@ -37,19 +37,34 @@ namespace SysML2.NET.Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace thi
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="{{String.LowerCaseFirstLetter ../this.Name}}">
+        /// <param name="{{String.LowerCaseFirstLetter ../this.Name}}Subject">
         /// The subject <see cref="I{{../this.Name}}"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static {{ Property.WriteTypeForExtendClass property }} Compute{{String.CapitalizeFirstLetter property.Name}}(this I{{../this.Name}} {{String.LowerCaseFirstLetter ../this.Name}})
+        internal static {{ Property.WriteTypeForExtendClass property }} Compute{{String.CapitalizeFirstLetter property.Name}}(this I{{../this.Name}} {{String.LowerCaseFirstLetter ../this.Name}}Subject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
         {{/if}}
+        {{/each}}
+        {{#each (this.OwnedOperation) as | operation | }}
+            {{ #Documentation operation }}
+            /// <param name="{{String.LowerCaseFirstLetter ../this.Name}}Subject">
+            /// The subject <see cref="I{{../this.Name}}"/>
+            /// </param>
+            {{ #ParameterDocumentation operation }}
+            [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+            {{ #Operation.WriteForPOCOExtend operation }}
+            {
+                throw new NotSupportedException("Create a GitHub issue when this method is required");
+            }
+            {{#unless @last}}
+        
+            {{/unless}}
         {{/each}}
     }
 }

--- a/SysML2.NET.CodeGenerator/Templates/Uml/core-poco-interface-uml-template.hbs
+++ b/SysML2.NET.CodeGenerator/Templates/Uml/core-poco-interface-uml-template.hbs
@@ -46,6 +46,14 @@ namespace SysML2.NET.Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace thi
         {{ #Property.WriteForPOCOInterface property }}
         
         {{/each}}
+        {{#each (this.OwnedOperation) as | operation | }}
+            {{ #Documentation operation }}
+            {{ #ParameterDocumentation operation }}
+            {{ #Operation.WriteForPOCOInterface operation }}
+            {{#unless @last}}
+            
+            {{/unless}}
+        {{/each}} 
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/AcceptActionUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/AcceptActionUsage.cs
@@ -922,7 +922,7 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ActionDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ActionDefinition.cs
@@ -606,7 +606,7 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ActionUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ActionUsage.cs
@@ -36,6 +36,7 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
     using SysML2.NET.Core.POCO.Core.Types;
     using SysML2.NET.Core.POCO.Kernel.Behaviors;
     using SysML2.NET.Core.POCO.Kernel.Classes;
+    using SysML2.NET.Core.POCO.Kernel.Functions;
     using SysML2.NET.Core.POCO.Root.Annotations;
     using SysML2.NET.Core.POCO.Root.Elements;
     using SysML2.NET.Core.POCO.Root.Namespaces;
@@ -920,7 +921,7 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ActorMembership.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ActorMembership.cs
@@ -290,7 +290,7 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -301,7 +301,7 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/AllocationDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/AllocationDefinition.cs
@@ -656,7 +656,7 @@ namespace SysML2.NET.Core.POCO.Systems.Allocations
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -667,7 +667,7 @@ namespace SysML2.NET.Core.POCO.Systems.Allocations
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/AllocationUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/AllocationUsage.cs
@@ -971,7 +971,7 @@ namespace SysML2.NET.Core.POCO.Systems.Allocations
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -982,7 +982,7 @@ namespace SysML2.NET.Core.POCO.Systems.Allocations
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/AnalysisCaseDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/AnalysisCaseDefinition.cs
@@ -649,7 +649,7 @@ namespace SysML2.NET.Core.POCO.Systems.AnalysisCases
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/AnalysisCaseUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/AnalysisCaseUsage.cs
@@ -979,7 +979,7 @@ namespace SysML2.NET.Core.POCO.Systems.AnalysisCases
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/AnnotatingElement.cs
+++ b/SysML2.NET/Core/AutoGenPoco/AnnotatingElement.cs
@@ -182,7 +182,7 @@ namespace SysML2.NET.Core.POCO.Root.Annotations
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Annotation.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Annotation.cs
@@ -191,7 +191,7 @@ namespace SysML2.NET.Core.POCO.Root.Annotations
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -202,7 +202,7 @@ namespace SysML2.NET.Core.POCO.Root.Annotations
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/AssertConstraintUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/AssertConstraintUsage.cs
@@ -953,7 +953,7 @@ namespace SysML2.NET.Core.POCO.Systems.Constraints
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/AssignmentActionUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/AssignmentActionUsage.cs
@@ -921,7 +921,7 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Association.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Association.cs
@@ -429,7 +429,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Associations
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -440,7 +440,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Associations
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/AssociationStructure.cs
+++ b/SysML2.NET/Core/AutoGenPoco/AssociationStructure.cs
@@ -431,7 +431,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Associations
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -442,7 +442,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Associations
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/AttributeDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/AttributeDefinition.cs
@@ -592,7 +592,7 @@ namespace SysML2.NET.Core.POCO.Systems.Attributes
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/AttributeUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/AttributeUsage.cs
@@ -894,7 +894,7 @@ namespace SysML2.NET.Core.POCO.Systems.Attributes
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Behavior.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Behavior.cs
@@ -407,7 +407,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Behaviors
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/BindingConnector.cs
+++ b/SysML2.NET/Core/AutoGenPoco/BindingConnector.cs
@@ -618,7 +618,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Connectors
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -629,7 +629,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Connectors
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/BindingConnectorAsUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/BindingConnectorAsUsage.cs
@@ -909,7 +909,7 @@ namespace SysML2.NET.Core.POCO.Systems.Connections
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -920,7 +920,7 @@ namespace SysML2.NET.Core.POCO.Systems.Connections
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/BooleanExpression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/BooleanExpression.cs
@@ -605,7 +605,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/CalculationDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/CalculationDefinition.cs
@@ -634,7 +634,7 @@ namespace SysML2.NET.Core.POCO.Systems.Calculations
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/CalculationUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/CalculationUsage.cs
@@ -948,7 +948,7 @@ namespace SysML2.NET.Core.POCO.Systems.Calculations
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/CaseDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/CaseDefinition.cs
@@ -651,7 +651,7 @@ namespace SysML2.NET.Core.POCO.Systems.Cases
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/CaseUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/CaseUsage.cs
@@ -970,7 +970,7 @@ namespace SysML2.NET.Core.POCO.Systems.Cases
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Class.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Class.cs
@@ -406,7 +406,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Classes
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Classifier.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Classifier.cs
@@ -409,7 +409,7 @@ namespace SysML2.NET.Core.POCO.Core.Classifiers
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/CollectExpression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/CollectExpression.cs
@@ -646,7 +646,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Comment.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Comment.cs
@@ -196,7 +196,7 @@ namespace SysML2.NET.Core.POCO.Root.Annotations
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ConcernDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ConcernDefinition.cs
@@ -653,7 +653,7 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ConcernUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ConcernUsage.cs
@@ -982,7 +982,7 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ConjugatedPortDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ConjugatedPortDefinition.cs
@@ -627,7 +627,7 @@ namespace SysML2.NET.Core.POCO.Systems.Ports
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ConjugatedPortTyping.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ConjugatedPortTyping.cs
@@ -194,7 +194,7 @@ namespace SysML2.NET.Core.POCO.Systems.Ports
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -205,7 +205,7 @@ namespace SysML2.NET.Core.POCO.Systems.Ports
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Conjugation.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Conjugation.cs
@@ -188,7 +188,7 @@ namespace SysML2.NET.Core.POCO.Core.Types
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -199,7 +199,7 @@ namespace SysML2.NET.Core.POCO.Core.Types
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ConnectionDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ConnectionDefinition.cs
@@ -644,7 +644,7 @@ namespace SysML2.NET.Core.POCO.Systems.Connections
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -655,7 +655,7 @@ namespace SysML2.NET.Core.POCO.Systems.Connections
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ConnectionUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ConnectionUsage.cs
@@ -964,7 +964,7 @@ namespace SysML2.NET.Core.POCO.Systems.Connections
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -975,7 +975,7 @@ namespace SysML2.NET.Core.POCO.Systems.Connections
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Connector.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Connector.cs
@@ -620,7 +620,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Connectors
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -631,7 +631,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Connectors
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ConstraintDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ConstraintDefinition.cs
@@ -617,7 +617,7 @@ namespace SysML2.NET.Core.POCO.Systems.Constraints
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ConstraintUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ConstraintUsage.cs
@@ -938,7 +938,7 @@ namespace SysML2.NET.Core.POCO.Systems.Constraints
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ConstructorExpression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ConstructorExpression.cs
@@ -624,7 +624,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/CrossSubsetting.cs
+++ b/SysML2.NET/Core/AutoGenPoco/CrossSubsetting.cs
@@ -216,7 +216,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -227,7 +227,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/DataType.cs
+++ b/SysML2.NET/Core/AutoGenPoco/DataType.cs
@@ -410,7 +410,7 @@ namespace SysML2.NET.Core.POCO.Kernel.DataTypes
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/DecisionNode.cs
+++ b/SysML2.NET/Core/AutoGenPoco/DecisionNode.cs
@@ -917,7 +917,7 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Definition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Definition.cs
@@ -596,7 +596,7 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Dependency.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Dependency.cs
@@ -177,7 +177,7 @@ namespace SysML2.NET.Core.POCO.Root.Dependencies
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -188,7 +188,7 @@ namespace SysML2.NET.Core.POCO.Root.Dependencies
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Differencing.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Differencing.cs
@@ -175,7 +175,7 @@ namespace SysML2.NET.Core.POCO.Core.Types
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -186,7 +186,7 @@ namespace SysML2.NET.Core.POCO.Core.Types
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Disjoining.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Disjoining.cs
@@ -176,7 +176,7 @@ namespace SysML2.NET.Core.POCO.Core.Types
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -187,7 +187,7 @@ namespace SysML2.NET.Core.POCO.Core.Types
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Documentation.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Documentation.cs
@@ -206,7 +206,7 @@ namespace SysML2.NET.Core.POCO.Root.Annotations
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ElementFilterMembership.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ElementFilterMembership.cs
@@ -269,7 +269,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Packages
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -280,7 +280,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Packages
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/EndFeatureMembership.cs
+++ b/SysML2.NET/Core/AutoGenPoco/EndFeatureMembership.cs
@@ -276,7 +276,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -287,7 +287,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/EnumerationDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/EnumerationDefinition.cs
@@ -615,7 +615,7 @@ namespace SysML2.NET.Core.POCO.Systems.Enumerations
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/EnumerationUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/EnumerationUsage.cs
@@ -897,7 +897,7 @@ namespace SysML2.NET.Core.POCO.Systems.Enumerations
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/EventOccurrenceUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/EventOccurrenceUsage.cs
@@ -919,7 +919,7 @@ namespace SysML2.NET.Core.POCO.Systems.Occurrences
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ExhibitStateUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ExhibitStateUsage.cs
@@ -985,7 +985,7 @@ namespace SysML2.NET.Core.POCO.Systems.States
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Expression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Expression.cs
@@ -607,7 +607,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Feature.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Feature.cs
@@ -590,7 +590,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/FeatureChainExpression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/FeatureChainExpression.cs
@@ -647,7 +647,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/FeatureChaining.cs
+++ b/SysML2.NET/Core/AutoGenPoco/FeatureChaining.cs
@@ -185,7 +185,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -196,7 +196,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/FeatureInverting.cs
+++ b/SysML2.NET/Core/AutoGenPoco/FeatureInverting.cs
@@ -185,7 +185,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -196,7 +196,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/FeatureMembership.cs
+++ b/SysML2.NET/Core/AutoGenPoco/FeatureMembership.cs
@@ -271,7 +271,7 @@ namespace SysML2.NET.Core.POCO.Core.Types
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -282,7 +282,7 @@ namespace SysML2.NET.Core.POCO.Core.Types
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/FeatureReferenceExpression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/FeatureReferenceExpression.cs
@@ -604,7 +604,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/FeatureTyping.cs
+++ b/SysML2.NET/Core/AutoGenPoco/FeatureTyping.cs
@@ -185,7 +185,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -196,7 +196,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/FeatureValue.cs
+++ b/SysML2.NET/Core/AutoGenPoco/FeatureValue.cs
@@ -291,7 +291,7 @@ namespace SysML2.NET.Core.POCO.Kernel.FeatureValues
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -302,7 +302,7 @@ namespace SysML2.NET.Core.POCO.Kernel.FeatureValues
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Flow.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Flow.cs
@@ -650,7 +650,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Interactions
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -661,7 +661,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Interactions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/FlowDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/FlowDefinition.cs
@@ -640,7 +640,7 @@ namespace SysML2.NET.Core.POCO.Systems.Flows
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -651,7 +651,7 @@ namespace SysML2.NET.Core.POCO.Systems.Flows
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/FlowEnd.cs
+++ b/SysML2.NET/Core/AutoGenPoco/FlowEnd.cs
@@ -579,7 +579,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Interactions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/FlowUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/FlowUsage.cs
@@ -990,7 +990,7 @@ namespace SysML2.NET.Core.POCO.Systems.Flows
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -1001,7 +1001,7 @@ namespace SysML2.NET.Core.POCO.Systems.Flows
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ForLoopActionUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ForLoopActionUsage.cs
@@ -937,7 +937,7 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ForkNode.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ForkNode.cs
@@ -918,7 +918,7 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/FramedConcernMembership.cs
+++ b/SysML2.NET/Core/AutoGenPoco/FramedConcernMembership.cs
@@ -312,7 +312,7 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -323,7 +323,7 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Function.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Function.cs
@@ -427,7 +427,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/IAcceptActionUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IAcceptActionUsage.cs
@@ -94,6 +94,13 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         [Property(xmiId: "_19_0_4_12e503d9_1612814670555_311543_168", aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: true, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         IExpression receiverArgument { get; }
 
+        /// <summary>
+        /// Check if this AcceptActionUsage is the triggerAction of a TransitionUsage.
+        /// </summary>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool IsTriggerAction() => this.ComputeIsTriggerActionOperation();
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IActionUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IActionUsage.cs
@@ -35,6 +35,7 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
     using SysML2.NET.Core.POCO.Core.Types;
     using SysML2.NET.Core.POCO.Kernel.Behaviors;
     using SysML2.NET.Core.POCO.Kernel.Classes;
+    using SysML2.NET.Core.POCO.Kernel.Functions;
     using SysML2.NET.Core.POCO.Root.Annotations;
     using SysML2.NET.Core.POCO.Root.Elements;
     using SysML2.NET.Core.POCO.Root.Namespaces;
@@ -80,6 +81,48 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         [RedefinedProperty(propertyName: "_18_5_3_b9102da_1536346315176_954314_17388")]
         List<IBehavior> actionDefinition { get; }
 
+        /// <summary>
+        /// Return the owned input parameters of this ActionUsage.
+        /// </summary>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        IFeature InputParameters() => this.ComputeInputParametersOperation();
+
+        /// <summary>
+        /// Return the i-th owned input parameter of the ActionUsage. Return null if the ActionUsage has less
+        /// than i owned input parameters.
+        /// </summary>
+        /// <param name="i">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        IFeature InputParameter(int i) => this.ComputeInputParameterOperation(i);
+
+        /// <summary>
+        /// Return the i-th argument Expression of an ActionUsage, defined as the value Expression of the
+        /// FeatureValue of the i-th owned input parameter of the ActionUsage. Return null if the ActionUsage
+        /// has less than i owned input parameters or the i-th owned input parameter has no FeatureValue.
+        /// </summary>
+        /// <param name="i">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IExpression
+        /// </returns>
+        IExpression Argument(int i) => this.ComputeArgumentOperation(i);
+
+        /// <summary>
+        /// Check if this ActionUsage is composite and has an owningType that is an ActionDefinition or
+        /// ActionUsage but is not the entryAction or exitAction of a StateDefinition or StateUsage. If so, then
+        /// it represents an Action that is a subaction of another Action.
+        /// </summary>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool IsSubactionUsage() => this.ComputeIsSubactionUsageOperation();
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/ICalculationUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ICalculationUsage.cs
@@ -81,6 +81,16 @@ namespace SysML2.NET.Core.POCO.Systems.Calculations
         [RedefinedProperty(propertyName: "_18_5_3_12e503d9_1543948477241_299049_20934")]
         IFunction calculationDefinition { get; }
 
+        /// <summary>
+        /// A CalculationUsage is not model-level evaluable.
+        /// </summary>
+        /// <param name="visited">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        new bool ModelLevelEvaluable(IFeature visited) => this.ComputeRedefinedModelLevelEvaluableOperation(visited);
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IConjugatedPortDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IConjugatedPortDefinition.cs
@@ -86,6 +86,14 @@ namespace SysML2.NET.Core.POCO.Systems.Ports
         [RedefinedProperty(propertyName: "_19_0_2_12e503d9_1575482646809_280165_440")]
         IPortConjugation ownedPortConjugator { get; }
 
+        /// <summary>
+        /// If the name of the originalPortDefinition is non-empty, then return that with the character ~
+        /// prepended.
+        /// </summary>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        new string EffectiveName() => this.ComputeRedefinedEffectiveNameOperation();
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IConstraintUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IConstraintUsage.cs
@@ -81,6 +81,26 @@ namespace SysML2.NET.Core.POCO.Systems.Constraints
         [RedefinedProperty(propertyName: "_19_0_2_12e503d9_1578025035149_386_969")]
         IPredicate constraintDefinition { get; }
 
+        /// <summary>
+        /// The naming Feature of a ConstraintUsage that is owned by a RequirementConstraintMembership and has
+        /// an ownedReferenceSubsetting is the featureTarget of the referencedFeature of that
+        /// ownedReferenceSubsetting.
+        /// </summary>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        new IFeature NamingFeature() => this.ComputeRedefinedNamingFeatureOperation();
+
+        /// <summary>
+        /// A ConstraintUsage is not model-level evaluable.
+        /// </summary>
+        /// <param name="visited">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        new bool ModelLevelEvaluable(IFeature visited) => this.ComputeRedefinedModelLevelEvaluableOperation(visited);
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IConstructorExpression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IConstructorExpression.cs
@@ -47,6 +47,17 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
     [GeneratedCode("SysML2.NET", "latest")]
     public partial interface IConstructorExpression : IInstantiationExpression
     {
+        /// <summary>
+        /// A ConstructorExpression is model-level evaluable if all its argument Expressions are model-level
+        /// evaluable.
+        /// </summary>
+        /// <param name="visited">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        new bool ModelLevelEvaluable(IFeature visited) => this.ComputeRedefinedModelLevelEvaluableOperation(visited);
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IControlNode.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IControlNode.cs
@@ -70,6 +70,23 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
     [GeneratedCode("SysML2.NET", "latest")]
     public partial interface IControlNode : IActionUsage
     {
+        /// <summary>
+        /// Check that the given Multiplicity has lowerBound and upperBound expressions that are model-level
+        /// evaluable to the given lower and upper values.
+        /// </summary>
+        /// <param name="mult">
+        /// No documentation provided
+        /// </param>
+        /// <param name="lower">
+        /// No documentation provided
+        /// </param>
+        /// <param name="upper">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool MultiplicityHasBounds(IMultiplicity mult, int lower, string upper) => this.ComputeMultiplicityHasBoundsOperation(mult, lower, upper);
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IElement.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IElement.cs
@@ -124,7 +124,7 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// </summary>
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
-        IReadOnlyCollection<IRelationship> OwnedRelationship { get; }
+        IReadOnlyList<IRelationship> OwnedRelationship { get; }
 
         /// <summary>
         /// The owner of this Element, derived as the owningRelatedElement of the owningRelationship of this
@@ -184,6 +184,55 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1543092869879_112608_17278")]
         List<ITextualRepresentation> textualRepresentation { get; }
 
+        /// <summary>
+        /// Return name, if that is not null, otherwise the shortName, if that is not null, otherwise null. If
+        /// the returned value is non-null, it is returned as-is if it has the form of a basic name, or,
+        /// otherwise, represented as a restricted name according to the lexical structure of the KerML textual
+        /// notation (i.e., surrounded by single quote characters and with special characters escaped).
+        /// </summary>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        string EscapedName() => this.ComputeEscapedNameOperation();
+
+        /// <summary>
+        /// Return an effective shortName for this Element. By default this is the same as its
+        /// declaredShortName.
+        /// </summary>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        string EffectiveShortName() => this.ComputeEffectiveShortNameOperation();
+
+        /// <summary>
+        /// Return an effective name for this Element. By default this is the same as its declaredName.
+        /// </summary>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        string EffectiveName() => this.ComputeEffectiveNameOperation();
+
+        /// <summary>
+        /// By default, return the library Namespace of the owningRelationship of this Element, if it has one.
+        /// </summary>
+        /// <returns>
+        /// The expected INamespace
+        /// </returns>
+        INamespace LibraryNamespace() => this.ComputeLibraryNamespaceOperation();
+
+        /// <summary>
+        /// Return a unique description of the location of this Element in the containment structure rooted in a
+        /// root Namespace. If the Element has a non-null qualifiedName, then return that. Otherwise, if it has
+        /// an owningRelationship, then return the string constructed by appending to the path of it's
+        /// owningRelationship the character / followed by the string representation of its position in the list
+        /// of ownedRelatedElements of the owningRelationship (indexed starting at 1). Otherwise, return the
+        /// empty string.                            (Note that this operation is overridden for Relationships
+        /// to use owningRelatedElement when appropriate.)
+        /// </summary>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        string Path() => this.ComputePathOperation();
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IExpression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IExpression.cs
@@ -72,6 +72,49 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
         [SubsettedProperty(propertyName: "_19_0_2_12e503d9_1595189174990_213826_657")]
         IFeature result { get; }
 
+        /// <summary>
+        /// Return whether this Expression is model-level evaluable. The visited parameter is used to track
+        /// possible circular Feature references made from FeatureReferenceExpressions (see the redefinition of
+        /// this operation for FeatureReferenceExpression). Such circular references are not allowed in
+        /// model-level evaluable expressions.                            An Expression that is not otherwise
+        /// specialized is model-level evaluable if it has no (non-implied) ownedSpecializations and all its
+        /// ownedFeatures are either in parameters, the result parameter or a result Expression owned via a
+        /// ResultExpressionMembership. The parameters  must not have any ownedFeatures or a FeatureValue, and
+        /// the result Expression must be model-level evaluable.
+        /// </summary>
+        /// <param name="visited">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool ModelLevelEvaluable(IFeature visited) => this.ComputeModelLevelEvaluableOperation(visited);
+
+        /// <summary>
+        /// If this Expression isModelLevelEvaluable, then evaluate it using the target as the context Element
+        /// for resolving Feature names and testing classification. The result is a collection of Elements,
+        /// which, for a fully evaluable Expression, will be a LiteralExpression or a Feature that is not an
+        /// Expression.
+        /// </summary>
+        /// <param name="target">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IElement
+        /// </returns>
+        IElement Evaluate(IElement target) => this.ComputeEvaluateOperation(target);
+
+        /// <summary>
+        /// Model-level evaluate this Expression with the given target. If the result is a LiteralBoolean,
+        /// return its value. Otherwise return false.
+        /// </summary>
+        /// <param name="target">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool CheckCondition(IElement target) => this.ComputeCheckConditionOperation(target);
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IFeature.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IFeature.cs
@@ -262,6 +262,208 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1533160674969_376003_43216", aggregation: AggregationKind.None, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: true, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         List<IType> type { get; }
 
+        /// <summary>
+        /// Return the directionOf this Feature relative to the given type.
+        /// </summary>
+        /// <param name="type">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected FeatureDirectionKind
+        /// </returns>
+        FeatureDirectionKind DirectionFor(IType type) => this.ComputeDirectionForOperation(type);
+
+        /// <summary>
+        /// If a Feature has no declaredShortName or declaredName, then its effective shortName is given by the
+        /// effective shortName of the Feature returned by the namingFeature() operation, if any.
+        /// </summary>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        new string EffectiveShortName() => this.ComputeRedefinedEffectiveShortNameOperation();
+
+        /// <summary>
+        /// If a Feature has no declaredName or declaredShortName                            , then its
+        /// effective name is given by the effective name of the Feature returned by the namingFeature()
+        /// operation, if any.
+        /// </summary>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        new string EffectiveName() => this.ComputeRedefinedEffectiveNameOperation();
+
+        /// <summary>
+        /// By default, the naming Feature of a Feature is given by its first redefinedFeature of its first
+        /// ownedRedefinition, if any.
+        /// </summary>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        IFeature NamingFeature() => this.ComputeNamingFeatureOperation();
+
+        /// <summary>
+        /// </summary>
+        /// <param name="excludeImplied">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IType
+        /// </returns>
+        new IType Supertypes(bool excludeImplied) => this.ComputeRedefinedSupertypesOperation(excludeImplied);
+
+        /// <summary>
+        /// Check whether this Feature directly redefines the given redefinedFeature.
+        /// </summary>
+        /// <param name="redefinedFeature">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool Redefines(IFeature redefinedFeature) => this.ComputeRedefinesOperation(redefinedFeature);
+
+        /// <summary>
+        /// Check whether this Feature directly redefines the named library Feature. libraryFeatureName must
+        /// conform to the syntax of a KerML qualified name and must resolve to a Feature in global scope.
+        /// </summary>
+        /// <param name="libraryFeatureName">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool RedefinesFromLibrary(string libraryFeatureName) => this.ComputeRedefinesFromLibraryOperation(libraryFeatureName);
+
+        /// <summary>
+        /// Check whether this Feature directly or indirectly specializes a Feature whose last two
+        /// chainingFeatures are the given Features first and second.
+        /// </summary>
+        /// <param name="first">
+        /// No documentation provided
+        /// </param>
+        /// <param name="second">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool SubsetsChain(IFeature first, IFeature second) => this.ComputeSubsetsChainOperation(first, second);
+
+        /// <summary>
+        /// A Feature is compatible with an otherType if it either directly or indirectly specializes the
+        /// otherType or if the otherType is also a Feature and all of the following are true.                  
+        ///          <ol>                            <li>Neither this Feature or the otherType have any
+        /// ownedFeatures.</li>                            <li>This Feature directly or indirectly redefines a
+        /// Feature that is also directly or indirectly redefined by the otherType.</li>                        
+        /// <li>This Feature can access the otherType.                            </li></ol>
+        /// </summary>
+        /// <param name="otherType">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        new bool IsCompatibleWith(IType otherType) => this.ComputeRedefinedIsCompatibleWithOperation(otherType);
+
+        /// <summary>
+        /// Return the Features used to determine the types of this Feature (other than this Feature itself). If
+        /// this Feature is not conjugated, then the typingFeatures consist of all subsetted Features, except
+        /// from CrossSubsetting, and the last chainingFeature (if any). If this Feature is conjugated, then the
+        /// typingFeatures are only its originalType (if the originalType is a Feature).                        
+        ///    <strong>Note.</strong> CrossSubsetting is excluded from the determination of the type of a
+        /// Feature in order to avoid circularity in the construction of implied CrossSubsetting relationships.
+        /// The validateFeatureCrossFeatureType requires that the crossFeature of a Feature have the same type
+        /// as the Feature.
+        /// </summary>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        IFeature TypingFeatures() => this.ComputeTypingFeaturesOperation();
+
+        /// <summary>
+        /// If isCartesianProduct is true, then return the list of Types whose Cartesian product can be
+        /// represented by this Feature. (If isCartesianProduct is not true, the operation will still return a
+        /// valid value, it will just not represent anything useful.)
+        /// </summary>
+        /// <returns>
+        /// The expected IType
+        /// </returns>
+        IType AsCartesianProduct() => this.ComputeAsCartesianProductOperation();
+
+        /// <summary>
+        /// Check whether this Feature can be used to represent a Cartesian product of Types.
+        /// </summary>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool IsCartesianProduct() => this.ComputeIsCartesianProductOperation();
+
+        /// <summary>
+        /// Return whether this Feature is an owned cross Feature of an end Feature.
+        /// </summary>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool IsOwnedCrossFeature() => this.ComputeIsOwnedCrossFeatureOperation();
+
+        /// <summary>
+        /// If this Feature is an end Feature of its owningType, then return the first ownedMember of the
+        /// Feature that is a Feature, but not a Multiplicity or a MetadataFeature, and whose owningMembership
+        /// is not a FeatureMembership. If this exists, it is the crossFeature of the end Feature.
+        /// </summary>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        IFeature OwnedCrossFeature() => this.ComputeOwnedCrossFeatureOperation();
+
+        /// <summary>
+        /// Return this Feature and all the Features that are directly or indirectly Redefined by this Feature.
+        /// </summary>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        IFeature AllRedefinedFeatures() => this.ComputeAllRedefinedFeaturesOperation();
+
+        /// <summary>
+        /// Return if the featuringTypes of this Feature are compatible with the given type. If type is null,
+        /// then check if this Feature is explicitly or implicitly featured by Base::Anything. If this Feature
+        /// has isVariable = true, then also consider it to be featured within its owningType. If this Feature
+        /// is a feature chain whose first chainingFeature has isVariable = true, then also consider it to be
+        /// featured within the owningType of its first chainingFeature.
+        /// </summary>
+        /// <param name="type">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool IsFeaturedWithin(IType type) => this.ComputeIsFeaturedWithinOperation(type);
+
+        /// <summary>
+        /// A Feature can access another feature if the other feature is featured within one of the direct or
+        /// indirect featuringTypes of this Feature.
+        /// </summary>
+        /// <param name="feature">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool CanAccess(IFeature feature) => this.ComputeCanAccessOperation(feature);
+
+        /// <summary>
+        /// Return whether the given type must be a featuringType of this Feature. If this Feature has
+        /// isVariable = false, then return true if the type is the owningType of the Feature. If isVariable =
+        /// true, then return true if the type is a Feature representing the snapshots of the owningType of this
+        /// Feature.
+        /// </summary>
+        /// <param name="type">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool IsFeaturingType(IType type) => this.ComputeIsFeaturingTypeOperation(type);
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IFeatureChainExpression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IFeatureChainExpression.cs
@@ -61,6 +61,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674979_644335_43267")]
         IFeature targetFeature { get; }
 
+        /// <summary>
+        /// Return the first ownedFeature of the first owned input parameter of this FeatureChainExpression (if
+        /// any).
+        /// </summary>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        IFeature SourceTargetFeature() => this.ComputeSourceTargetFeatureOperation();
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IFeatureReferenceExpression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IFeatureReferenceExpression.cs
@@ -53,6 +53,40 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674979_644335_43267")]
         IFeature referent { get; }
 
+        /// <summary>
+        /// A FeatureReferenceExpression is model-level evaluable if it&#39;s referent                          
+        ///  <ul>                            <li>conforms to the self-reference feature Anything::self;</li>    
+        ///                        <li>is an Expression that is model-level evaluable;</li>                     
+        ///       <li>has an owningType that is a Metaclass or MetadataFeature; or</li>                         
+        ///   <li>has no featuringTypes and, if it has a FeatureValue, the value Expression is model-level
+        /// evaluable.</li>                            </ul>
+        /// </summary>
+        /// <param name="visited">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        new bool ModelLevelEvaluable(IFeature visited) => this.ComputeRedefinedModelLevelEvaluableOperation(visited);
+
+        /// <summary>
+        /// First, determine a value Expression for the referent:                            <ul>               
+        ///             <li>If the target Element is a Type that has a feature that is the referent or (directly
+        /// or indirectly) redefines it, then the value Expression of the FeatureValue for that feature (if
+        /// any).</li>                            <li>Else, if the referent has no featuringTypes, the value
+        /// Expression of the FeatureValue for the referent (if any).</li>                            </ul>     
+        ///                       Then:                            <ul>                            <li>If such a
+        /// value Expression exists, return the result of evaluating that Expression on the target.</li>        
+        ///                    <li>Else, if the referent is not an Expression, return the referent.</li>        
+        /// <li>Else return the empty sequence.</li>                            </ul>
+        /// </summary>
+        /// <param name="target">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IElement
+        /// </returns>
+        new IElement Evaluate(IElement target) => this.ComputeRedefinedEvaluateOperation(target);
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IImport.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IImport.cs
@@ -81,6 +81,17 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         [Property(xmiId: "_18_5_3_12e503d9_1533160674976_798509_43257", aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: "private")]
         VisibilityKind Visibility { get; set; }
 
+        /// <summary>
+        /// Returns Memberships that are to become importedMemberships of the importOwningNamespace. (The
+        /// excluded parameter is used to handle the possibility of circular Import Relationships.)
+        /// </summary>
+        /// <param name="excluded">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        IMembership ImportedMemberships(INamespace excluded) => this.ComputeImportedMembershipsOperation(excluded);
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IInstantiationExpression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IInstantiationExpression.cs
@@ -64,6 +64,16 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674979_644335_43267")]
         IType instantiatedType { get; }
 
+        /// <summary>
+        /// Return the Type to act as the instantiatedType for this InstantiationExpression. By default, this is
+        /// the memberElement of the first ownedMembership that is not a FeatureMembership, which must be a
+        /// Type.                            <b>Note.</b> This operation is overridden in the subclass
+        /// OperatorExpression.
+        /// </summary>
+        /// <returns>
+        /// The expected IType
+        /// </returns>
+        IType InstantiatedType() => this.ComputeInstantiatedTypeOperation();
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IInvocationExpression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IInvocationExpression.cs
@@ -50,6 +50,30 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
     [GeneratedCode("SysML2.NET", "latest")]
     public partial interface IInvocationExpression : IInstantiationExpression
     {
+        /// <summary>
+        /// An InvocationExpression is model-level evaluable if all its argument Expressions are model-level
+        /// evaluable and its function is model-level evaluable.
+        /// </summary>
+        /// <param name="visited">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        new bool ModelLevelEvaluable(IFeature visited) => this.ComputeRedefinedModelLevelEvaluableOperation(visited);
+
+        /// <summary>
+        /// Apply the Function that is the type of this InvocationExpression to the argument values resulting
+        /// from evaluating each of the argument Expressions on the given target. If the application is not
+        /// possible, then return an empty sequence.
+        /// </summary>
+        /// <param name="target">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IElement
+        /// </returns>
+        new IElement Evaluate(IElement target) => this.ComputeRedefinedEvaluateOperation(target);
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/ILibraryPackage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ILibraryPackage.cs
@@ -50,6 +50,13 @@ namespace SysML2.NET.Core.POCO.Kernel.Packages
         [Property(xmiId: "_19_0_4_12e503d9_1665459011301_65344_899", aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: "false")]
         bool IsStandard { get; set; }
 
+        /// <summary>
+        /// The libraryNamespace for a LibraryPackage is itself.
+        /// </summary>
+        /// <returns>
+        /// The expected INamespace
+        /// </returns>
+        new INamespace LibraryNamespace() => this.ComputeRedefinedLibraryNamespaceOperation();
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/ILiteralExpression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ILiteralExpression.cs
@@ -45,6 +45,27 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
     [GeneratedCode("SysML2.NET", "latest")]
     public partial interface ILiteralExpression : IExpression
     {
+        /// <summary>
+        /// A LiteralExpression is always model-level evaluable.
+        /// </summary>
+        /// <param name="visited">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        new bool ModelLevelEvaluable(IFeature visited) => this.ComputeRedefinedModelLevelEvaluableOperation(visited);
+
+        /// <summary>
+        /// The model-level value of a LiteralExpression is itself.
+        /// </summary>
+        /// <param name="target">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IElement
+        /// </returns>
+        new IElement Evaluate(IElement target) => this.ComputeRedefinedEvaluateOperation(target);
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IMembership.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IMembership.cs
@@ -88,6 +88,20 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         [Property(xmiId: "_18_5_3_12e503d9_1533160674964_42975_43193", aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: "public")]
         VisibilityKind Visibility { get; set; }
 
+        /// <summary>
+        /// Whether this Membership is distinguishable from a given other Membership. By default, this is true
+        /// if this Membership has no memberShortName or memberName; or each of the memberShortName and
+        /// memberName are different than both of those of the other Membership; or neither of the metaclasses
+        /// of the memberElement of this Membership and the memberElement of the other Membership conform to the
+        /// other. But this may be overridden in specializations of Membership.
+        /// </summary>
+        /// <param name="other">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool IsDistinguishableFrom(IMembership other) => this.ComputeIsDistinguishableFromOperation(other);
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IMembershipImport.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IMembershipImport.cs
@@ -49,6 +49,18 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         [RedefinedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_138197_43179")]
         IMembership ImportedMembership { get; set; }
 
+        /// <summary>
+        /// Returns at least the importedMembership. If isRecursive = true and the memberElement of the
+        /// importedMembership is a Namespace, then Memberships are also recursively imported from that
+        /// Namespace.
+        /// </summary>
+        /// <param name="excluded">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        new IMembership ImportedMemberships(INamespace excluded) => this.ComputeRedefinedImportedMembershipsOperation(excluded);
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IMetadataAccessExpression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IMetadataAccessExpression.cs
@@ -33,6 +33,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
     using SysML2.NET.Core.POCO.Core.Types;
     using SysML2.NET.Core.POCO.Kernel.Behaviors;
     using SysML2.NET.Core.POCO.Kernel.Functions;
+    using SysML2.NET.Core.POCO.Kernel.Metadata;
     using SysML2.NET.Core.POCO.Root.Annotations;
     using SysML2.NET.Core.POCO.Root.Elements;
     using SysML2.NET.Core.POCO.Root.Namespaces;
@@ -55,6 +56,41 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674979_644335_43267")]
         IElement referencedElement { get; }
 
+        /// <summary>
+        /// A MetadataAccessExpression is always model-level evaluable.
+        /// </summary>
+        /// <param name="visited">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        new bool ModelLevelEvaluable(IFeature visited) => this.ComputeRedefinedModelLevelEvaluableOperation(visited);
+
+        /// <summary>
+        /// Return the ownedElements of the referencedElement that are MetadataFeatures and have the
+        /// referencedElement as an annotatedElement, plus a MetadataFeature whose annotatedElement is the
+        /// referencedElement, whose metaclass is the reflective Metaclass corresponding to the MOF class of the
+        /// referencedElement and whose ownedFeatures are bound to the values of the MOF properties of the
+        /// referencedElement.
+        /// </summary>
+        /// <param name="target">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IElement
+        /// </returns>
+        new IElement Evaluate(IElement target) => this.ComputeRedefinedEvaluateOperation(target);
+
+        /// <summary>
+        /// Return a MetadataFeature whose annotatedElement is the referencedElement, whose metaclass is the
+        /// reflective Metaclass corresponding to the MOF class of the referencedElement and whose ownedFeatures
+        /// are bound to the MOF properties of the referencedElement.
+        /// </summary>
+        /// <returns>
+        /// The expected IMetadataFeature
+        /// </returns>
+        IMetadataFeature MetaclassFeature() => this.ComputeMetaclassFeatureOperation();
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IMetadataFeature.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IMetadataFeature.cs
@@ -52,6 +52,44 @@ namespace SysML2.NET.Core.POCO.Kernel.Metadata
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674969_376003_43216")]
         IMetaclass metaclass { get; }
 
+        /// <summary>
+        /// If the given baseFeature is a feature of this MetadataFeature, or is directly or indirectly
+        /// redefined by a feature, then return the result of evaluating the appropriate (model-level evaluable)
+        /// value Expression for it (if any), with the MetadataFeature as the target.
+        /// </summary>
+        /// <param name="baseFeature">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IElement
+        /// </returns>
+        IElement EvaluateFeature(IFeature baseFeature) => this.ComputeEvaluateFeatureOperation(baseFeature);
+
+        /// <summary>
+        /// Check if this MetadataFeature has a metaclass which is a kind of SemanticMetadata.
+        /// </summary>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool IsSemantic() => this.ComputeIsSemanticOperation();
+
+        /// <summary>
+        /// Check if this MetadataFeature has a metaclass that is a kind of KerML::Element (that is, it is from
+        /// the reflective abstract syntax model).
+        /// </summary>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool IsSyntactic() => this.ComputeIsSyntacticOperation();
+
+        /// <summary>
+        /// If this MetadataFeature reflectively represents a model element, then return the corresponding
+        /// Element instance from the MOF abstract syntax representation of the model.
+        /// </summary>
+        /// <returns>
+        /// The expected IElement
+        /// </returns>
+        IElement SyntaxElement() => this.ComputeSyntaxElementOperation();
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IMultiplicityRange.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IMultiplicityRange.cs
@@ -74,6 +74,32 @@ namespace SysML2.NET.Core.POCO.Kernel.Multiplicities
         [SubsettedProperty(propertyName: "_19_0_2_12e503d9_1573095221994_519580_5095")]
         IExpression upperBound { get; }
 
+        /// <summary>
+        /// Check whether this MultiplicityRange represents the range bounded by the given values lower and
+        /// upper, presuming the lowerBound and upperBound Expressions are model-level evaluable.
+        /// </summary>
+        /// <param name="lower">
+        /// No documentation provided
+        /// </param>
+        /// <param name="upper">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool HasBounds(int lower, string upper) => this.ComputeHasBoundsOperation(lower, upper);
+
+        /// <summary>
+        /// Evaluate the given bound Expression (at model level) and return the result represented as a MOF
+        /// UnlimitedNatural value.
+        /// </summary>
+        /// <param name="bound">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        string ValueOf(IExpression bound) => this.ComputeValueOfOperation(bound);
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/INamespace.cs
+++ b/SysML2.NET/Core/AutoGenPoco/INamespace.cs
@@ -28,6 +28,7 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
     using System.CodeDom.Compiler;
     using System.Collections.Generic;
 
+    using SysML2.NET.Core.Root.Namespaces;
     using SysML2.NET.Core.POCO.Root.Annotations;
     using SysML2.NET.Core.POCO.Root.Elements;
     using SysML2.NET.Decorators;
@@ -96,6 +97,158 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1543092026091_217766_16748")]
         List<IMembership> ownedMembership { get; }
 
+        /// <summary>
+        /// Return the names of the given element as it is known in this Namespace.
+        /// </summary>
+        /// <param name="element">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        string NamesOf(IElement element) => this.ComputeNamesOfOperation(element);
+
+        /// <summary>
+        /// Returns this visibility of mem relative to this Namespace. If mem is an importedMembership, this is
+        /// the visibility of its Import. Otherwise it is the visibility of the Membership itself.
+        /// </summary>
+        /// <param name="mem">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected VisibilityKind
+        /// </returns>
+        VisibilityKind VisibilityOf(IMembership mem) => this.ComputeVisibilityOfOperation(mem);
+
+        /// <summary>
+        /// If includeAll = true, then return all the Memberships of this Namespace. Otherwise, return only the
+        /// publicly visible Memberships of this Namespace, including ownedMemberships that have a visibility of
+        /// public and Memberships imported with a visibility of public. If isRecursive = true, also recursively
+        /// include all visible Memberships of any public owned Namespaces, or, if IncludeAll = true, all
+        /// Memberships of all owned Namespaces. When computing imported Memberships, ignore this Namespace and
+        /// any Namespaces in the given excluded set.
+        /// </summary>
+        /// <param name="excluded">
+        /// No documentation provided
+        /// </param>
+        /// <param name="isRecursive">
+        /// No documentation provided
+        /// </param>
+        /// <param name="includeAll">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        IMembership VisibleMemberships(INamespace excluded, bool isRecursive, bool includeAll) => this.ComputeVisibleMembershipsOperation(excluded, isRecursive, includeAll);
+
+        /// <summary>
+        /// Derive the imported Memberships of this Namespace as the importedMembership of all ownedImports,
+        /// excluding those Imports whose importOwningNamespace is in the excluded set, and excluding
+        /// Memberships that have distinguisibility collisions with each other or with any ownedMembership.
+        /// </summary>
+        /// <param name="excluded">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        IMembership ImportedMemberships(INamespace excluded) => this.ComputeImportedMembershipsOperation(excluded);
+
+        /// <summary>
+        /// If visibility is not null, return the Memberships of this Namespace with the given visibility,
+        /// including ownedMemberships with the given visibility and Memberships imported with the given
+        /// visibility. If visibility is null, return all ownedMemberships and imported Memberships regardless
+        /// of visibility. When computing imported Memberships, ignore this Namespace and any Namespaces in the
+        /// given excluded set.
+        /// </summary>
+        /// <param name="visibility">
+        /// No documentation provided
+        /// </param>
+        /// <param name="excluded">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        IMembership MembershipsOfVisibility(VisibilityKind visibility, INamespace excluded) => this.ComputeMembershipsOfVisibilityOperation(visibility, excluded);
+
+        /// <summary>
+        /// Resolve the given qualified name to the named Membership (if any), starting with this Namespace as
+        /// the local scope. The qualified name string must conform to the concrete syntax of the KerML textual
+        /// notation. According to the KerML name resolution rules every qualified name will resolve to either a
+        /// single Membership, or to none.
+        /// </summary>
+        /// <param name="qualifiedName">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        IMembership Resolve(string qualifiedName) => this.ComputeResolveOperation(qualifiedName);
+
+        /// <summary>
+        /// Resolve the given qualified name to the named Membership (if any) in the effective global Namespace
+        /// that is the outermost naming scope. The qualified name string must conform to the concrete syntax of
+        /// the KerML textual notation.
+        /// </summary>
+        /// <param name="qualifiedName">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        IMembership ResolveGlobal(string qualifiedName) => this.ComputeResolveGlobalOperation(qualifiedName);
+
+        /// <summary>
+        /// Resolve a simple name starting with this Namespace as the local scope, and continuing with
+        /// containing outer scopes as necessary. However, if this Namespace is a root Namespace, then the
+        /// resolution is done directly in global scope.
+        /// </summary>
+        /// <param name="name">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        IMembership ResolveLocal(string name) => this.ComputeResolveLocalOperation(name);
+
+        /// <summary>
+        /// Resolve a simple name from the visible Memberships of this Namespace.
+        /// </summary>
+        /// <param name="name">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        IMembership ResolveVisible(string name) => this.ComputeResolveVisibleOperation(name);
+
+        /// <summary>
+        /// Return a string with valid KerML syntax representing the qualification part of a given
+        /// qualifiedName, that is, a qualified name with all the segment names of the given name except the
+        /// last. If the given qualifiedName has only one segment, then return null.
+        /// </summary>
+        /// <param name="qualifiedName">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        string QualificationOf(string qualifiedName) => this.ComputeQualificationOfOperation(qualifiedName);
+
+        /// <summary>
+        /// Return the simple name that is the last segment name of the given qualifiedName. If this segment
+        /// name has the form of a KerML unrestricted name, then "unescape" it by removing the surrounding
+        /// single quotes and replacing all escape sequences with the specified character.
+        /// </summary>
+        /// <param name="qualifiedName">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        string UnqualifiedNameOf(string qualifiedName) => this.ComputeUnqualifiedNameOfOperation(qualifiedName);
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/INamespaceImport.cs
+++ b/SysML2.NET/Core/AutoGenPoco/INamespaceImport.cs
@@ -50,6 +50,18 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         [RedefinedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_138197_43179")]
         INamespace ImportedNamespace { get; set; }
 
+        /// <summary>
+        /// Returns at least the visible Memberships of the importedNamespace. If isRecursive = true, then
+        /// Memberships are also recursively imported from any ownedMembers of the importedNamespace that are
+        /// themselves Namespaces.
+        /// </summary>
+        /// <param name="excluded">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        new IMembership ImportedMemberships(INamespace excluded) => this.ComputeRedefinedImportedMembershipsOperation(excluded);
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/INullExpression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/INullExpression.cs
@@ -45,6 +45,27 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
     [GeneratedCode("SysML2.NET", "latest")]
     public partial interface INullExpression : IExpression
     {
+        /// <summary>
+        /// A NullExpression is always model-level evaluable.
+        /// </summary>
+        /// <param name="visited">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        new bool ModelLevelEvaluable(IFeature visited) => this.ComputeRedefinedModelLevelEvaluableOperation(visited);
+
+        /// <summary>
+        /// The model-level value of a NullExpression is an empty sequence.
+        /// </summary>
+        /// <param name="target">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IElement
+        /// </returns>
+        new IElement Evaluate(IElement target) => this.ComputeRedefinedEvaluateOperation(target);
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IOperatorExpression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IOperatorExpression.cs
@@ -53,6 +53,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         [Property(xmiId: "_18_5_3_12e503d9_1557528808100_646606_111674", aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         string Operator { get; set; }
 
+        /// <summary>
+        /// The instantiatedType of an OperatorExpression is the resolution of it's operator from one of the
+        /// packages BaseFunctions, DataFunctions, or ControlFunctions from the Kernel Function Library.
+        /// </summary>
+        /// <returns>
+        /// The expected IType
+        /// </returns>
+        new IType InstantiatedType() => this.ComputeRedefinedInstantiatedTypeOperation();
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IOwningMembership.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IOwningMembership.cs
@@ -71,6 +71,15 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         [RedefinedProperty(propertyName: "_19_0_4_12e503d9_1651721174176_601088_238")]
         string ownedMemberShortName { get; }
 
+        /// <summary>
+        /// If the ownedMemberElement of this OwningMembership has a non-null qualifiedName, then return the
+        /// string constructed by appending to that qualifiedName the string "/owningMembership". Otherwise,
+        /// return the path of the OwningMembership as specified for a Relationship in general.
+        /// </summary>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        new string Path() => this.ComputeRedefinedPathOperation();
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IPackage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IPackage.cs
@@ -51,6 +51,27 @@ namespace SysML2.NET.Core.POCO.Kernel.Packages
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674979_259543_43268")]
         List<IExpression> filterCondition { get; }
 
+        /// <summary>
+        /// Exclude Elements that do not meet all the filterConditions.
+        /// </summary>
+        /// <param name="excluded">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        new IMembership ImportedMemberships(INamespace excluded) => this.ComputeRedefinedImportedMembershipsOperation(excluded);
+
+        /// <summary>
+        /// Determine whether the given element meets all the filterConditions.
+        /// </summary>
+        /// <param name="element">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool IncludeAsMember(IElement element) => this.ComputeIncludeAsMemberOperation(element);
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IParameterMembership.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IParameterMembership.cs
@@ -28,6 +28,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Behaviors
     using System.CodeDom.Compiler;
     using System.Collections.Generic;
 
+    using SysML2.NET.Core.Core.Types;
     using SysML2.NET.Core.Root.Namespaces;
     using SysML2.NET.Core.POCO.Core.Features;
     using SysML2.NET.Core.POCO.Core.Types;
@@ -52,6 +53,13 @@ namespace SysML2.NET.Core.POCO.Kernel.Behaviors
         [RedefinedProperty(propertyName: "_18_5_3_12e503d9_1533160674993_898044_43344")]
         IFeature ownedMemberParameter { get; }
 
+        /// <summary>
+        /// Return the required value of the direction of the ownedMemberParameter. By default, this is in.
+        /// </summary>
+        /// <returns>
+        /// The expected FeatureDirectionKind
+        /// </returns>
+        FeatureDirectionKind ParameterDirection() => this.ComputeParameterDirectionOperation();
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IPerformActionUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IPerformActionUsage.cs
@@ -79,6 +79,15 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         [RedefinedProperty(propertyName: "_19_0_4_12e503d9_1622831790393_676695_195")]
         IActionUsage performedAction { get; }
 
+        /// <summary>
+        /// The naming Feature of a PerformActionUsage is its performedAction, if this is different than the
+        /// PerformActionUsage. If the PerformActionUsage is its own performedAction, then the naming Feature is
+        /// the same as the usual default for a Usage.
+        /// </summary>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        new IFeature NamingFeature() => this.ComputeRedefinedNamingFeatureOperation();
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IReferenceUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IReferenceUsage.cs
@@ -76,6 +76,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         [RedefinedProperty(propertyName: "_19_0_4_12e503d9_1624035114787_488767_41423")]
         new bool isReference { get; }
 
+        /// <summary>
+        /// If this ReferenceUsage is the payload parameter of a TransitionUsage, then its naming Feature is the
+        /// payloadParameter of the triggerAction of that TransitionUsage (if any).
+        /// </summary>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        new IFeature NamingFeature() => this.ComputeRedefinedNamingFeatureOperation();
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IRelationship.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IRelationship.cs
@@ -62,7 +62,7 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// </summary>
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
-        IReadOnlyCollection<IElement> OwnedRelatedElement { get; }
+        IReadOnlyList<IElement> OwnedRelatedElement { get; }
 
         /// <summary>
         /// The relatedElement of this Relationship that owns the Relationship, if any.
@@ -92,6 +92,25 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         List<IElement> Target { get; set; }
 
+        /// <summary>
+        /// Return whether this Relationship has either an owningRelatedElement or owningRelationship that is a
+        /// library element.
+        /// </summary>
+        /// <returns>
+        /// The expected INamespace
+        /// </returns>
+        new INamespace LibraryNamespace() => this.ComputeRedefinedLibraryNamespaceOperation();
+
+        /// <summary>
+        /// If the owningRelationship of the Relationship is null but its owningRelatedElement is non-null,
+        /// construct the path using the position of the Relationship in the list of ownedRelationships of its
+        /// owningRelatedElement. Otherwise, return the path of the Relationship as specified for an Element in
+        /// general.
+        /// </summary>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        new string Path() => this.ComputeRedefinedPathOperation();
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IReturnParameterMembership.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IReturnParameterMembership.cs
@@ -28,6 +28,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
     using System.CodeDom.Compiler;
     using System.Collections.Generic;
 
+    using SysML2.NET.Core.Core.Types;
     using SysML2.NET.Core.Root.Namespaces;
     using SysML2.NET.Core.POCO.Core.Features;
     using SysML2.NET.Core.POCO.Core.Types;
@@ -46,6 +47,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
     [GeneratedCode("SysML2.NET", "latest")]
     public partial interface IReturnParameterMembership : IParameterMembership
     {
+        /// <summary>
+        /// The ownedMemberParameter of a ReturnParameterMembership must have direction out. (This is a leaf
+        /// operation that cannot be further redefined.)
+        /// </summary>
+        /// <returns>
+        /// The expected FeatureDirectionKind
+        /// </returns>
+        new FeatureDirectionKind ParameterDirection() => this.ComputeRedefinedParameterDirectionOperation();
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IStateUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IStateUsage.cs
@@ -112,6 +112,19 @@ namespace SysML2.NET.Core.POCO.Systems.States
         [RedefinedProperty(propertyName: "_18_5_3_12e503d9_1565500905804_589845_30779")]
         List<IBehavior> stateDefinition { get; }
 
+        /// <summary>
+        /// Check if this StateUsage is composite and has an owningType that is a StateDefinition or StateUsage
+        /// with the given value of isParallel, but is not an entryAction, doAction, or exitAction. If so, then
+        /// it represents a StateAction that is a substate or exclusiveState (for isParallel = false) of another
+        /// StateAction.
+        /// </summary>
+        /// <param name="isParallel">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool IsSubstateUsage(bool isParallel) => this.ComputeIsSubstateUsageOperation(isParallel);
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/ITransitionUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ITransitionUsage.cs
@@ -124,6 +124,23 @@ namespace SysML2.NET.Core.POCO.Systems.States
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674959_226999_43167")]
         List<IAcceptActionUsage> triggerAction { get; }
 
+        /// <summary>
+        /// Return the payloadParameter of the triggerAction of this TransitionUsage, if it has one.
+        /// </summary>
+        /// <returns>
+        /// The expected IReferenceUsage
+        /// </returns>
+        IReferenceUsage TriggerPayloadParameter() => this.ComputeTriggerPayloadParameterOperation();
+
+        /// <summary>
+        /// Return the Feature to be used as the source of the succession of this TransitionUsage, which is the
+        /// first member of the TransitionUsage that is a Feature, that is owned by the TransitionUsage via a
+        /// Membership that is not a FeatureMembership, and whose featureTarget is an ActionUsage.
+        /// </summary>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        IFeature SourceFeature() => this.ComputeSourceFeatureOperation();
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/ITriggerInvocationExpression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ITriggerInvocationExpression.cs
@@ -55,6 +55,15 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         [Property(xmiId: "_19_0_4_12e503d9_1643588513495_774789_300", aggregation: AggregationKind.None, lowerValue: 1, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         TriggerKind Kind { get; set; }
 
+        /// <summary>
+        /// Return one of the Functions TriggerWhen, TriggerAt or TriggerAfter, from the Kernel Semantic Library
+        /// Triggers package, depending on whether the kind of this TriggerInvocationExpression is when, at or
+        /// after, respectively.
+        /// </summary>
+        /// <returns>
+        /// The expected IType
+        /// </returns>
+        new IType InstantiatedType() => this.ComputeRedefinedInstantiatedTypeOperation();
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IType.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IType.cs
@@ -28,6 +28,7 @@ namespace SysML2.NET.Core.POCO.Core.Types
     using System.CodeDom.Compiler;
     using System.Collections.Generic;
 
+    using SysML2.NET.Core.Core.Types;
     using SysML2.NET.Core.POCO.Core.Features;
     using SysML2.NET.Core.POCO.Root.Annotations;
     using SysML2.NET.Core.POCO.Root.Elements;
@@ -243,6 +244,203 @@ namespace SysML2.NET.Core.POCO.Core.Types
         [Property(xmiId: "_19_0_4_b9102da_1661974896766_783268_1231", aggregation: AggregationKind.None, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: true, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         List<IType> unioningType { get; }
 
+        /// <summary>
+        /// The visible Memberships of a Type include inheritedMemberships.
+        /// </summary>
+        /// <param name="excluded">
+        /// No documentation provided
+        /// </param>
+        /// <param name="isRecursive">
+        /// No documentation provided
+        /// </param>
+        /// <param name="includeAll">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        new IMembership VisibleMemberships(INamespace excluded, bool isRecursive, bool includeAll) => this.ComputeRedefinedVisibleMembershipsOperation(excluded, isRecursive, includeAll);
+
+        /// <summary>
+        /// Return the Memberships inheritable from supertypes of this Type with redefined Features removed.
+        /// When computing inheritable Memberships, exclude Imports of excludedNamespaces, Specializations of
+        /// excludedTypes, and, if excludeImplied = true, all implied Specializations.
+        /// </summary>
+        /// <param name="excludedNamespaces">
+        /// No documentation provided
+        /// </param>
+        /// <param name="excludedTypes">
+        /// No documentation provided
+        /// </param>
+        /// <param name="excludeImplied">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        IMembership InheritedMemberships(INamespace excludedNamespaces, IType excludedTypes, bool excludeImplied) => this.ComputeInheritedMembershipsOperation(excludedNamespaces, excludedTypes, excludeImplied);
+
+        /// <summary>
+        /// Return all the non-private Memberships of all the supertypes of this Type, excluding any supertypes
+        /// that are this Type or are in the given set of excludedTypes. If excludeImplied = true, then also
+        /// transitively exclude any supertypes from implied Specializations.
+        /// </summary>
+        /// <param name="excludedNamespaces">
+        /// No documentation provided
+        /// </param>
+        /// <param name="excludedTypes">
+        /// No documentation provided
+        /// </param>
+        /// <param name="excludeImplied">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        IMembership InheritableMemberships(INamespace excludedNamespaces, IType excludedTypes, bool excludeImplied) => this.ComputeInheritableMembershipsOperation(excludedNamespaces, excludedTypes, excludeImplied);
+
+        /// <summary>
+        /// Return the public, protected and inherited Memberships of this Type. When computing imported
+        /// Memberships, exclude the given set of excludedNamespaces. When computing inherited Memberships,
+        /// exclude Types in the given set of excludedTypes. If excludeImplied = true, then also exclude any
+        /// supertypes from implied Specializations.
+        /// </summary>
+        /// <param name="excludedNamespaces">
+        /// No documentation provided
+        /// </param>
+        /// <param name="excludedTypes">
+        /// No documentation provided
+        /// </param>
+        /// <param name="excludeImplied">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        IMembership NonPrivateMemberships(INamespace excludedNamespaces, IType excludedTypes, bool excludeImplied) => this.ComputeNonPrivateMembershipsOperation(excludedNamespaces, excludedTypes, excludeImplied);
+
+        /// <summary>
+        /// Return a subset of memberships, removing those Memberships whose memberElements are Features and for
+        /// which either of the following two conditions holds:                            <ol>                 
+        ///           <li>The memberElement of the Membership is included in redefined Features of another
+        /// Membership in memberships.</li>                            <li>One of the redefined Features of the
+        /// Membership is a directly redefinedFeature of an ownedFeature of this Type.</li>                     
+        ///       </ol>                            For this purpose, the redefined Features of a Membership
+        /// whose memberElement is a Feature includes the memberElement and all Features directly or indirectly
+        /// redefined by the memberElement.
+        /// </summary>
+        /// <param name="memberships">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        IMembership RemoveRedefinedFeatures(IMembership memberships) => this.ComputeRemoveRedefinedFeaturesOperation(memberships);
+
+        /// <summary>
+        /// If the memberElement of the given membership is a Feature, then return all Features directly or
+        /// indirectly redefined by the memberElement.
+        /// </summary>
+        /// <param name="membership">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        IFeature AllRedefinedFeaturesOf(IMembership membership) => this.ComputeAllRedefinedFeaturesOfOperation(membership);
+
+        /// <summary>
+        /// If the given feature is a feature of this Type, then return its direction relative to this Type,
+        /// taking conjugation into account.
+        /// </summary>
+        /// <param name="feature">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected FeatureDirectionKind
+        /// </returns>
+        FeatureDirectionKind DirectionOf(IFeature feature) => this.ComputeDirectionOfOperation(feature);
+
+        /// <summary>
+        /// Return the direction of the given feature relative to this Type, excluding a given set of Types from
+        /// the search of supertypes of this Type.
+        /// </summary>
+        /// <param name="feature">
+        /// No documentation provided
+        /// </param>
+        /// <param name="excluded">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected FeatureDirectionKind
+        /// </returns>
+        FeatureDirectionKind DirectionOfExcluding(IFeature feature, IType excluded) => this.ComputeDirectionOfExcludingOperation(feature, excluded);
+
+        /// <summary>
+        /// If this Type is conjugated, then return just the originalType of the Conjugation. Otherwise, return
+        /// the general Types from all ownedSpecializations of this type, if excludeImplied = false, or all
+        /// non-implied ownedSpecializations, if excludeImplied = true.
+        /// </summary>
+        /// <param name="excludeImplied">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IType
+        /// </returns>
+        IType Supertypes(bool excludeImplied) => this.ComputeSupertypesOperation(excludeImplied);
+
+        /// <summary>
+        /// Return this Type and all Types that are directly or transitively supertypes of this Type (as
+        /// determined by the supertypes operation with excludeImplied = false).
+        /// </summary>
+        /// <returns>
+        /// The expected IType
+        /// </returns>
+        IType AllSupertypes() => this.ComputeAllSupertypesOperation();
+
+        /// <summary>
+        /// Check whether this Type is a direct or indirect specialization of the given supertype.
+        /// </summary>
+        /// <param name="supertype">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool Specializes(IType supertype) => this.ComputeSpecializesOperation(supertype);
+
+        /// <summary>
+        /// Check whether this Type is a direct or indirect specialization of the named library Type.
+        /// libraryTypeName must conform to the syntax of a KerML qualified name and must resolve to a Type in
+        /// global scope.
+        /// </summary>
+        /// <param name="libraryTypeName">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool SpecializesFromLibrary(string libraryTypeName) => this.ComputeSpecializesFromLibraryOperation(libraryTypeName);
+
+        /// <summary>
+        /// By default, this Type is compatible with an otherType if it directly or indirectly specializes the
+        /// otherType.
+        /// </summary>
+        /// <param name="otherType">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool IsCompatibleWith(IType otherType) => this.ComputeIsCompatibleWithOperation(otherType);
+
+        /// <summary>
+        /// Return the owned or inherited Multiplicities for this Type<./code>.
+        /// </summary>
+        /// <returns>
+        /// The expected IMultiplicity
+        /// </returns>
+        IMultiplicity Multiplicities() => this.ComputeMultiplicitiesOperation();
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IUsage.cs
@@ -341,6 +341,23 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674979_190614_43269")]
         List<IVariantMembership> variantMembership { get; }
 
+        /// <summary>
+        /// If this Usage is a variant, then its naming Feature is the referencedFeature of its
+        /// ownedReferenceSubsetting.
+        /// </summary>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        new IFeature NamingFeature() => this.ComputeRedefinedNamingFeatureOperation();
+
+        /// <summary>
+        /// If ownedReferenceSubsetting is not null, return the featureTarget of the referencedFeature of the
+        /// ownedReferenceSubsetting.
+        /// </summary>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        IFeature ReferencedFeatureTarget() => this.ComputeReferencedFeatureTargetOperation();
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IViewUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IViewUsage.cs
@@ -109,6 +109,16 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         [Property(xmiId: "_19_0_2_12e503d9_1596657318021_274182_5067", aggregation: AggregationKind.None, lowerValue: 0, upperValue: 1, isOrdered: false, isReadOnly: false, isDerived: true, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         IRenderingUsage viewRendering { get; }
 
+        /// <summary>
+        /// Determine whether the given element meets all the owned and inherited viewConditions.
+        /// </summary>
+        /// <param name="element">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        bool IncludeAsExposed(IElement element) => this.ComputeIncludeAsExposedOperation(element);
     }
 }
 

--- a/SysML2.NET/Core/AutoGenPoco/IfActionUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IfActionUsage.cs
@@ -936,7 +936,7 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/IncludeUseCaseUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IncludeUseCaseUsage.cs
@@ -1001,7 +1001,7 @@ namespace SysML2.NET.Core.POCO.Systems.UseCases
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/IndexExpression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/IndexExpression.cs
@@ -646,7 +646,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Interaction.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Interaction.cs
@@ -431,7 +431,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Interactions
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -442,7 +442,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Interactions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/InterfaceDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/InterfaceDefinition.cs
@@ -653,7 +653,7 @@ namespace SysML2.NET.Core.POCO.Systems.Interfaces
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -664,7 +664,7 @@ namespace SysML2.NET.Core.POCO.Systems.Interfaces
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/InterfaceUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/InterfaceUsage.cs
@@ -971,7 +971,7 @@ namespace SysML2.NET.Core.POCO.Systems.Interfaces
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -982,7 +982,7 @@ namespace SysML2.NET.Core.POCO.Systems.Interfaces
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Intersecting.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Intersecting.cs
@@ -175,7 +175,7 @@ namespace SysML2.NET.Core.POCO.Core.Types
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -186,7 +186,7 @@ namespace SysML2.NET.Core.POCO.Core.Types
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Invariant.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Invariant.cs
@@ -613,7 +613,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/InvocationExpression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/InvocationExpression.cs
@@ -627,7 +627,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ItemDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ItemDefinition.cs
@@ -598,7 +598,7 @@ namespace SysML2.NET.Core.POCO.Systems.Items
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ItemUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ItemUsage.cs
@@ -910,7 +910,7 @@ namespace SysML2.NET.Core.POCO.Systems.Items
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/JoinNode.cs
+++ b/SysML2.NET/Core/AutoGenPoco/JoinNode.cs
@@ -918,7 +918,7 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/LibraryPackage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/LibraryPackage.cs
@@ -227,7 +227,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Packages
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/LiteralBoolean.cs
+++ b/SysML2.NET/Core/AutoGenPoco/LiteralBoolean.cs
@@ -605,7 +605,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/LiteralExpression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/LiteralExpression.cs
@@ -604,7 +604,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/LiteralInfinity.cs
+++ b/SysML2.NET/Core/AutoGenPoco/LiteralInfinity.cs
@@ -605,7 +605,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/LiteralInteger.cs
+++ b/SysML2.NET/Core/AutoGenPoco/LiteralInteger.cs
@@ -605,7 +605,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/LiteralRational.cs
+++ b/SysML2.NET/Core/AutoGenPoco/LiteralRational.cs
@@ -605,7 +605,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/LiteralString.cs
+++ b/SysML2.NET/Core/AutoGenPoco/LiteralString.cs
@@ -605,7 +605,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Membership.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Membership.cs
@@ -211,7 +211,7 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -222,7 +222,7 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/MembershipExpose.cs
+++ b/SysML2.NET/Core/AutoGenPoco/MembershipExpose.cs
@@ -223,7 +223,7 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -234,7 +234,7 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/MembershipImport.cs
+++ b/SysML2.NET/Core/AutoGenPoco/MembershipImport.cs
@@ -207,7 +207,7 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -218,7 +218,7 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/MergeNode.cs
+++ b/SysML2.NET/Core/AutoGenPoco/MergeNode.cs
@@ -918,7 +918,7 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Metaclass.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Metaclass.cs
@@ -405,7 +405,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Metadata
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/MetadataAccessExpression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/MetadataAccessExpression.cs
@@ -34,6 +34,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
     using SysML2.NET.Core.POCO.Core.Types;
     using SysML2.NET.Core.POCO.Kernel.Behaviors;
     using SysML2.NET.Core.POCO.Kernel.Functions;
+    using SysML2.NET.Core.POCO.Kernel.Metadata;
     using SysML2.NET.Core.POCO.Root.Annotations;
     using SysML2.NET.Core.POCO.Root.Elements;
     using SysML2.NET.Core.POCO.Root.Namespaces;
@@ -607,7 +608,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/MetadataDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/MetadataDefinition.cs
@@ -595,7 +595,7 @@ namespace SysML2.NET.Core.POCO.Systems.Metadata
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/MetadataFeature.cs
+++ b/SysML2.NET/Core/AutoGenPoco/MetadataFeature.cs
@@ -614,7 +614,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Metadata
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/MetadataUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/MetadataUsage.cs
@@ -956,7 +956,7 @@ namespace SysML2.NET.Core.POCO.Systems.Metadata
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Multiplicity.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Multiplicity.cs
@@ -587,7 +587,7 @@ namespace SysML2.NET.Core.POCO.Core.Types
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/MultiplicityRange.cs
+++ b/SysML2.NET/Core/AutoGenPoco/MultiplicityRange.cs
@@ -602,7 +602,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Multiplicities
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Namespace.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Namespace.cs
@@ -29,6 +29,7 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
     using System.Collections.Generic;
     using System.Linq;
 
+    using SysML2.NET.Core.Root.Namespaces;
     using SysML2.NET.Core.POCO.Root.Annotations;
     using SysML2.NET.Core.POCO.Root.Elements;
     using SysML2.NET.Collections;
@@ -215,7 +216,7 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/NamespaceExpose.cs
+++ b/SysML2.NET/Core/AutoGenPoco/NamespaceExpose.cs
@@ -223,7 +223,7 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -234,7 +234,7 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/NamespaceImport.cs
+++ b/SysML2.NET/Core/AutoGenPoco/NamespaceImport.cs
@@ -208,7 +208,7 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -219,7 +219,7 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/NullExpression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/NullExpression.cs
@@ -604,7 +604,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ObjectiveMembership.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ObjectiveMembership.cs
@@ -279,7 +279,7 @@ namespace SysML2.NET.Core.POCO.Systems.Cases
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -290,7 +290,7 @@ namespace SysML2.NET.Core.POCO.Systems.Cases
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/OccurrenceDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/OccurrenceDefinition.cs
@@ -598,7 +598,7 @@ namespace SysML2.NET.Core.POCO.Systems.Occurrences
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/OccurrenceUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/OccurrenceUsage.cs
@@ -899,7 +899,7 @@ namespace SysML2.NET.Core.POCO.Systems.Occurrences
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/OperatorExpression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/OperatorExpression.cs
@@ -631,7 +631,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/OwningMembership.cs
+++ b/SysML2.NET/Core/AutoGenPoco/OwningMembership.cs
@@ -255,7 +255,7 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -266,7 +266,7 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Package.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Package.cs
@@ -219,7 +219,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Packages
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ParameterMembership.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ParameterMembership.cs
@@ -29,6 +29,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Behaviors
     using System.Collections.Generic;
     using System.Linq;
 
+    using SysML2.NET.Core.Core.Types;
     using SysML2.NET.Core.Root.Namespaces;
     using SysML2.NET.Core.POCO.Core.Features;
     using SysML2.NET.Core.POCO.Core.Types;
@@ -279,7 +280,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Behaviors
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -290,7 +291,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Behaviors
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/PartDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/PartDefinition.cs
@@ -596,7 +596,7 @@ namespace SysML2.NET.Core.POCO.Systems.Parts
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/PartUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/PartUsage.cs
@@ -909,7 +909,7 @@ namespace SysML2.NET.Core.POCO.Systems.Parts
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/PayloadFeature.cs
+++ b/SysML2.NET/Core/AutoGenPoco/PayloadFeature.cs
@@ -577,7 +577,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Interactions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/PerformActionUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/PerformActionUsage.cs
@@ -939,7 +939,7 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/PortConjugation.cs
+++ b/SysML2.NET/Core/AutoGenPoco/PortConjugation.cs
@@ -213,7 +213,7 @@ namespace SysML2.NET.Core.POCO.Systems.Ports
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -224,7 +224,7 @@ namespace SysML2.NET.Core.POCO.Systems.Ports
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/PortDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/PortDefinition.cs
@@ -605,7 +605,7 @@ namespace SysML2.NET.Core.POCO.Systems.Ports
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/PortUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/PortUsage.cs
@@ -898,7 +898,7 @@ namespace SysML2.NET.Core.POCO.Systems.Ports
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Predicate.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Predicate.cs
@@ -425,7 +425,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Redefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Redefinition.cs
@@ -196,7 +196,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -207,7 +207,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ReferenceSubsetting.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ReferenceSubsetting.cs
@@ -190,7 +190,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -201,7 +201,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ReferenceUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ReferenceUsage.cs
@@ -880,7 +880,7 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/RenderingDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/RenderingDefinition.cs
@@ -595,7 +595,7 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/RenderingUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/RenderingUsage.cs
@@ -908,7 +908,7 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/RequirementConstraintMembership.cs
+++ b/SysML2.NET/Core/AutoGenPoco/RequirementConstraintMembership.cs
@@ -287,7 +287,7 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -298,7 +298,7 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/RequirementDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/RequirementDefinition.cs
@@ -653,7 +653,7 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/RequirementUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/RequirementUsage.cs
@@ -971,7 +971,7 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/RequirementVerificationMembership.cs
+++ b/SysML2.NET/Core/AutoGenPoco/RequirementVerificationMembership.cs
@@ -305,7 +305,7 @@ namespace SysML2.NET.Core.POCO.Systems.VerificationCases
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -316,7 +316,7 @@ namespace SysML2.NET.Core.POCO.Systems.VerificationCases
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ResultExpressionMembership.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ResultExpressionMembership.cs
@@ -272,7 +272,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -283,7 +283,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ReturnParameterMembership.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ReturnParameterMembership.cs
@@ -29,6 +29,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
     using System.Collections.Generic;
     using System.Linq;
 
+    using SysML2.NET.Core.Core.Types;
     using SysML2.NET.Core.Root.Namespaces;
     using SysML2.NET.Core.POCO.Core.Features;
     using SysML2.NET.Core.POCO.Core.Types;
@@ -280,7 +281,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -291,7 +292,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/SatisfyRequirementUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/SatisfyRequirementUsage.cs
@@ -991,7 +991,7 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/SelectExpression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/SelectExpression.cs
@@ -646,7 +646,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/SendActionUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/SendActionUsage.cs
@@ -923,7 +923,7 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Specialization.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Specialization.cs
@@ -175,7 +175,7 @@ namespace SysML2.NET.Core.POCO.Core.Types
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -186,7 +186,7 @@ namespace SysML2.NET.Core.POCO.Core.Types
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/StakeholderMembership.cs
+++ b/SysML2.NET/Core/AutoGenPoco/StakeholderMembership.cs
@@ -282,7 +282,7 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -293,7 +293,7 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/StateDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/StateDefinition.cs
@@ -644,7 +644,7 @@ namespace SysML2.NET.Core.POCO.Systems.States
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/StateSubactionMembership.cs
+++ b/SysML2.NET/Core/AutoGenPoco/StateSubactionMembership.cs
@@ -287,7 +287,7 @@ namespace SysML2.NET.Core.POCO.Systems.States
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -298,7 +298,7 @@ namespace SysML2.NET.Core.POCO.Systems.States
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/StateUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/StateUsage.cs
@@ -958,7 +958,7 @@ namespace SysML2.NET.Core.POCO.Systems.States
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Step.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Step.cs
@@ -588,7 +588,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Behaviors
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Structure.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Structure.cs
@@ -407,7 +407,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Structures
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Subclassification.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Subclassification.cs
@@ -186,7 +186,7 @@ namespace SysML2.NET.Core.POCO.Core.Classifiers
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -197,7 +197,7 @@ namespace SysML2.NET.Core.POCO.Core.Classifiers
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/SubjectMembership.cs
+++ b/SysML2.NET/Core/AutoGenPoco/SubjectMembership.cs
@@ -282,7 +282,7 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -293,7 +293,7 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Subsetting.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Subsetting.cs
@@ -190,7 +190,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -201,7 +201,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Succession.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Succession.cs
@@ -617,7 +617,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Connectors
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -628,7 +628,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Connectors
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/SuccessionAsUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/SuccessionAsUsage.cs
@@ -909,7 +909,7 @@ namespace SysML2.NET.Core.POCO.Systems.Connections
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -920,7 +920,7 @@ namespace SysML2.NET.Core.POCO.Systems.Connections
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/SuccessionFlow.cs
+++ b/SysML2.NET/Core/AutoGenPoco/SuccessionFlow.cs
@@ -651,7 +651,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Interactions
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -662,7 +662,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Interactions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/SuccessionFlowUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/SuccessionFlowUsage.cs
@@ -990,7 +990,7 @@ namespace SysML2.NET.Core.POCO.Systems.Flows
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -1001,7 +1001,7 @@ namespace SysML2.NET.Core.POCO.Systems.Flows
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/TerminateActionUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/TerminateActionUsage.cs
@@ -922,7 +922,7 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/TextualRepresentation.cs
+++ b/SysML2.NET/Core/AutoGenPoco/TextualRepresentation.cs
@@ -222,7 +222,7 @@ namespace SysML2.NET.Core.POCO.Root.Annotations
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/TransitionFeatureMembership.cs
+++ b/SysML2.NET/Core/AutoGenPoco/TransitionFeatureMembership.cs
@@ -280,7 +280,7 @@ namespace SysML2.NET.Core.POCO.Systems.States
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -291,7 +291,7 @@ namespace SysML2.NET.Core.POCO.Systems.States
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/TransitionUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/TransitionUsage.cs
@@ -944,7 +944,7 @@ namespace SysML2.NET.Core.POCO.Systems.States
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/TriggerInvocationExpression.cs
+++ b/SysML2.NET/Core/AutoGenPoco/TriggerInvocationExpression.cs
@@ -633,7 +633,7 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Type.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Type.cs
@@ -29,6 +29,7 @@ namespace SysML2.NET.Core.POCO.Core.Types
     using System.Collections.Generic;
     using System.Linq;
 
+    using SysML2.NET.Core.Core.Types;
     using SysML2.NET.Core.POCO.Core.Features;
     using SysML2.NET.Core.POCO.Root.Annotations;
     using SysML2.NET.Core.POCO.Root.Elements;
@@ -404,7 +405,7 @@ namespace SysML2.NET.Core.POCO.Core.Types
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/TypeFeaturing.cs
+++ b/SysML2.NET/Core/AutoGenPoco/TypeFeaturing.cs
@@ -183,7 +183,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -194,7 +194,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Unioning.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Unioning.cs
@@ -165,7 +165,7 @@ namespace SysML2.NET.Core.POCO.Core.Types
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -176,7 +176,7 @@ namespace SysML2.NET.Core.POCO.Core.Types
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/Usage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/Usage.cs
@@ -874,7 +874,7 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/UseCaseDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/UseCaseDefinition.cs
@@ -659,7 +659,7 @@ namespace SysML2.NET.Core.POCO.Systems.UseCases
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/UseCaseUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/UseCaseUsage.cs
@@ -979,7 +979,7 @@ namespace SysML2.NET.Core.POCO.Systems.UseCases
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/VariantMembership.cs
+++ b/SysML2.NET/Core/AutoGenPoco/VariantMembership.cs
@@ -258,7 +258,7 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -269,7 +269,7 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/VerificationCaseDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/VerificationCaseDefinition.cs
@@ -650,7 +650,7 @@ namespace SysML2.NET.Core.POCO.Systems.VerificationCases
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/VerificationCaseUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/VerificationCaseUsage.cs
@@ -970,7 +970,7 @@ namespace SysML2.NET.Core.POCO.Systems.VerificationCases
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ViewDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ViewDefinition.cs
@@ -597,7 +597,7 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ViewRenderingMembership.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ViewRenderingMembership.cs
@@ -270,7 +270,7 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         [Property(xmiId: "_18_5_3_12e503d9_1533160674986_59873_43302", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_132339_43177")]
         [Implements(implementation: "IRelationship.OwnedRelatedElement")]
-        public IReadOnlyCollection<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
+        public IReadOnlyList<IElement> OwnedRelatedElement => ((IContainedRelationship)this).OwnedRelatedElement;
 
         /// <summary>Backing field for IRelationship.OwnedRelatedElement</summary>
         ContainerList<IRelationship, IElement> IContainedRelationship.OwnedRelatedElement { get; set; }
@@ -281,7 +281,7 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ViewUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ViewUsage.cs
@@ -919,7 +919,7 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ViewpointDefinition.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ViewpointDefinition.cs
@@ -652,7 +652,7 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/ViewpointUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/ViewpointUsage.cs
@@ -971,7 +971,7 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Core/AutoGenPoco/WhileLoopActionUsage.cs
+++ b/SysML2.NET/Core/AutoGenPoco/WhileLoopActionUsage.cs
@@ -930,7 +930,7 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         [Property(xmiId: "_18_5_3_12e503d9_1543092026091_217766_16748", aggregation: AggregationKind.Composite, lowerValue: 0, upperValue: int.MaxValue, isOrdered: true, isReadOnly: false, isDerived: false, isDerivedUnion: false, isUnique: true, defaultValue: null)]
         [SubsettedProperty(propertyName: "_18_5_3_12e503d9_1533160674961_585972_43176")]
         [Implements(implementation: "IElement.OwnedRelationship")]
-        public IReadOnlyCollection<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
+        public IReadOnlyList<IRelationship> OwnedRelationship => ((IContainedElement)this).OwnedRelationship;
 
         /// <summary>Backing field for IElement.OwnedRelationship</summary>
         ContainerList<IElement, IRelationship> IContainedElement.OwnedRelationship { get; set; }

--- a/SysML2.NET/Extend/AcceptActionUsageExtensions.cs
+++ b/SysML2.NET/Extend/AcceptActionUsageExtensions.cs
@@ -60,23 +60,19 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
     /// The <see cref="AcceptActionUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IAcceptActionUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class AcceptActionUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="acceptActionUsage">
+        /// <param name="acceptActionUsageSubject">
         /// The subject <see cref="IAcceptActionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IExpression ComputePayloadArgument(this IAcceptActionUsage acceptActionUsage)
+        internal static IExpression ComputePayloadArgument(this IAcceptActionUsage acceptActionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -84,14 +80,14 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="acceptActionUsage">
+        /// <param name="acceptActionUsageSubject">
         /// The subject <see cref="IAcceptActionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IReferenceUsage ComputePayloadParameter(this IAcceptActionUsage acceptActionUsage)
+        internal static IReferenceUsage ComputePayloadParameter(this IAcceptActionUsage acceptActionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -99,17 +95,31 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="acceptActionUsage">
+        /// <param name="acceptActionUsageSubject">
         /// The subject <see cref="IAcceptActionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IExpression ComputeReceiverArgument(this IAcceptActionUsage acceptActionUsage)
+        internal static IExpression ComputeReceiverArgument(this IAcceptActionUsage acceptActionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// Check if this AcceptActionUsage is the triggerAction of a TransitionUsage.
+        /// </summary>
+        /// <param name="acceptActionUsageSubject">
+        /// The subject <see cref="IAcceptActionUsage"/>
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeIsTriggerActionOperation(this IAcceptActionUsage acceptActionUsageSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/ActionDefinitionExtensions.cs
+++ b/SysML2.NET/Extend/ActionDefinitionExtensions.cs
@@ -56,23 +56,19 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
     /// The <see cref="ActionDefinitionExtensions"/> class provides extensions methods for
     /// the <see cref="IActionDefinition"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ActionDefinitionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="actionDefinition">
+        /// <param name="actionDefinitionSubject">
         /// The subject <see cref="IActionDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IActionUsage> ComputeAction(this IActionDefinition actionDefinition)
+        internal static List<IActionUsage> ComputeAction(this IActionDefinition actionDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/ActionUsageExtensions.cs
+++ b/SysML2.NET/Extend/ActionUsageExtensions.cs
@@ -30,6 +30,7 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
     using SysML2.NET.Core.POCO.Core.Types;
     using SysML2.NET.Core.POCO.Kernel.Behaviors;
     using SysML2.NET.Core.POCO.Kernel.Classes;
+    using SysML2.NET.Core.POCO.Kernel.Functions;
     using SysML2.NET.Core.POCO.Root.Annotations;
     using SysML2.NET.Core.POCO.Root.Elements;
     using SysML2.NET.Core.POCO.Root.Namespaces;
@@ -59,26 +60,92 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
     /// The <see cref="ActionUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IActionUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ActionUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="actionUsage">
+        /// <param name="actionUsageSubject">
         /// The subject <see cref="IActionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IBehavior> ComputeActionDefinition(this IActionUsage actionUsage)
+        internal static List<IBehavior> ComputeActionDefinition(this IActionUsage actionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// Return the owned input parameters of this ActionUsage.
+        /// </summary>
+        /// <param name="actionUsageSubject">
+        /// The subject <see cref="IActionUsage"/>
+        /// </param>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IFeature ComputeInputParametersOperation(this IActionUsage actionUsageSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return the i-th owned input parameter of the ActionUsage. Return null if the ActionUsage has less
+        /// than i owned input parameters.
+        /// </summary>
+        /// <param name="actionUsageSubject">
+        /// The subject <see cref="IActionUsage"/>
+        /// </param>
+        /// <param name="i">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IFeature ComputeInputParameterOperation(this IActionUsage actionUsageSubject, int i)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return the i-th argument Expression of an ActionUsage, defined as the value Expression of the
+        /// FeatureValue of the i-th owned input parameter of the ActionUsage. Return null if the ActionUsage
+        /// has less than i owned input parameters or the i-th owned input parameter has no FeatureValue.
+        /// </summary>
+        /// <param name="actionUsageSubject">
+        /// The subject <see cref="IActionUsage"/>
+        /// </param>
+        /// <param name="i">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IExpression
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IExpression ComputeArgumentOperation(this IActionUsage actionUsageSubject, int i)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Check if this ActionUsage is composite and has an owningType that is an ActionDefinition or
+        /// ActionUsage but is not the entryAction or exitAction of a StateDefinition or StateUsage. If so, then
+        /// it represents an Action that is a subaction of another Action.
+        /// </summary>
+        /// <param name="actionUsageSubject">
+        /// The subject <see cref="IActionUsage"/>
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeIsSubactionUsageOperation(this IActionUsage actionUsageSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/ActorMembershipExtensions.cs
+++ b/SysML2.NET/Extend/ActorMembershipExtensions.cs
@@ -36,23 +36,19 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
     /// The <see cref="ActorMembershipExtensions"/> class provides extensions methods for
     /// the <see cref="IActorMembership"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ActorMembershipExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="actorMembership">
+        /// <param name="actorMembershipSubject">
         /// The subject <see cref="IActorMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IPartUsage ComputeOwnedActorParameter(this IActorMembership actorMembership)
+        internal static IPartUsage ComputeOwnedActorParameter(this IActorMembership actorMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/AllocationDefinitionExtensions.cs
+++ b/SysML2.NET/Extend/AllocationDefinitionExtensions.cs
@@ -26,6 +26,7 @@ namespace SysML2.NET.Core.POCO.Systems.Allocations
     using SysML2.NET.Core.POCO.Core.Classifiers;
     using SysML2.NET.Core.POCO.Core.Features;
     using SysML2.NET.Core.POCO.Core.Types;
+    using SysML2.NET.Core.POCO.Kernel.Associations;
     using SysML2.NET.Core.POCO.Root.Annotations;
     using SysML2.NET.Core.POCO.Root.Elements;
     using SysML2.NET.Core.POCO.Root.Namespaces;
@@ -55,23 +56,19 @@ namespace SysML2.NET.Core.POCO.Systems.Allocations
     /// The <see cref="AllocationDefinitionExtensions"/> class provides extensions methods for
     /// the <see cref="IAllocationDefinition"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class AllocationDefinitionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="allocationDefinition">
+        /// <param name="allocationDefinitionSubject">
         /// The subject <see cref="IAllocationDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IAllocationUsage> ComputeAllocation(this IAllocationDefinition allocationDefinition)
+        internal static List<IAllocationUsage> ComputeAllocation(this IAllocationDefinition allocationDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/AllocationUsageExtensions.cs
+++ b/SysML2.NET/Extend/AllocationUsageExtensions.cs
@@ -30,6 +30,7 @@ namespace SysML2.NET.Core.POCO.Systems.Allocations
     using SysML2.NET.Core.POCO.Core.Types;
     using SysML2.NET.Core.POCO.Kernel.Associations;
     using SysML2.NET.Core.POCO.Kernel.Classes;
+    using SysML2.NET.Core.POCO.Kernel.Connectors;
     using SysML2.NET.Core.POCO.Kernel.Structures;
     using SysML2.NET.Core.POCO.Root.Annotations;
     using SysML2.NET.Core.POCO.Root.Elements;
@@ -60,23 +61,19 @@ namespace SysML2.NET.Core.POCO.Systems.Allocations
     /// The <see cref="AllocationUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IAllocationUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class AllocationUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="allocationUsage">
+        /// <param name="allocationUsageSubject">
         /// The subject <see cref="IAllocationUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IAllocationDefinition> ComputeAllocationDefinition(this IAllocationUsage allocationUsage)
+        internal static List<IAllocationDefinition> ComputeAllocationDefinition(this IAllocationUsage allocationUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/AnalysisCaseDefinitionExtensions.cs
+++ b/SysML2.NET/Extend/AnalysisCaseDefinitionExtensions.cs
@@ -57,23 +57,19 @@ namespace SysML2.NET.Core.POCO.Systems.AnalysisCases
     /// The <see cref="AnalysisCaseDefinitionExtensions"/> class provides extensions methods for
     /// the <see cref="IAnalysisCaseDefinition"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class AnalysisCaseDefinitionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="analysisCaseDefinition">
+        /// <param name="analysisCaseDefinitionSubject">
         /// The subject <see cref="IAnalysisCaseDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IExpression ComputeResultExpression(this IAnalysisCaseDefinition analysisCaseDefinition)
+        internal static IExpression ComputeResultExpression(this IAnalysisCaseDefinition analysisCaseDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/AnalysisCaseUsageExtensions.cs
+++ b/SysML2.NET/Extend/AnalysisCaseUsageExtensions.cs
@@ -60,23 +60,19 @@ namespace SysML2.NET.Core.POCO.Systems.AnalysisCases
     /// The <see cref="AnalysisCaseUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IAnalysisCaseUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class AnalysisCaseUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="analysisCaseUsage">
+        /// <param name="analysisCaseUsageSubject">
         /// The subject <see cref="IAnalysisCaseUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IAnalysisCaseDefinition ComputeAnalysisCaseDefinition(this IAnalysisCaseUsage analysisCaseUsage)
+        internal static IAnalysisCaseDefinition ComputeAnalysisCaseDefinition(this IAnalysisCaseUsage analysisCaseUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -84,14 +80,14 @@ namespace SysML2.NET.Core.POCO.Systems.AnalysisCases
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="analysisCaseUsage">
+        /// <param name="analysisCaseUsageSubject">
         /// The subject <see cref="IAnalysisCaseUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IExpression ComputeResultExpression(this IAnalysisCaseUsage analysisCaseUsage)
+        internal static IExpression ComputeResultExpression(this IAnalysisCaseUsage analysisCaseUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/AnnotatingElementExtensions.cs
+++ b/SysML2.NET/Extend/AnnotatingElementExtensions.cs
@@ -30,23 +30,19 @@ namespace SysML2.NET.Core.POCO.Root.Annotations
     /// The <see cref="AnnotatingElementExtensions"/> class provides extensions methods for
     /// the <see cref="IAnnotatingElement"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class AnnotatingElementExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="annotatingElement">
+        /// <param name="annotatingElementSubject">
         /// The subject <see cref="IAnnotatingElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IElement> ComputeAnnotatedElement(this IAnnotatingElement annotatingElement)
+        internal static List<IElement> ComputeAnnotatedElement(this IAnnotatingElement annotatingElementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -54,14 +50,14 @@ namespace SysML2.NET.Core.POCO.Root.Annotations
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="annotatingElement">
+        /// <param name="annotatingElementSubject">
         /// The subject <see cref="IAnnotatingElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IAnnotation> ComputeAnnotation(this IAnnotatingElement annotatingElement)
+        internal static List<IAnnotation> ComputeAnnotation(this IAnnotatingElement annotatingElementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -69,14 +65,14 @@ namespace SysML2.NET.Core.POCO.Root.Annotations
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="annotatingElement">
+        /// <param name="annotatingElementSubject">
         /// The subject <see cref="IAnnotatingElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IAnnotation> ComputeOwnedAnnotatingRelationship(this IAnnotatingElement annotatingElement)
+        internal static List<IAnnotation> ComputeOwnedAnnotatingRelationship(this IAnnotatingElement annotatingElementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -84,14 +80,14 @@ namespace SysML2.NET.Core.POCO.Root.Annotations
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="annotatingElement">
+        /// <param name="annotatingElementSubject">
         /// The subject <see cref="IAnnotatingElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IAnnotation ComputeOwningAnnotatingRelationship(this IAnnotatingElement annotatingElement)
+        internal static IAnnotation ComputeOwningAnnotatingRelationship(this IAnnotatingElement annotatingElementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/AnnotationExtensions.cs
+++ b/SysML2.NET/Extend/AnnotationExtensions.cs
@@ -30,23 +30,19 @@ namespace SysML2.NET.Core.POCO.Root.Annotations
     /// The <see cref="AnnotationExtensions"/> class provides extensions methods for
     /// the <see cref="IAnnotation"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class AnnotationExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="annotation">
+        /// <param name="annotationSubject">
         /// The subject <see cref="IAnnotation"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IAnnotatingElement ComputeAnnotatingElement(this IAnnotation annotation)
+        internal static IAnnotatingElement ComputeAnnotatingElement(this IAnnotation annotationSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -54,14 +50,14 @@ namespace SysML2.NET.Core.POCO.Root.Annotations
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="annotation">
+        /// <param name="annotationSubject">
         /// The subject <see cref="IAnnotation"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IAnnotatingElement ComputeOwnedAnnotatingElement(this IAnnotation annotation)
+        internal static IAnnotatingElement ComputeOwnedAnnotatingElement(this IAnnotation annotationSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -69,14 +65,14 @@ namespace SysML2.NET.Core.POCO.Root.Annotations
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="annotation">
+        /// <param name="annotationSubject">
         /// The subject <see cref="IAnnotation"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IElement ComputeOwningAnnotatedElement(this IAnnotation annotation)
+        internal static IElement ComputeOwningAnnotatedElement(this IAnnotation annotationSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -84,14 +80,14 @@ namespace SysML2.NET.Core.POCO.Root.Annotations
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="annotation">
+        /// <param name="annotationSubject">
         /// The subject <see cref="IAnnotation"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IAnnotatingElement ComputeOwningAnnotatingElement(this IAnnotation annotation)
+        internal static IAnnotatingElement ComputeOwningAnnotatingElement(this IAnnotation annotationSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/AssertConstraintUsageExtensions.cs
+++ b/SysML2.NET/Extend/AssertConstraintUsageExtensions.cs
@@ -60,23 +60,19 @@ namespace SysML2.NET.Core.POCO.Systems.Constraints
     /// The <see cref="AssertConstraintUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IAssertConstraintUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class AssertConstraintUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="assertConstraintUsage">
+        /// <param name="assertConstraintUsageSubject">
         /// The subject <see cref="IAssertConstraintUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IConstraintUsage ComputeAssertedConstraint(this IAssertConstraintUsage assertConstraintUsage)
+        internal static IConstraintUsage ComputeAssertedConstraint(this IAssertConstraintUsage assertConstraintUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/AssignmentActionUsageExtensions.cs
+++ b/SysML2.NET/Extend/AssignmentActionUsageExtensions.cs
@@ -60,23 +60,19 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
     /// The <see cref="AssignmentActionUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IAssignmentActionUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class AssignmentActionUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="assignmentActionUsage">
+        /// <param name="assignmentActionUsageSubject">
         /// The subject <see cref="IAssignmentActionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeReferent(this IAssignmentActionUsage assignmentActionUsage)
+        internal static IFeature ComputeReferent(this IAssignmentActionUsage assignmentActionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -84,14 +80,14 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="assignmentActionUsage">
+        /// <param name="assignmentActionUsageSubject">
         /// The subject <see cref="IAssignmentActionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IExpression ComputeTargetArgument(this IAssignmentActionUsage assignmentActionUsage)
+        internal static IExpression ComputeTargetArgument(this IAssignmentActionUsage assignmentActionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -99,14 +95,14 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="assignmentActionUsage">
+        /// <param name="assignmentActionUsageSubject">
         /// The subject <see cref="IAssignmentActionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IExpression ComputeValueExpression(this IAssignmentActionUsage assignmentActionUsage)
+        internal static IExpression ComputeValueExpression(this IAssignmentActionUsage assignmentActionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/AssociationExtensions.cs
+++ b/SysML2.NET/Extend/AssociationExtensions.cs
@@ -34,23 +34,19 @@ namespace SysML2.NET.Core.POCO.Kernel.Associations
     /// The <see cref="AssociationExtensions"/> class provides extensions methods for
     /// the <see cref="IAssociation"/> interface
     /// </summary>
-    
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]internal static class AssociationExtensions
+    internal static class AssociationExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="association">
+        /// <param name="associationSubject">
         /// The subject <see cref="IAssociation"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeature> ComputeAssociationEnd(this IAssociation association)
+        internal static List<IFeature> ComputeAssociationEnd(this IAssociation associationSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -58,14 +54,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Associations
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="association">
+        /// <param name="associationSubject">
         /// The subject <see cref="IAssociation"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IType> ComputeRelatedType(this IAssociation association)
+        internal static List<IType> ComputeRelatedType(this IAssociation associationSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -73,14 +69,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Associations
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="association">
+        /// <param name="associationSubject">
         /// The subject <see cref="IAssociation"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IType ComputeSourceType(this IAssociation association)
+        internal static IType ComputeSourceType(this IAssociation associationSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -88,14 +84,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Associations
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="association">
+        /// <param name="associationSubject">
         /// The subject <see cref="IAssociation"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IType> ComputeTargetType(this IAssociation association)
+        internal static List<IType> ComputeTargetType(this IAssociation associationSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/AttributeUsageExtensions.cs
+++ b/SysML2.NET/Extend/AttributeUsageExtensions.cs
@@ -57,23 +57,19 @@ namespace SysML2.NET.Core.POCO.Systems.Attributes
     /// The <see cref="AttributeUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IAttributeUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class AttributeUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="attributeUsage">
+        /// <param name="attributeUsageSubject">
         /// The subject <see cref="IAttributeUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IDataType> ComputeAttributeDefinition(this IAttributeUsage attributeUsage)
+        internal static List<IDataType> ComputeAttributeDefinition(this IAttributeUsage attributeUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -81,14 +77,14 @@ namespace SysML2.NET.Core.POCO.Systems.Attributes
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="attributeUsage">
+        /// <param name="attributeUsageSubject">
         /// The subject <see cref="IAttributeUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static bool ComputeIsReference(this IAttributeUsage attributeUsage)
+        internal static bool ComputeIsReference(this IAttributeUsage attributeUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/BehaviorExtensions.cs
+++ b/SysML2.NET/Extend/BehaviorExtensions.cs
@@ -35,23 +35,19 @@ namespace SysML2.NET.Core.POCO.Kernel.Behaviors
     /// The <see cref="BehaviorExtensions"/> class provides extensions methods for
     /// the <see cref="IBehavior"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class BehaviorExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="behavior">
+        /// <param name="behaviorSubject">
         /// The subject <see cref="IBehavior"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeature> ComputeParameter(this IBehavior behavior)
+        internal static List<IFeature> ComputeParameter(this IBehavior behaviorSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -59,14 +55,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Behaviors
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="behavior">
+        /// <param name="behaviorSubject">
         /// The subject <see cref="IBehavior"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IStep> ComputeStep(this IBehavior behavior)
+        internal static List<IStep> ComputeStep(this IBehavior behaviorSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/BooleanExpressionExtensions.cs
+++ b/SysML2.NET/Extend/BooleanExpressionExtensions.cs
@@ -35,23 +35,19 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
     /// The <see cref="BooleanExpressionExtensions"/> class provides extensions methods for
     /// the <see cref="IBooleanExpression"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class BooleanExpressionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="booleanExpression">
+        /// <param name="booleanExpressionSubject">
         /// The subject <see cref="IBooleanExpression"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IPredicate ComputePredicate(this IBooleanExpression booleanExpression)
+        internal static IPredicate ComputePredicate(this IBooleanExpression booleanExpressionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/CalculationDefinitionExtensions.cs
+++ b/SysML2.NET/Extend/CalculationDefinitionExtensions.cs
@@ -57,23 +57,19 @@ namespace SysML2.NET.Core.POCO.Systems.Calculations
     /// The <see cref="CalculationDefinitionExtensions"/> class provides extensions methods for
     /// the <see cref="ICalculationDefinition"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class CalculationDefinitionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="calculationDefinition">
+        /// <param name="calculationDefinitionSubject">
         /// The subject <see cref="ICalculationDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<ICalculationUsage> ComputeCalculation(this ICalculationDefinition calculationDefinition)
+        internal static List<ICalculationUsage> ComputeCalculation(this ICalculationDefinition calculationDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/CalculationUsageExtensions.cs
+++ b/SysML2.NET/Extend/CalculationUsageExtensions.cs
@@ -60,26 +60,39 @@ namespace SysML2.NET.Core.POCO.Systems.Calculations
     /// The <see cref="CalculationUsageExtensions"/> class provides extensions methods for
     /// the <see cref="ICalculationUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class CalculationUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="calculationUsage">
+        /// <param name="calculationUsageSubject">
         /// The subject <see cref="ICalculationUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFunction ComputeCalculationDefinition(this ICalculationUsage calculationUsage)
+        internal static IFunction ComputeCalculationDefinition(this ICalculationUsage calculationUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// A CalculationUsage is not model-level evaluable.
+        /// </summary>
+        /// <param name="calculationUsageSubject">
+        /// The subject <see cref="ICalculationUsage"/>
+        /// </param>
+        /// <param name="visited">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeRedefinedModelLevelEvaluableOperation(this ICalculationUsage calculationUsageSubject, IFeature visited)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/CaseDefinitionExtensions.cs
+++ b/SysML2.NET/Extend/CaseDefinitionExtensions.cs
@@ -57,23 +57,19 @@ namespace SysML2.NET.Core.POCO.Systems.Cases
     /// The <see cref="CaseDefinitionExtensions"/> class provides extensions methods for
     /// the <see cref="ICaseDefinition"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class CaseDefinitionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="caseDefinition">
+        /// <param name="caseDefinitionSubject">
         /// The subject <see cref="ICaseDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IPartUsage> ComputeActorParameter(this ICaseDefinition caseDefinition)
+        internal static List<IPartUsage> ComputeActorParameter(this ICaseDefinition caseDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -81,14 +77,14 @@ namespace SysML2.NET.Core.POCO.Systems.Cases
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="caseDefinition">
+        /// <param name="caseDefinitionSubject">
         /// The subject <see cref="ICaseDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IRequirementUsage ComputeObjectiveRequirement(this ICaseDefinition caseDefinition)
+        internal static IRequirementUsage ComputeObjectiveRequirement(this ICaseDefinition caseDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -96,14 +92,14 @@ namespace SysML2.NET.Core.POCO.Systems.Cases
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="caseDefinition">
+        /// <param name="caseDefinitionSubject">
         /// The subject <see cref="ICaseDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IUsage ComputeSubjectParameter(this ICaseDefinition caseDefinition)
+        internal static IUsage ComputeSubjectParameter(this ICaseDefinition caseDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/CaseUsageExtensions.cs
+++ b/SysML2.NET/Extend/CaseUsageExtensions.cs
@@ -60,23 +60,19 @@ namespace SysML2.NET.Core.POCO.Systems.Cases
     /// The <see cref="CaseUsageExtensions"/> class provides extensions methods for
     /// the <see cref="ICaseUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class CaseUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="caseUsage">
+        /// <param name="caseUsageSubject">
         /// The subject <see cref="ICaseUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IPartUsage> ComputeActorParameter(this ICaseUsage caseUsage)
+        internal static List<IPartUsage> ComputeActorParameter(this ICaseUsage caseUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -84,14 +80,14 @@ namespace SysML2.NET.Core.POCO.Systems.Cases
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="caseUsage">
+        /// <param name="caseUsageSubject">
         /// The subject <see cref="ICaseUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static ICaseDefinition ComputeCaseDefinition(this ICaseUsage caseUsage)
+        internal static ICaseDefinition ComputeCaseDefinition(this ICaseUsage caseUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -99,14 +95,14 @@ namespace SysML2.NET.Core.POCO.Systems.Cases
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="caseUsage">
+        /// <param name="caseUsageSubject">
         /// The subject <see cref="ICaseUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IRequirementUsage ComputeObjectiveRequirement(this ICaseUsage caseUsage)
+        internal static IRequirementUsage ComputeObjectiveRequirement(this ICaseUsage caseUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -114,14 +110,14 @@ namespace SysML2.NET.Core.POCO.Systems.Cases
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="caseUsage">
+        /// <param name="caseUsageSubject">
         /// The subject <see cref="ICaseUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IUsage ComputeSubjectParameter(this ICaseUsage caseUsage)
+        internal static IUsage ComputeSubjectParameter(this ICaseUsage caseUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/ClassifierExtensions.cs
+++ b/SysML2.NET/Extend/ClassifierExtensions.cs
@@ -33,23 +33,19 @@ namespace SysML2.NET.Core.POCO.Core.Classifiers
     /// The <see cref="ClassifierExtensions"/> class provides extensions methods for
     /// the <see cref="IClassifier"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ClassifierExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="classifier">
+        /// <param name="classifierSubject">
         /// The subject <see cref="IClassifier"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<ISubclassification> ComputeOwnedSubclassification(this IClassifier classifier)
+        internal static List<ISubclassification> ComputeOwnedSubclassification(this IClassifier classifierSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/CollectExpressionExtensions.cs
+++ b/SysML2.NET/Extend/CollectExpressionExtensions.cs
@@ -20,16 +20,22 @@
 
 namespace SysML2.NET.Core.POCO.Kernel.Expressions
 {
-    using System.Diagnostics.CodeAnalysis;
- 
+    using System;
+    using System.Collections.Generic;
+
+    using SysML2.NET.Core.Core.Types;
+    using SysML2.NET.Core.POCO.Core.Features;
+    using SysML2.NET.Core.POCO.Core.Types;
+    using SysML2.NET.Core.POCO.Kernel.Behaviors;
+    using SysML2.NET.Core.POCO.Kernel.Functions;
+    using SysML2.NET.Core.POCO.Root.Annotations;
+    using SysML2.NET.Core.POCO.Root.Elements;
+    using SysML2.NET.Core.POCO.Root.Namespaces;
+
     /// <summary>
     /// The <see cref="CollectExpressionExtensions"/> class provides extensions methods for
     /// the <see cref="ICollectExpression"/> interface
     /// </summary>
-    [SuppressMessage(
-        "Major Code Smell",
-        "S2094:Classes should not be empty",
-        Justification = "Extension class intentionally empty; methods are generated conditionally.")]
     internal static class CollectExpressionExtensions
     {
     }

--- a/SysML2.NET/Extend/CommentExtensions.cs
+++ b/SysML2.NET/Extend/CommentExtensions.cs
@@ -20,16 +20,16 @@
 
 namespace SysML2.NET.Core.POCO.Root.Annotations
 {
-    using System.Diagnostics.CodeAnalysis;
-    
+    using System;
+    using System.Collections.Generic;
+
+    using SysML2.NET.Core.POCO.Root.Elements;
+    using SysML2.NET.Core.POCO.Root.Namespaces;
+
     /// <summary>
     /// The <see cref="CommentExtensions"/> class provides extensions methods for
     /// the <see cref="IComment"/> interface
     /// </summary>
-    [SuppressMessage(
-        "Major Code Smell",
-        "S2094:Classes should not be empty",
-        Justification = "Extension class intentionally empty; methods are generated conditionally.")]
     internal static class CommentExtensions
     {
     }

--- a/SysML2.NET/Extend/ConcernUsageExtensions.cs
+++ b/SysML2.NET/Extend/ConcernUsageExtensions.cs
@@ -60,23 +60,19 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
     /// The <see cref="ConcernUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IConcernUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ConcernUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="concernUsage">
+        /// <param name="concernUsageSubject">
         /// The subject <see cref="IConcernUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IConcernDefinition ComputeConcernDefinition(this IConcernUsage concernUsage)
+        internal static IConcernDefinition ComputeConcernDefinition(this IConcernUsage concernUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/ConjugatedPortDefinitionExtensions.cs
+++ b/SysML2.NET/Extend/ConjugatedPortDefinitionExtensions.cs
@@ -55,23 +55,19 @@ namespace SysML2.NET.Core.POCO.Systems.Ports
     /// The <see cref="ConjugatedPortDefinitionExtensions"/> class provides extensions methods for
     /// the <see cref="IConjugatedPortDefinition"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ConjugatedPortDefinitionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="conjugatedPortDefinition">
+        /// <param name="conjugatedPortDefinitionSubject">
         /// The subject <see cref="IConjugatedPortDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IPortDefinition ComputeOriginalPortDefinition(this IConjugatedPortDefinition conjugatedPortDefinition)
+        internal static IPortDefinition ComputeOriginalPortDefinition(this IConjugatedPortDefinition conjugatedPortDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -79,17 +75,32 @@ namespace SysML2.NET.Core.POCO.Systems.Ports
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="conjugatedPortDefinition">
+        /// <param name="conjugatedPortDefinitionSubject">
         /// The subject <see cref="IConjugatedPortDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IPortConjugation ComputeOwnedPortConjugator(this IConjugatedPortDefinition conjugatedPortDefinition)
+        internal static IPortConjugation ComputeOwnedPortConjugator(this IConjugatedPortDefinition conjugatedPortDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// If the name of the originalPortDefinition is non-empty, then return that with the character ~
+        /// prepended.
+        /// </summary>
+        /// <param name="conjugatedPortDefinitionSubject">
+        /// The subject <see cref="IConjugatedPortDefinition"/>
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static string ComputeRedefinedEffectiveNameOperation(this IConjugatedPortDefinition conjugatedPortDefinitionSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/ConjugatedPortTypingExtensions.cs
+++ b/SysML2.NET/Extend/ConjugatedPortTypingExtensions.cs
@@ -33,23 +33,19 @@ namespace SysML2.NET.Core.POCO.Systems.Ports
     /// The <see cref="ConjugatedPortTypingExtensions"/> class provides extensions methods for
     /// the <see cref="IConjugatedPortTyping"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ConjugatedPortTypingExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="conjugatedPortTyping">
+        /// <param name="conjugatedPortTypingSubject">
         /// The subject <see cref="IConjugatedPortTyping"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IPortDefinition ComputePortDefinition(this IConjugatedPortTyping conjugatedPortTyping)
+        internal static IPortDefinition ComputePortDefinition(this IConjugatedPortTyping conjugatedPortTypingSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/ConjugationExtensions.cs
+++ b/SysML2.NET/Extend/ConjugationExtensions.cs
@@ -31,23 +31,19 @@ namespace SysML2.NET.Core.POCO.Core.Types
     /// The <see cref="ConjugationExtensions"/> class provides extensions methods for
     /// the <see cref="IConjugation"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ConjugationExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="conjugation">
+        /// <param name="conjugationSubject">
         /// The subject <see cref="IConjugation"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IType ComputeOwningType(this IConjugation conjugation)
+        internal static IType ComputeOwningType(this IConjugation conjugationSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/ConnectionDefinitionExtensions.cs
+++ b/SysML2.NET/Extend/ConnectionDefinitionExtensions.cs
@@ -56,23 +56,19 @@ namespace SysML2.NET.Core.POCO.Systems.Connections
     /// The <see cref="ConnectionDefinitionExtensions"/> class provides extensions methods for
     /// the <see cref="IConnectionDefinition"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ConnectionDefinitionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="connectionDefinition">
+        /// <param name="connectionDefinitionSubject">
         /// The subject <see cref="IConnectionDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IUsage> ComputeConnectionEnd(this IConnectionDefinition connectionDefinition)
+        internal static List<IUsage> ComputeConnectionEnd(this IConnectionDefinition connectionDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/ConnectionUsageExtensions.cs
+++ b/SysML2.NET/Extend/ConnectionUsageExtensions.cs
@@ -30,6 +30,7 @@ namespace SysML2.NET.Core.POCO.Systems.Connections
     using SysML2.NET.Core.POCO.Core.Types;
     using SysML2.NET.Core.POCO.Kernel.Associations;
     using SysML2.NET.Core.POCO.Kernel.Classes;
+    using SysML2.NET.Core.POCO.Kernel.Connectors;
     using SysML2.NET.Core.POCO.Kernel.Structures;
     using SysML2.NET.Core.POCO.Root.Annotations;
     using SysML2.NET.Core.POCO.Root.Elements;
@@ -60,23 +61,19 @@ namespace SysML2.NET.Core.POCO.Systems.Connections
     /// The <see cref="ConnectionUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IConnectionUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ConnectionUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="connectionUsage">
+        /// <param name="connectionUsageSubject">
         /// The subject <see cref="IConnectionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IAssociationStructure> ComputeConnectionDefinition(this IConnectionUsage connectionUsage)
+        internal static List<IAssociationStructure> ComputeConnectionDefinition(this IConnectionUsage connectionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/ConnectorExtensions.cs
+++ b/SysML2.NET/Extend/ConnectorExtensions.cs
@@ -35,23 +35,19 @@ namespace SysML2.NET.Core.POCO.Kernel.Connectors
     /// The <see cref="ConnectorExtensions"/> class provides extensions methods for
     /// the <see cref="IConnector"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ConnectorExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="connector">
+        /// <param name="connectorSubject">
         /// The subject <see cref="IConnector"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IAssociation> ComputeAssociation(this IConnector connector)
+        internal static List<IAssociation> ComputeAssociation(this IConnector connectorSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -59,14 +55,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Connectors
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="connector">
+        /// <param name="connectorSubject">
         /// The subject <see cref="IConnector"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeature> ComputeConnectorEnd(this IConnector connector)
+        internal static List<IFeature> ComputeConnectorEnd(this IConnector connectorSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -74,14 +70,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Connectors
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="connector">
+        /// <param name="connectorSubject">
         /// The subject <see cref="IConnector"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IType ComputeDefaultFeaturingType(this IConnector connector)
+        internal static IType ComputeDefaultFeaturingType(this IConnector connectorSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -89,14 +85,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Connectors
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="connector">
+        /// <param name="connectorSubject">
         /// The subject <see cref="IConnector"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeature> ComputeRelatedFeature(this IConnector connector)
+        internal static List<IFeature> ComputeRelatedFeature(this IConnector connectorSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -104,14 +100,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Connectors
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="connector">
+        /// <param name="connectorSubject">
         /// The subject <see cref="IConnector"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeSourceFeature(this IConnector connector)
+        internal static IFeature ComputeSourceFeature(this IConnector connectorSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -119,14 +115,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Connectors
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="connector">
+        /// <param name="connectorSubject">
         /// The subject <see cref="IConnector"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeature> ComputeTargetFeature(this IConnector connector)
+        internal static List<IFeature> ComputeTargetFeature(this IConnector connectorSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/ConstraintUsageExtensions.cs
+++ b/SysML2.NET/Extend/ConstraintUsageExtensions.cs
@@ -60,26 +60,56 @@ namespace SysML2.NET.Core.POCO.Systems.Constraints
     /// The <see cref="ConstraintUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IConstraintUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ConstraintUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="constraintUsage">
+        /// <param name="constraintUsageSubject">
         /// The subject <see cref="IConstraintUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IPredicate ComputeConstraintDefinition(this IConstraintUsage constraintUsage)
+        internal static IPredicate ComputeConstraintDefinition(this IConstraintUsage constraintUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// The naming Feature of a ConstraintUsage that is owned by a RequirementConstraintMembership and has
+        /// an ownedReferenceSubsetting is the featureTarget of the referencedFeature of that
+        /// ownedReferenceSubsetting.
+        /// </summary>
+        /// <param name="constraintUsageSubject">
+        /// The subject <see cref="IConstraintUsage"/>
+        /// </param>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IFeature ComputeRedefinedNamingFeatureOperation(this IConstraintUsage constraintUsageSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// A ConstraintUsage is not model-level evaluable.
+        /// </summary>
+        /// <param name="constraintUsageSubject">
+        /// The subject <see cref="IConstraintUsage"/>
+        /// </param>
+        /// <param name="visited">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeRedefinedModelLevelEvaluableOperation(this IConstraintUsage constraintUsageSubject, IFeature visited)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/ConstructorExpressionExtensions.cs
+++ b/SysML2.NET/Extend/ConstructorExpressionExtensions.cs
@@ -1,0 +1,60 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ConstructorExpressionExtensions.cs" company="Starion Group S.A.">
+//
+//    Copyright (C) 2022-2026 Starion Group S.A.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Core.POCO.Kernel.Expressions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using SysML2.NET.Core.Core.Types;
+    using SysML2.NET.Core.POCO.Core.Features;
+    using SysML2.NET.Core.POCO.Core.Types;
+    using SysML2.NET.Core.POCO.Kernel.Behaviors;
+    using SysML2.NET.Core.POCO.Kernel.Functions;
+    using SysML2.NET.Core.POCO.Root.Annotations;
+    using SysML2.NET.Core.POCO.Root.Elements;
+    using SysML2.NET.Core.POCO.Root.Namespaces;
+
+    /// <summary>
+    /// The <see cref="ConstructorExpressionExtensions"/> class provides extensions methods for
+    /// the <see cref="IConstructorExpression"/> interface
+    /// </summary>
+    internal static class ConstructorExpressionExtensions
+    {
+        /// <summary>
+        /// A ConstructorExpression is model-level evaluable if all its argument Expressions are model-level
+        /// evaluable.
+        /// </summary>
+        /// <param name="constructorExpressionSubject">
+        /// The subject <see cref="IConstructorExpression"/>
+        /// </param>
+        /// <param name="visited">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeRedefinedModelLevelEvaluableOperation(this IConstructorExpression constructorExpressionSubject, IFeature visited)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+    }
+}

--- a/SysML2.NET/Extend/ControlNodeExtensions.cs
+++ b/SysML2.NET/Extend/ControlNodeExtensions.cs
@@ -1,0 +1,89 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ControlNodeExtensions.cs" company="Starion Group S.A.">
+//
+//    Copyright (C) 2022-2026 Starion Group S.A.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Core.POCO.Systems.Actions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using SysML2.NET.Core.Core.Types;
+    using SysML2.NET.Core.Systems.Occurrences;
+    using SysML2.NET.Core.POCO.Core.Classifiers;
+    using SysML2.NET.Core.POCO.Core.Features;
+    using SysML2.NET.Core.POCO.Core.Types;
+    using SysML2.NET.Core.POCO.Kernel.Behaviors;
+    using SysML2.NET.Core.POCO.Kernel.Classes;
+    using SysML2.NET.Core.POCO.Root.Annotations;
+    using SysML2.NET.Core.POCO.Root.Elements;
+    using SysML2.NET.Core.POCO.Root.Namespaces;
+    using SysML2.NET.Core.POCO.Systems.Allocations;
+    using SysML2.NET.Core.POCO.Systems.AnalysisCases;
+    using SysML2.NET.Core.POCO.Systems.Attributes;
+    using SysML2.NET.Core.POCO.Systems.Calculations;
+    using SysML2.NET.Core.POCO.Systems.Cases;
+    using SysML2.NET.Core.POCO.Systems.Connections;
+    using SysML2.NET.Core.POCO.Systems.Constraints;
+    using SysML2.NET.Core.POCO.Systems.DefinitionAndUsage;
+    using SysML2.NET.Core.POCO.Systems.Enumerations;
+    using SysML2.NET.Core.POCO.Systems.Flows;
+    using SysML2.NET.Core.POCO.Systems.Interfaces;
+    using SysML2.NET.Core.POCO.Systems.Items;
+    using SysML2.NET.Core.POCO.Systems.Metadata;
+    using SysML2.NET.Core.POCO.Systems.Occurrences;
+    using SysML2.NET.Core.POCO.Systems.Parts;
+    using SysML2.NET.Core.POCO.Systems.Ports;
+    using SysML2.NET.Core.POCO.Systems.Requirements;
+    using SysML2.NET.Core.POCO.Systems.States;
+    using SysML2.NET.Core.POCO.Systems.UseCases;
+    using SysML2.NET.Core.POCO.Systems.VerificationCases;
+    using SysML2.NET.Core.POCO.Systems.Views;
+
+    /// <summary>
+    /// The <see cref="ControlNodeExtensions"/> class provides extensions methods for
+    /// the <see cref="IControlNode"/> interface
+    /// </summary>
+    internal static class ControlNodeExtensions
+    {
+        /// <summary>
+        /// Check that the given Multiplicity has lowerBound and upperBound expressions that are model-level
+        /// evaluable to the given lower and upper values.
+        /// </summary>
+        /// <param name="controlNodeSubject">
+        /// The subject <see cref="IControlNode"/>
+        /// </param>
+        /// <param name="mult">
+        /// No documentation provided
+        /// </param>
+        /// <param name="lower">
+        /// No documentation provided
+        /// </param>
+        /// <param name="upper">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeMultiplicityHasBoundsOperation(this IControlNode controlNodeSubject, IMultiplicity mult, int lower, string upper)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+    }
+}

--- a/SysML2.NET/Extend/CrossSubsettingExtensions.cs
+++ b/SysML2.NET/Extend/CrossSubsettingExtensions.cs
@@ -32,23 +32,19 @@ namespace SysML2.NET.Core.POCO.Core.Features
     /// The <see cref="CrossSubsettingExtensions"/> class provides extensions methods for
     /// the <see cref="ICrossSubsetting"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class CrossSubsettingExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="crossSubsetting">
+        /// <param name="crossSubsettingSubject">
         /// The subject <see cref="ICrossSubsetting"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeCrossingFeature(this ICrossSubsetting crossSubsetting)
+        internal static IFeature ComputeCrossingFeature(this ICrossSubsetting crossSubsettingSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/DefinitionExtensions.cs
+++ b/SysML2.NET/Extend/DefinitionExtensions.cs
@@ -55,23 +55,19 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
     /// The <see cref="DefinitionExtensions"/> class provides extensions methods for
     /// the <see cref="IDefinition"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class DefinitionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IUsage> ComputeDirectedUsage(this IDefinition definition)
+        internal static List<IUsage> ComputeDirectedUsage(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -79,14 +75,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IActionUsage> ComputeOwnedAction(this IDefinition definition)
+        internal static List<IActionUsage> ComputeOwnedAction(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -94,14 +90,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IAllocationUsage> ComputeOwnedAllocation(this IDefinition definition)
+        internal static List<IAllocationUsage> ComputeOwnedAllocation(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -109,14 +105,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IAnalysisCaseUsage> ComputeOwnedAnalysisCase(this IDefinition definition)
+        internal static List<IAnalysisCaseUsage> ComputeOwnedAnalysisCase(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -124,14 +120,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IAttributeUsage> ComputeOwnedAttribute(this IDefinition definition)
+        internal static List<IAttributeUsage> ComputeOwnedAttribute(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -139,14 +135,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<ICalculationUsage> ComputeOwnedCalculation(this IDefinition definition)
+        internal static List<ICalculationUsage> ComputeOwnedCalculation(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -154,14 +150,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<ICaseUsage> ComputeOwnedCase(this IDefinition definition)
+        internal static List<ICaseUsage> ComputeOwnedCase(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -169,14 +165,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IConcernUsage> ComputeOwnedConcern(this IDefinition definition)
+        internal static List<IConcernUsage> ComputeOwnedConcern(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -184,14 +180,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IConnectorAsUsage> ComputeOwnedConnection(this IDefinition definition)
+        internal static List<IConnectorAsUsage> ComputeOwnedConnection(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -199,14 +195,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IConstraintUsage> ComputeOwnedConstraint(this IDefinition definition)
+        internal static List<IConstraintUsage> ComputeOwnedConstraint(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -214,14 +210,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IEnumerationUsage> ComputeOwnedEnumeration(this IDefinition definition)
+        internal static List<IEnumerationUsage> ComputeOwnedEnumeration(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -229,14 +225,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFlowUsage> ComputeOwnedFlow(this IDefinition definition)
+        internal static List<IFlowUsage> ComputeOwnedFlow(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -244,14 +240,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IInterfaceUsage> ComputeOwnedInterface(this IDefinition definition)
+        internal static List<IInterfaceUsage> ComputeOwnedInterface(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -259,14 +255,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IItemUsage> ComputeOwnedItem(this IDefinition definition)
+        internal static List<IItemUsage> ComputeOwnedItem(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -274,14 +270,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IMetadataUsage> ComputeOwnedMetadata(this IDefinition definition)
+        internal static List<IMetadataUsage> ComputeOwnedMetadata(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -289,14 +285,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IOccurrenceUsage> ComputeOwnedOccurrence(this IDefinition definition)
+        internal static List<IOccurrenceUsage> ComputeOwnedOccurrence(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -304,14 +300,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IPartUsage> ComputeOwnedPart(this IDefinition definition)
+        internal static List<IPartUsage> ComputeOwnedPart(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -319,14 +315,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IPortUsage> ComputeOwnedPort(this IDefinition definition)
+        internal static List<IPortUsage> ComputeOwnedPort(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -334,14 +330,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IReferenceUsage> ComputeOwnedReference(this IDefinition definition)
+        internal static List<IReferenceUsage> ComputeOwnedReference(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -349,14 +345,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IRenderingUsage> ComputeOwnedRendering(this IDefinition definition)
+        internal static List<IRenderingUsage> ComputeOwnedRendering(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -364,14 +360,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IRequirementUsage> ComputeOwnedRequirement(this IDefinition definition)
+        internal static List<IRequirementUsage> ComputeOwnedRequirement(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -379,14 +375,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IStateUsage> ComputeOwnedState(this IDefinition definition)
+        internal static List<IStateUsage> ComputeOwnedState(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -394,14 +390,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<ITransitionUsage> ComputeOwnedTransition(this IDefinition definition)
+        internal static List<ITransitionUsage> ComputeOwnedTransition(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -409,14 +405,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IUsage> ComputeOwnedUsage(this IDefinition definition)
+        internal static List<IUsage> ComputeOwnedUsage(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -424,14 +420,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IUseCaseUsage> ComputeOwnedUseCase(this IDefinition definition)
+        internal static List<IUseCaseUsage> ComputeOwnedUseCase(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -439,14 +435,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IVerificationCaseUsage> ComputeOwnedVerificationCase(this IDefinition definition)
+        internal static List<IVerificationCaseUsage> ComputeOwnedVerificationCase(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -454,14 +450,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IViewUsage> ComputeOwnedView(this IDefinition definition)
+        internal static List<IViewUsage> ComputeOwnedView(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -469,14 +465,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IViewpointUsage> ComputeOwnedViewpoint(this IDefinition definition)
+        internal static List<IViewpointUsage> ComputeOwnedViewpoint(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -484,14 +480,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IUsage> ComputeUsage(this IDefinition definition)
+        internal static List<IUsage> ComputeUsage(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -499,14 +495,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IUsage> ComputeVariant(this IDefinition definition)
+        internal static List<IUsage> ComputeVariant(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -514,14 +510,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="definition">
+        /// <param name="definitionSubject">
         /// The subject <see cref="IDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IVariantMembership> ComputeVariantMembership(this IDefinition definition)
+        internal static List<IVariantMembership> ComputeVariantMembership(this IDefinition definitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/DependencyExtensions.cs
+++ b/SysML2.NET/Extend/DependencyExtensions.cs
@@ -20,16 +20,17 @@
 
 namespace SysML2.NET.Core.POCO.Root.Dependencies
 {
-    using System.Diagnostics.CodeAnalysis;
+    using System;
+    using System.Collections.Generic;
+
+    using SysML2.NET.Core.POCO.Root.Annotations;
+    using SysML2.NET.Core.POCO.Root.Elements;
+    using SysML2.NET.Core.POCO.Root.Namespaces;
 
     /// <summary>
     /// The <see cref="DependencyExtensions"/> class provides extensions methods for
     /// the <see cref="IDependency"/> interface
     /// </summary>
-    [SuppressMessage(
-        "Major Code Smell",
-        "S2094:Classes should not be empty",
-        Justification = "Extension class intentionally empty; methods are generated conditionally.")]
     internal static class DependencyExtensions
     {
     }

--- a/SysML2.NET/Extend/DifferencingExtensions.cs
+++ b/SysML2.NET/Extend/DifferencingExtensions.cs
@@ -31,23 +31,19 @@ namespace SysML2.NET.Core.POCO.Core.Types
     /// The <see cref="DifferencingExtensions"/> class provides extensions methods for
     /// the <see cref="IDifferencing"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class DifferencingExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="differencing">
+        /// <param name="differencingSubject">
         /// The subject <see cref="IDifferencing"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IType ComputeTypeDifferenced(this IDifferencing differencing)
+        internal static IType ComputeTypeDifferenced(this IDifferencing differencingSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/DisjoiningExtensions.cs
+++ b/SysML2.NET/Extend/DisjoiningExtensions.cs
@@ -31,23 +31,19 @@ namespace SysML2.NET.Core.POCO.Core.Types
     /// The <see cref="DisjoiningExtensions"/> class provides extensions methods for
     /// the <see cref="IDisjoining"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class DisjoiningExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="disjoining">
+        /// <param name="disjoiningSubject">
         /// The subject <see cref="IDisjoining"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IType ComputeOwningType(this IDisjoining disjoining)
+        internal static IType ComputeOwningType(this IDisjoining disjoiningSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/DocumentationExtensions.cs
+++ b/SysML2.NET/Extend/DocumentationExtensions.cs
@@ -30,23 +30,19 @@ namespace SysML2.NET.Core.POCO.Root.Annotations
     /// The <see cref="DocumentationExtensions"/> class provides extensions methods for
     /// the <see cref="IDocumentation"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class DocumentationExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="documentation">
+        /// <param name="documentationSubject">
         /// The subject <see cref="IDocumentation"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IElement ComputeDocumentedElement(this IDocumentation documentation)
+        internal static IElement ComputeDocumentedElement(this IDocumentation documentationSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/ElementExtensions.cs
+++ b/SysML2.NET/Extend/ElementExtensions.cs
@@ -30,23 +30,19 @@ namespace SysML2.NET.Core.POCO.Root.Elements
     /// The <see cref="ElementExtensions"/> class provides extensions methods for
     /// the <see cref="IElement"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ElementExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="element">
+        /// <param name="elementSubject">
         /// The subject <see cref="IElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IDocumentation> ComputeDocumentation(this IElement element)
+        internal static List<IDocumentation> ComputeDocumentation(this IElement elementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -54,14 +50,14 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="element">
+        /// <param name="elementSubject">
         /// The subject <see cref="IElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static bool ComputeIsLibraryElement(this IElement element)
+        internal static bool ComputeIsLibraryElement(this IElement elementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -69,14 +65,14 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="element">
+        /// <param name="elementSubject">
         /// The subject <see cref="IElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static string ComputeName(this IElement element)
+        internal static string ComputeName(this IElement elementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -84,14 +80,14 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="element">
+        /// <param name="elementSubject">
         /// The subject <see cref="IElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IAnnotation> ComputeOwnedAnnotation(this IElement element)
+        internal static List<IAnnotation> ComputeOwnedAnnotation(this IElement elementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -99,14 +95,14 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="element">
+        /// <param name="elementSubject">
         /// The subject <see cref="IElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IElement> ComputeOwnedElement(this IElement element)
+        internal static List<IElement> ComputeOwnedElement(this IElement elementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -114,14 +110,14 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="element">
+        /// <param name="elementSubject">
         /// The subject <see cref="IElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IElement ComputeOwner(this IElement element)
+        internal static IElement ComputeOwner(this IElement elementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -129,14 +125,14 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="element">
+        /// <param name="elementSubject">
         /// The subject <see cref="IElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IOwningMembership ComputeOwningMembership(this IElement element)
+        internal static IOwningMembership ComputeOwningMembership(this IElement elementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -144,14 +140,14 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="element">
+        /// <param name="elementSubject">
         /// The subject <see cref="IElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static INamespace ComputeOwningNamespace(this IElement element)
+        internal static INamespace ComputeOwningNamespace(this IElement elementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -159,14 +155,14 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="element">
+        /// <param name="elementSubject">
         /// The subject <see cref="IElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static string ComputeQualifiedName(this IElement element)
+        internal static string ComputeQualifiedName(this IElement elementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -174,14 +170,14 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="element">
+        /// <param name="elementSubject">
         /// The subject <see cref="IElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static string ComputeShortName(this IElement element)
+        internal static string ComputeShortName(this IElement elementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -189,17 +185,101 @@ namespace SysML2.NET.Core.POCO.Root.Elements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="element">
+        /// <param name="elementSubject">
         /// The subject <see cref="IElement"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<ITextualRepresentation> ComputeTextualRepresentation(this IElement element)
+        internal static List<ITextualRepresentation> ComputeTextualRepresentation(this IElement elementSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// Return name, if that is not null, otherwise the shortName, if that is not null, otherwise null. If
+        /// the returned value is non-null, it is returned as-is if it has the form of a basic name, or,
+        /// otherwise, represented as a restricted name according to the lexical structure of the KerML textual
+        /// notation (i.e., surrounded by single quote characters and with special characters escaped).
+        /// </summary>
+        /// <param name="elementSubject">
+        /// The subject <see cref="IElement"/>
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static string ComputeEscapedNameOperation(this IElement elementSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return an effective shortName for this Element. By default this is the same as its
+        /// declaredShortName.
+        /// </summary>
+        /// <param name="elementSubject">
+        /// The subject <see cref="IElement"/>
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static string ComputeEffectiveShortNameOperation(this IElement elementSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return an effective name for this Element. By default this is the same as its declaredName.
+        /// </summary>
+        /// <param name="elementSubject">
+        /// The subject <see cref="IElement"/>
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static string ComputeEffectiveNameOperation(this IElement elementSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// By default, return the library Namespace of the owningRelationship of this Element, if it has one.
+        /// </summary>
+        /// <param name="elementSubject">
+        /// The subject <see cref="IElement"/>
+        /// </param>
+        /// <returns>
+        /// The expected INamespace
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static INamespace ComputeLibraryNamespaceOperation(this IElement elementSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return a unique description of the location of this Element in the containment structure rooted in a
+        /// root Namespace. If the Element has a non-null qualifiedName, then return that. Otherwise, if it has
+        /// an owningRelationship, then return the string constructed by appending to the path of it's
+        /// owningRelationship the character / followed by the string representation of its position in the list
+        /// of ownedRelatedElements of the owningRelationship (indexed starting at 1). Otherwise, return the
+        /// empty string.                            (Note that this operation is overridden for Relationships
+        /// to use owningRelatedElement when appropriate.)
+        /// </summary>
+        /// <param name="elementSubject">
+        /// The subject <see cref="IElement"/>
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static string ComputePathOperation(this IElement elementSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/ElementFilterMembershipExtensions.cs
+++ b/SysML2.NET/Extend/ElementFilterMembershipExtensions.cs
@@ -33,23 +33,19 @@ namespace SysML2.NET.Core.POCO.Kernel.Packages
     /// The <see cref="ElementFilterMembershipExtensions"/> class provides extensions methods for
     /// the <see cref="IElementFilterMembership"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ElementFilterMembershipExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="elementFilterMembership">
+        /// <param name="elementFilterMembershipSubject">
         /// The subject <see cref="IElementFilterMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IExpression ComputeCondition(this IElementFilterMembership elementFilterMembership)
+        internal static IExpression ComputeCondition(this IElementFilterMembership elementFilterMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/EndFeatureMembershipExtensions.cs
+++ b/SysML2.NET/Extend/EndFeatureMembershipExtensions.cs
@@ -33,23 +33,19 @@ namespace SysML2.NET.Core.POCO.Core.Features
     /// The <see cref="EndFeatureMembershipExtensions"/> class provides extensions methods for
     /// the <see cref="IEndFeatureMembership"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class EndFeatureMembershipExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="endFeatureMembership">
+        /// <param name="endFeatureMembershipSubject">
         /// The subject <see cref="IEndFeatureMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeOwnedMemberFeature(this IEndFeatureMembership endFeatureMembership)
+        internal static IFeature ComputeOwnedMemberFeature(this IEndFeatureMembership endFeatureMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/EnumerationDefinitionExtensions.cs
+++ b/SysML2.NET/Extend/EnumerationDefinitionExtensions.cs
@@ -55,23 +55,19 @@ namespace SysML2.NET.Core.POCO.Systems.Enumerations
     /// The <see cref="EnumerationDefinitionExtensions"/> class provides extensions methods for
     /// the <see cref="IEnumerationDefinition"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class EnumerationDefinitionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="enumerationDefinition">
+        /// <param name="enumerationDefinitionSubject">
         /// The subject <see cref="IEnumerationDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IEnumerationUsage> ComputeEnumeratedValue(this IEnumerationDefinition enumerationDefinition)
+        internal static List<IEnumerationUsage> ComputeEnumeratedValue(this IEnumerationDefinition enumerationDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/EnumerationUsageExtensions.cs
+++ b/SysML2.NET/Extend/EnumerationUsageExtensions.cs
@@ -57,23 +57,19 @@ namespace SysML2.NET.Core.POCO.Systems.Enumerations
     /// The <see cref="EnumerationUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IEnumerationUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class EnumerationUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="enumerationUsage">
+        /// <param name="enumerationUsageSubject">
         /// The subject <see cref="IEnumerationUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IEnumerationDefinition ComputeEnumerationDefinition(this IEnumerationUsage enumerationUsage)
+        internal static IEnumerationDefinition ComputeEnumerationDefinition(this IEnumerationUsage enumerationUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/EventOccurrenceUsageExtensions.cs
+++ b/SysML2.NET/Extend/EventOccurrenceUsageExtensions.cs
@@ -58,23 +58,19 @@ namespace SysML2.NET.Core.POCO.Systems.Occurrences
     /// The <see cref="EventOccurrenceUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IEventOccurrenceUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class EventOccurrenceUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="eventOccurrenceUsage">
+        /// <param name="eventOccurrenceUsageSubject">
         /// The subject <see cref="IEventOccurrenceUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IOccurrenceUsage ComputeEventOccurrence(this IEventOccurrenceUsage eventOccurrenceUsage)
+        internal static IOccurrenceUsage ComputeEventOccurrence(this IEventOccurrenceUsage eventOccurrenceUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -82,14 +78,14 @@ namespace SysML2.NET.Core.POCO.Systems.Occurrences
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="eventOccurrenceUsage">
+        /// <param name="eventOccurrenceUsageSubject">
         /// The subject <see cref="IEventOccurrenceUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static bool ComputeIsReference(this IEventOccurrenceUsage eventOccurrenceUsage)
+        internal static bool ComputeIsReference(this IEventOccurrenceUsage eventOccurrenceUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/ExhibitStateUsageExtensions.cs
+++ b/SysML2.NET/Extend/ExhibitStateUsageExtensions.cs
@@ -59,23 +59,19 @@ namespace SysML2.NET.Core.POCO.Systems.States
     /// The <see cref="ExhibitStateUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IExhibitStateUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ExhibitStateUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="exhibitStateUsage">
+        /// <param name="exhibitStateUsageSubject">
         /// The subject <see cref="IExhibitStateUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IStateUsage ComputeExhibitedState(this IExhibitStateUsage exhibitStateUsage)
+        internal static IStateUsage ComputeExhibitedState(this IExhibitStateUsage exhibitStateUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/ExposeExtensions.cs
+++ b/SysML2.NET/Extend/ExposeExtensions.cs
@@ -20,16 +20,18 @@
 
 namespace SysML2.NET.Core.POCO.Systems.Views
 {
-    using System.Diagnostics.CodeAnalysis;
+    using System;
+    using System.Collections.Generic;
+
+    using SysML2.NET.Core.Root.Namespaces;
+    using SysML2.NET.Core.POCO.Root.Annotations;
+    using SysML2.NET.Core.POCO.Root.Elements;
+    using SysML2.NET.Core.POCO.Root.Namespaces;
 
     /// <summary>
     /// The <see cref="ExposeExtensions"/> class provides extensions methods for
     /// the <see cref="IExpose"/> interface
     /// </summary>
-    [SuppressMessage(
-        "Major Code Smell",
-        "S2094:Classes should not be empty",
-        Justification = "Extension class intentionally empty; methods are generated conditionally.")]
     internal static class ExposeExtensions
     {
     }

--- a/SysML2.NET/Extend/ExpressionExtensions.cs
+++ b/SysML2.NET/Extend/ExpressionExtensions.cs
@@ -35,23 +35,19 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
     /// The <see cref="ExpressionExtensions"/> class provides extensions methods for
     /// the <see cref="IExpression"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ExpressionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="expression">
+        /// <param name="expressionSubject">
         /// The subject <see cref="IExpression"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFunction ComputeFunction(this IExpression expression)
+        internal static IFunction ComputeFunction(this IExpression expressionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -59,14 +55,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="expression">
+        /// <param name="expressionSubject">
         /// The subject <see cref="IExpression"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static bool ComputeIsModelLevelEvaluable(this IExpression expression)
+        internal static bool ComputeIsModelLevelEvaluable(this IExpression expressionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -74,17 +70,81 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="expression">
+        /// <param name="expressionSubject">
         /// The subject <see cref="IExpression"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeResult(this IExpression expression)
+        internal static IFeature ComputeResult(this IExpression expressionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// Return whether this Expression is model-level evaluable. The visited parameter is used to track
+        /// possible circular Feature references made from FeatureReferenceExpressions (see the redefinition of
+        /// this operation for FeatureReferenceExpression). Such circular references are not allowed in
+        /// model-level evaluable expressions.                            An Expression that is not otherwise
+        /// specialized is model-level evaluable if it has no (non-implied) ownedSpecializations and all its
+        /// ownedFeatures are either in parameters, the result parameter or a result Expression owned via a
+        /// ResultExpressionMembership. The parameters  must not have any ownedFeatures or a FeatureValue, and
+        /// the result Expression must be model-level evaluable.
+        /// </summary>
+        /// <param name="expressionSubject">
+        /// The subject <see cref="IExpression"/>
+        /// </param>
+        /// <param name="visited">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeModelLevelEvaluableOperation(this IExpression expressionSubject, IFeature visited)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// If this Expression isModelLevelEvaluable, then evaluate it using the target as the context Element
+        /// for resolving Feature names and testing classification. The result is a collection of Elements,
+        /// which, for a fully evaluable Expression, will be a LiteralExpression or a Feature that is not an
+        /// Expression.
+        /// </summary>
+        /// <param name="expressionSubject">
+        /// The subject <see cref="IExpression"/>
+        /// </param>
+        /// <param name="target">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IElement
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IElement ComputeEvaluateOperation(this IExpression expressionSubject, IElement target)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Model-level evaluate this Expression with the given target. If the result is a LiteralBoolean,
+        /// return its value. Otherwise return false.
+        /// </summary>
+        /// <param name="expressionSubject">
+        /// The subject <see cref="IExpression"/>
+        /// </param>
+        /// <param name="target">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeCheckConditionOperation(this IExpression expressionSubject, IElement target)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/FeatureChainExpressionExtensions.cs
+++ b/SysML2.NET/Extend/FeatureChainExpressionExtensions.cs
@@ -36,26 +36,37 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
     /// The <see cref="FeatureChainExpressionExtensions"/> class provides extensions methods for
     /// the <see cref="IFeatureChainExpression"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class FeatureChainExpressionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="featureChainExpression">
+        /// <param name="featureChainExpressionSubject">
         /// The subject <see cref="IFeatureChainExpression"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeTargetFeature(this IFeatureChainExpression featureChainExpression)
+        internal static IFeature ComputeTargetFeature(this IFeatureChainExpression featureChainExpressionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// Return the first ownedFeature of the first owned input parameter of this FeatureChainExpression (if
+        /// any).
+        /// </summary>
+        /// <param name="featureChainExpressionSubject">
+        /// The subject <see cref="IFeatureChainExpression"/>
+        /// </param>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IFeature ComputeSourceTargetFeatureOperation(this IFeatureChainExpression featureChainExpressionSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/FeatureChainingExtensions.cs
+++ b/SysML2.NET/Extend/FeatureChainingExtensions.cs
@@ -31,23 +31,19 @@ namespace SysML2.NET.Core.POCO.Core.Features
     /// The <see cref="FeatureChainingExtensions"/> class provides extensions methods for
     /// the <see cref="IFeatureChaining"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class FeatureChainingExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="featureChaining">
+        /// <param name="featureChainingSubject">
         /// The subject <see cref="IFeatureChaining"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeFeatureChained(this IFeatureChaining featureChaining)
+        internal static IFeature ComputeFeatureChained(this IFeatureChaining featureChainingSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/FeatureExtensions.cs
+++ b/SysML2.NET/Extend/FeatureExtensions.cs
@@ -33,23 +33,19 @@ namespace SysML2.NET.Core.POCO.Core.Features
     /// The <see cref="FeatureExtensions"/> class provides extensions methods for
     /// the <see cref="IFeature"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class FeatureExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeature> ComputeChainingFeature(this IFeature feature)
+        internal static List<IFeature> ComputeChainingFeature(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -57,14 +53,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeCrossFeature(this IFeature feature)
+        internal static IFeature ComputeCrossFeature(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -72,14 +68,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IType ComputeEndOwningType(this IFeature feature)
+        internal static IType ComputeEndOwningType(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -87,14 +83,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeFeatureTarget(this IFeature feature)
+        internal static IFeature ComputeFeatureTarget(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -102,14 +98,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IType> ComputeFeaturingType(this IFeature feature)
+        internal static List<IType> ComputeFeaturingType(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -117,14 +113,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static ICrossSubsetting ComputeOwnedCrossSubsetting(this IFeature feature)
+        internal static ICrossSubsetting ComputeOwnedCrossSubsetting(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -132,14 +128,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeatureChaining> ComputeOwnedFeatureChaining(this IFeature feature)
+        internal static List<IFeatureChaining> ComputeOwnedFeatureChaining(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -147,14 +143,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeatureInverting> ComputeOwnedFeatureInverting(this IFeature feature)
+        internal static List<IFeatureInverting> ComputeOwnedFeatureInverting(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -162,14 +158,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IRedefinition> ComputeOwnedRedefinition(this IFeature feature)
+        internal static List<IRedefinition> ComputeOwnedRedefinition(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -177,14 +173,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IReferenceSubsetting ComputeOwnedReferenceSubsetting(this IFeature feature)
+        internal static IReferenceSubsetting ComputeOwnedReferenceSubsetting(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -192,14 +188,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<ISubsetting> ComputeOwnedSubsetting(this IFeature feature)
+        internal static List<ISubsetting> ComputeOwnedSubsetting(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -207,14 +203,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<ITypeFeaturing> ComputeOwnedTypeFeaturing(this IFeature feature)
+        internal static List<ITypeFeaturing> ComputeOwnedTypeFeaturing(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -222,14 +218,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeatureTyping> ComputeOwnedTyping(this IFeature feature)
+        internal static List<IFeatureTyping> ComputeOwnedTyping(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -237,14 +233,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeatureMembership ComputeOwningFeatureMembership(this IFeature feature)
+        internal static IFeatureMembership ComputeOwningFeatureMembership(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -252,14 +248,14 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IType ComputeOwningType(this IFeature feature)
+        internal static IType ComputeOwningType(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -267,17 +263,345 @@ namespace SysML2.NET.Core.POCO.Core.Features
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="feature">
+        /// <param name="featureSubject">
         /// The subject <see cref="IFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IType> ComputeType(this IFeature feature)
+        internal static List<IType> ComputeType(this IFeature featureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// Return the directionOf this Feature relative to the given type.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <param name="type">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected FeatureDirectionKind
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static FeatureDirectionKind ComputeDirectionForOperation(this IFeature featureSubject, IType type)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// If a Feature has no declaredShortName or declaredName, then its effective shortName is given by the
+        /// effective shortName of the Feature returned by the namingFeature() operation, if any.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static string ComputeRedefinedEffectiveShortNameOperation(this IFeature featureSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// If a Feature has no declaredName or declaredShortName                            , then its
+        /// effective name is given by the effective name of the Feature returned by the namingFeature()
+        /// operation, if any.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static string ComputeRedefinedEffectiveNameOperation(this IFeature featureSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// By default, the naming Feature of a Feature is given by its first redefinedFeature of its first
+        /// ownedRedefinition, if any.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IFeature ComputeNamingFeatureOperation(this IFeature featureSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <param name="excludeImplied">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IType
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IType ComputeRedefinedSupertypesOperation(this IFeature featureSubject, bool excludeImplied)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Check whether this Feature directly redefines the given redefinedFeature.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <param name="redefinedFeature">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeRedefinesOperation(this IFeature featureSubject, IFeature redefinedFeature)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Check whether this Feature directly redefines the named library Feature. libraryFeatureName must
+        /// conform to the syntax of a KerML qualified name and must resolve to a Feature in global scope.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <param name="libraryFeatureName">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeRedefinesFromLibraryOperation(this IFeature featureSubject, string libraryFeatureName)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Check whether this Feature directly or indirectly specializes a Feature whose last two
+        /// chainingFeatures are the given Features first and second.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <param name="first">
+        /// No documentation provided
+        /// </param>
+        /// <param name="second">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeSubsetsChainOperation(this IFeature featureSubject, IFeature first, IFeature second)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// A Feature is compatible with an otherType if it either directly or indirectly specializes the
+        /// otherType or if the otherType is also a Feature and all of the following are true.                  
+        ///          <ol>                            <li>Neither this Feature or the otherType have any
+        /// ownedFeatures.</li>                            <li>This Feature directly or indirectly redefines a
+        /// Feature that is also directly or indirectly redefined by the otherType.</li>                        
+        /// <li>This Feature can access the otherType.                            </li></ol>
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <param name="otherType">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeRedefinedIsCompatibleWithOperation(this IFeature featureSubject, IType otherType)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return the Features used to determine the types of this Feature (other than this Feature itself). If
+        /// this Feature is not conjugated, then the typingFeatures consist of all subsetted Features, except
+        /// from CrossSubsetting, and the last chainingFeature (if any). If this Feature is conjugated, then the
+        /// typingFeatures are only its originalType (if the originalType is a Feature).                        
+        ///    <strong>Note.</strong> CrossSubsetting is excluded from the determination of the type of a
+        /// Feature in order to avoid circularity in the construction of implied CrossSubsetting relationships.
+        /// The validateFeatureCrossFeatureType requires that the crossFeature of a Feature have the same type
+        /// as the Feature.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IFeature ComputeTypingFeaturesOperation(this IFeature featureSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// If isCartesianProduct is true, then return the list of Types whose Cartesian product can be
+        /// represented by this Feature. (If isCartesianProduct is not true, the operation will still return a
+        /// valid value, it will just not represent anything useful.)
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <returns>
+        /// The expected IType
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IType ComputeAsCartesianProductOperation(this IFeature featureSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Check whether this Feature can be used to represent a Cartesian product of Types.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeIsCartesianProductOperation(this IFeature featureSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return whether this Feature is an owned cross Feature of an end Feature.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeIsOwnedCrossFeatureOperation(this IFeature featureSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// If this Feature is an end Feature of its owningType, then return the first ownedMember of the
+        /// Feature that is a Feature, but not a Multiplicity or a MetadataFeature, and whose owningMembership
+        /// is not a FeatureMembership. If this exists, it is the crossFeature of the end Feature.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IFeature ComputeOwnedCrossFeatureOperation(this IFeature featureSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return this Feature and all the Features that are directly or indirectly Redefined by this Feature.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IFeature ComputeAllRedefinedFeaturesOperation(this IFeature featureSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return if the featuringTypes of this Feature are compatible with the given type. If type is null,
+        /// then check if this Feature is explicitly or implicitly featured by Base::Anything. If this Feature
+        /// has isVariable = true, then also consider it to be featured within its owningType. If this Feature
+        /// is a feature chain whose first chainingFeature has isVariable = true, then also consider it to be
+        /// featured within the owningType of its first chainingFeature.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <param name="type">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeIsFeaturedWithinOperation(this IFeature featureSubject, IType type)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// A Feature can access another feature if the other feature is featured within one of the direct or
+        /// indirect featuringTypes of this Feature.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <param name="feature">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeCanAccessOperation(this IFeature featureSubject, IFeature feature)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return whether the given type must be a featuringType of this Feature. If this Feature has
+        /// isVariable = false, then return true if the type is the owningType of the Feature. If isVariable =
+        /// true, then return true if the type is a Feature representing the snapshots of the owningType of this
+        /// Feature.
+        /// </summary>
+        /// <param name="featureSubject">
+        /// The subject <see cref="IFeature"/>
+        /// </param>
+        /// <param name="type">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeIsFeaturingTypeOperation(this IFeature featureSubject, IType type)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/FeatureInvertingExtensions.cs
+++ b/SysML2.NET/Extend/FeatureInvertingExtensions.cs
@@ -31,23 +31,19 @@ namespace SysML2.NET.Core.POCO.Core.Features
     /// The <see cref="FeatureInvertingExtensions"/> class provides extensions methods for
     /// the <see cref="IFeatureInverting"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class FeatureInvertingExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="featureInverting">
+        /// <param name="featureInvertingSubject">
         /// The subject <see cref="IFeatureInverting"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeOwningFeature(this IFeatureInverting featureInverting)
+        internal static IFeature ComputeOwningFeature(this IFeatureInverting featureInvertingSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/FeatureMembershipExtensions.cs
+++ b/SysML2.NET/Extend/FeatureMembershipExtensions.cs
@@ -33,23 +33,19 @@ namespace SysML2.NET.Core.POCO.Core.Types
     /// The <see cref="FeatureMembershipExtensions"/> class provides extensions methods for
     /// the <see cref="IFeatureMembership"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class FeatureMembershipExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="featureMembership">
+        /// <param name="featureMembershipSubject">
         /// The subject <see cref="IFeatureMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeOwnedMemberFeature(this IFeatureMembership featureMembership)
+        internal static IFeature ComputeOwnedMemberFeature(this IFeatureMembership featureMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -57,14 +53,14 @@ namespace SysML2.NET.Core.POCO.Core.Types
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="featureMembership">
+        /// <param name="featureMembershipSubject">
         /// The subject <see cref="IFeatureMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IType ComputeOwningType(this IFeatureMembership featureMembership)
+        internal static IType ComputeOwningType(this IFeatureMembership featureMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/FeatureReferenceExpressionExtensions.cs
+++ b/SysML2.NET/Extend/FeatureReferenceExpressionExtensions.cs
@@ -36,26 +36,70 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
     /// The <see cref="FeatureReferenceExpressionExtensions"/> class provides extensions methods for
     /// the <see cref="IFeatureReferenceExpression"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class FeatureReferenceExpressionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="featureReferenceExpression">
+        /// <param name="featureReferenceExpressionSubject">
         /// The subject <see cref="IFeatureReferenceExpression"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeReferent(this IFeatureReferenceExpression featureReferenceExpression)
+        internal static IFeature ComputeReferent(this IFeatureReferenceExpression featureReferenceExpressionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// A FeatureReferenceExpression is model-level evaluable if it&#39;s referent                          
+        ///  <ul>                            <li>conforms to the self-reference feature Anything::self;</li>    
+        ///                        <li>is an Expression that is model-level evaluable;</li>                     
+        ///       <li>has an owningType that is a Metaclass or MetadataFeature; or</li>                         
+        ///   <li>has no featuringTypes and, if it has a FeatureValue, the value Expression is model-level
+        /// evaluable.</li>                            </ul>
+        /// </summary>
+        /// <param name="featureReferenceExpressionSubject">
+        /// The subject <see cref="IFeatureReferenceExpression"/>
+        /// </param>
+        /// <param name="visited">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeRedefinedModelLevelEvaluableOperation(this IFeatureReferenceExpression featureReferenceExpressionSubject, IFeature visited)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// First, determine a value Expression for the referent:                            <ul>               
+        ///             <li>If the target Element is a Type that has a feature that is the referent or (directly
+        /// or indirectly) redefines it, then the value Expression of the FeatureValue for that feature (if
+        /// any).</li>                            <li>Else, if the referent has no featuringTypes, the value
+        /// Expression of the FeatureValue for the referent (if any).</li>                            </ul>     
+        ///                       Then:                            <ul>                            <li>If such a
+        /// value Expression exists, return the result of evaluating that Expression on the target.</li>        
+        ///                    <li>Else, if the referent is not an Expression, return the referent.</li>        
+        /// <li>Else return the empty sequence.</li>                            </ul>
+        /// </summary>
+        /// <param name="featureReferenceExpressionSubject">
+        /// The subject <see cref="IFeatureReferenceExpression"/>
+        /// </param>
+        /// <param name="target">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IElement
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IElement ComputeRedefinedEvaluateOperation(this IFeatureReferenceExpression featureReferenceExpressionSubject, IElement target)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/FeatureTypingExtensions.cs
+++ b/SysML2.NET/Extend/FeatureTypingExtensions.cs
@@ -32,23 +32,19 @@ namespace SysML2.NET.Core.POCO.Core.Features
     /// The <see cref="FeatureTypingExtensions"/> class provides extensions methods for
     /// the <see cref="IFeatureTyping"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class FeatureTypingExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="featureTyping">
+        /// <param name="featureTypingSubject">
         /// The subject <see cref="IFeatureTyping"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeOwningFeature(this IFeatureTyping featureTyping)
+        internal static IFeature ComputeOwningFeature(this IFeatureTyping featureTypingSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/FeatureValueExtensions.cs
+++ b/SysML2.NET/Extend/FeatureValueExtensions.cs
@@ -34,23 +34,19 @@ namespace SysML2.NET.Core.POCO.Kernel.FeatureValues
     /// The <see cref="FeatureValueExtensions"/> class provides extensions methods for
     /// the <see cref="IFeatureValue"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class FeatureValueExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="featureValue">
+        /// <param name="featureValueSubject">
         /// The subject <see cref="IFeatureValue"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeFeatureWithValue(this IFeatureValue featureValue)
+        internal static IFeature ComputeFeatureWithValue(this IFeatureValue featureValueSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -58,14 +54,14 @@ namespace SysML2.NET.Core.POCO.Kernel.FeatureValues
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="featureValue">
+        /// <param name="featureValueSubject">
         /// The subject <see cref="IFeatureValue"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IExpression ComputeValue(this IFeatureValue featureValue)
+        internal static IExpression ComputeValue(this IFeatureValue featureValueSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/FlowDefinitionExtensions.cs
+++ b/SysML2.NET/Extend/FlowDefinitionExtensions.cs
@@ -26,6 +26,7 @@ namespace SysML2.NET.Core.POCO.Systems.Flows
     using SysML2.NET.Core.POCO.Core.Classifiers;
     using SysML2.NET.Core.POCO.Core.Features;
     using SysML2.NET.Core.POCO.Core.Types;
+    using SysML2.NET.Core.POCO.Kernel.Associations;
     using SysML2.NET.Core.POCO.Kernel.Behaviors;
     using SysML2.NET.Core.POCO.Kernel.Interactions;
     using SysML2.NET.Core.POCO.Root.Annotations;
@@ -57,23 +58,19 @@ namespace SysML2.NET.Core.POCO.Systems.Flows
     /// The <see cref="FlowDefinitionExtensions"/> class provides extensions methods for
     /// the <see cref="IFlowDefinition"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class FlowDefinitionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="flowDefinition">
+        /// <param name="flowDefinitionSubject">
         /// The subject <see cref="IFlowDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IUsage> ComputeFlowEnd(this IFlowDefinition flowDefinition)
+        internal static List<IUsage> ComputeFlowEnd(this IFlowDefinition flowDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/FlowExtensions.cs
+++ b/SysML2.NET/Extend/FlowExtensions.cs
@@ -38,23 +38,19 @@ namespace SysML2.NET.Core.POCO.Kernel.Interactions
     /// The <see cref="FlowExtensions"/> class provides extensions methods for
     /// the <see cref="IFlow"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class FlowExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="flow">
+        /// <param name="flowSubject">
         /// The subject <see cref="IFlow"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFlowEnd> ComputeFlowEnd(this IFlow flow)
+        internal static List<IFlowEnd> ComputeFlowEnd(this IFlow flowSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -62,14 +58,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Interactions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="flow">
+        /// <param name="flowSubject">
         /// The subject <see cref="IFlow"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IInteraction> ComputeInteraction(this IFlow flow)
+        internal static List<IInteraction> ComputeInteraction(this IFlow flowSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -77,14 +73,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Interactions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="flow">
+        /// <param name="flowSubject">
         /// The subject <see cref="IFlow"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IPayloadFeature ComputePayloadFeature(this IFlow flow)
+        internal static IPayloadFeature ComputePayloadFeature(this IFlow flowSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -92,14 +88,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Interactions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="flow">
+        /// <param name="flowSubject">
         /// The subject <see cref="IFlow"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IClassifier> ComputePayloadType(this IFlow flow)
+        internal static List<IClassifier> ComputePayloadType(this IFlow flowSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -107,14 +103,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Interactions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="flow">
+        /// <param name="flowSubject">
         /// The subject <see cref="IFlow"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeSourceOutputFeature(this IFlow flow)
+        internal static IFeature ComputeSourceOutputFeature(this IFlow flowSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -122,14 +118,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Interactions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="flow">
+        /// <param name="flowSubject">
         /// The subject <see cref="IFlow"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeTargetInputFeature(this IFlow flow)
+        internal static IFeature ComputeTargetInputFeature(this IFlow flowSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/FlowUsageExtensions.cs
+++ b/SysML2.NET/Extend/FlowUsageExtensions.cs
@@ -31,6 +31,7 @@ namespace SysML2.NET.Core.POCO.Systems.Flows
     using SysML2.NET.Core.POCO.Kernel.Associations;
     using SysML2.NET.Core.POCO.Kernel.Behaviors;
     using SysML2.NET.Core.POCO.Kernel.Classes;
+    using SysML2.NET.Core.POCO.Kernel.Connectors;
     using SysML2.NET.Core.POCO.Kernel.Interactions;
     using SysML2.NET.Core.POCO.Root.Annotations;
     using SysML2.NET.Core.POCO.Root.Elements;
@@ -61,23 +62,19 @@ namespace SysML2.NET.Core.POCO.Systems.Flows
     /// The <see cref="FlowUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IFlowUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class FlowUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="flowUsage">
+        /// <param name="flowUsageSubject">
         /// The subject <see cref="IFlowUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IInteraction> ComputeFlowDefinition(this IFlowUsage flowUsage)
+        internal static List<IInteraction> ComputeFlowDefinition(this IFlowUsage flowUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/ForLoopActionUsageExtensions.cs
+++ b/SysML2.NET/Extend/ForLoopActionUsageExtensions.cs
@@ -60,23 +60,19 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
     /// The <see cref="ForLoopActionUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IForLoopActionUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ForLoopActionUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="forLoopActionUsage">
+        /// <param name="forLoopActionUsageSubject">
         /// The subject <see cref="IForLoopActionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IReferenceUsage ComputeLoopVariable(this IForLoopActionUsage forLoopActionUsage)
+        internal static IReferenceUsage ComputeLoopVariable(this IForLoopActionUsage forLoopActionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -84,14 +80,14 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="forLoopActionUsage">
+        /// <param name="forLoopActionUsageSubject">
         /// The subject <see cref="IForLoopActionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IExpression ComputeSeqArgument(this IForLoopActionUsage forLoopActionUsage)
+        internal static IExpression ComputeSeqArgument(this IForLoopActionUsage forLoopActionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/FramedConcernMembershipExtensions.cs
+++ b/SysML2.NET/Extend/FramedConcernMembershipExtensions.cs
@@ -36,23 +36,19 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
     /// The <see cref="FramedConcernMembershipExtensions"/> class provides extensions methods for
     /// the <see cref="IFramedConcernMembership"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class FramedConcernMembershipExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="framedConcernMembership">
+        /// <param name="framedConcernMembershipSubject">
         /// The subject <see cref="IFramedConcernMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IConcernUsage ComputeOwnedConcern(this IFramedConcernMembership framedConcernMembership)
+        internal static IConcernUsage ComputeOwnedConcern(this IFramedConcernMembership framedConcernMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -60,14 +56,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="framedConcernMembership">
+        /// <param name="framedConcernMembershipSubject">
         /// The subject <see cref="IFramedConcernMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IConcernUsage ComputeReferencedConcern(this IFramedConcernMembership framedConcernMembership)
+        internal static IConcernUsage ComputeReferencedConcern(this IFramedConcernMembership framedConcernMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/FunctionExtensions.cs
+++ b/SysML2.NET/Extend/FunctionExtensions.cs
@@ -35,23 +35,19 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
     /// The <see cref="FunctionExtensions"/> class provides extensions methods for
     /// the <see cref="IFunction"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class FunctionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="function">
+        /// <param name="functionSubject">
         /// The subject <see cref="IFunction"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IExpression> ComputeExpression(this IFunction function)
+        internal static List<IExpression> ComputeExpression(this IFunction functionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -59,14 +55,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="function">
+        /// <param name="functionSubject">
         /// The subject <see cref="IFunction"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static bool ComputeIsModelLevelEvaluable(this IFunction function)
+        internal static bool ComputeIsModelLevelEvaluable(this IFunction functionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -74,14 +70,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="function">
+        /// <param name="functionSubject">
         /// The subject <see cref="IFunction"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeResult(this IFunction function)
+        internal static IFeature ComputeResult(this IFunction functionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/IfActionUsageExtensions.cs
+++ b/SysML2.NET/Extend/IfActionUsageExtensions.cs
@@ -60,23 +60,19 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
     /// The <see cref="IfActionUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IIfActionUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class IfActionUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="ifActionUsage">
+        /// <param name="ifActionUsageSubject">
         /// The subject <see cref="IIfActionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IActionUsage ComputeElseAction(this IIfActionUsage ifActionUsage)
+        internal static IActionUsage ComputeElseAction(this IIfActionUsage ifActionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -84,14 +80,14 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="ifActionUsage">
+        /// <param name="ifActionUsageSubject">
         /// The subject <see cref="IIfActionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IExpression ComputeIfArgument(this IIfActionUsage ifActionUsage)
+        internal static IExpression ComputeIfArgument(this IIfActionUsage ifActionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -99,14 +95,14 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="ifActionUsage">
+        /// <param name="ifActionUsageSubject">
         /// The subject <see cref="IIfActionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IActionUsage ComputeThenAction(this IIfActionUsage ifActionUsage)
+        internal static IActionUsage ComputeThenAction(this IIfActionUsage ifActionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/ImportExtensions.cs
+++ b/SysML2.NET/Extend/ImportExtensions.cs
@@ -31,23 +31,19 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
     /// The <see cref="ImportExtensions"/> class provides extensions methods for
     /// the <see cref="IImport"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ImportExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="import">
+        /// <param name="importSubject">
         /// The subject <see cref="IImport"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IElement ComputeImportedElement(this IImport import)
+        internal static IElement ComputeImportedElement(this IImport importSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -55,17 +51,35 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="import">
+        /// <param name="importSubject">
         /// The subject <see cref="IImport"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static INamespace ComputeImportOwningNamespace(this IImport import)
+        internal static INamespace ComputeImportOwningNamespace(this IImport importSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// Returns Memberships that are to become importedMemberships of the importOwningNamespace. (The
+        /// excluded parameter is used to handle the possibility of circular Import Relationships.)
+        /// </summary>
+        /// <param name="importSubject">
+        /// The subject <see cref="IImport"/>
+        /// </param>
+        /// <param name="excluded">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IMembership ComputeImportedMembershipsOperation(this IImport importSubject, INamespace excluded)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/IncludeUseCaseUsageExtensions.cs
+++ b/SysML2.NET/Extend/IncludeUseCaseUsageExtensions.cs
@@ -60,23 +60,19 @@ namespace SysML2.NET.Core.POCO.Systems.UseCases
     /// The <see cref="IncludeUseCaseUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IIncludeUseCaseUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class IncludeUseCaseUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="includeUseCaseUsage">
+        /// <param name="includeUseCaseUsageSubject">
         /// The subject <see cref="IIncludeUseCaseUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IUseCaseUsage ComputeUseCaseIncluded(this IIncludeUseCaseUsage includeUseCaseUsage)
+        internal static IUseCaseUsage ComputeUseCaseIncluded(this IIncludeUseCaseUsage includeUseCaseUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/IndexExpressionExtensions.cs
+++ b/SysML2.NET/Extend/IndexExpressionExtensions.cs
@@ -20,16 +20,22 @@
 
 namespace SysML2.NET.Core.POCO.Kernel.Expressions
 {
-    using System.Diagnostics.CodeAnalysis;
+    using System;
+    using System.Collections.Generic;
+
+    using SysML2.NET.Core.Core.Types;
+    using SysML2.NET.Core.POCO.Core.Features;
+    using SysML2.NET.Core.POCO.Core.Types;
+    using SysML2.NET.Core.POCO.Kernel.Behaviors;
+    using SysML2.NET.Core.POCO.Kernel.Functions;
+    using SysML2.NET.Core.POCO.Root.Annotations;
+    using SysML2.NET.Core.POCO.Root.Elements;
+    using SysML2.NET.Core.POCO.Root.Namespaces;
 
     /// <summary>
     /// The <see cref="IndexExpressionExtensions"/> class provides extensions methods for
     /// the <see cref="IIndexExpression"/> interface
     /// </summary>
-    [SuppressMessage(
-        "Major Code Smell",
-        "S2094:Classes should not be empty",
-        Justification = "Extension class intentionally empty; methods are generated conditionally.")]
     internal static class IndexExpressionExtensions
     {
     }

--- a/SysML2.NET/Extend/InstantiationExpressionExtensions.cs
+++ b/SysML2.NET/Extend/InstantiationExpressionExtensions.cs
@@ -36,23 +36,19 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
     /// The <see cref="InstantiationExpressionExtensions"/> class provides extensions methods for
     /// the <see cref="IInstantiationExpression"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class InstantiationExpressionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="instantiationExpression">
+        /// <param name="instantiationExpressionSubject">
         /// The subject <see cref="IInstantiationExpression"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IExpression> ComputeArgument(this IInstantiationExpression instantiationExpression)
+        internal static List<IExpression> ComputeArgument(this IInstantiationExpression instantiationExpressionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -60,17 +56,34 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="instantiationExpression">
+        /// <param name="instantiationExpressionSubject">
         /// The subject <see cref="IInstantiationExpression"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IType ComputeInstantiatedType(this IInstantiationExpression instantiationExpression)
+        internal static IType ComputeInstantiatedType(this IInstantiationExpression instantiationExpressionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// Return the Type to act as the instantiatedType for this InstantiationExpression. By default, this is
+        /// the memberElement of the first ownedMembership that is not a FeatureMembership, which must be a
+        /// Type.                            <b>Note.</b> This operation is overridden in the subclass
+        /// OperatorExpression.
+        /// </summary>
+        /// <param name="instantiationExpressionSubject">
+        /// The subject <see cref="IInstantiationExpression"/>
+        /// </param>
+        /// <returns>
+        /// The expected IType
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IType ComputeInstantiatedTypeOperation(this IInstantiationExpression instantiationExpressionSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/InterfaceDefinitionExtensions.cs
+++ b/SysML2.NET/Extend/InterfaceDefinitionExtensions.cs
@@ -26,6 +26,7 @@ namespace SysML2.NET.Core.POCO.Systems.Interfaces
     using SysML2.NET.Core.POCO.Core.Classifiers;
     using SysML2.NET.Core.POCO.Core.Features;
     using SysML2.NET.Core.POCO.Core.Types;
+    using SysML2.NET.Core.POCO.Kernel.Associations;
     using SysML2.NET.Core.POCO.Root.Annotations;
     using SysML2.NET.Core.POCO.Root.Elements;
     using SysML2.NET.Core.POCO.Root.Namespaces;
@@ -55,23 +56,19 @@ namespace SysML2.NET.Core.POCO.Systems.Interfaces
     /// The <see cref="InterfaceDefinitionExtensions"/> class provides extensions methods for
     /// the <see cref="IInterfaceDefinition"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class InterfaceDefinitionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="interfaceDefinition">
+        /// <param name="interfaceDefinitionSubject">
         /// The subject <see cref="IInterfaceDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IPortUsage> ComputeInterfaceEnd(this IInterfaceDefinition interfaceDefinition)
+        internal static List<IPortUsage> ComputeInterfaceEnd(this IInterfaceDefinition interfaceDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/InterfaceUsageExtensions.cs
+++ b/SysML2.NET/Extend/InterfaceUsageExtensions.cs
@@ -30,6 +30,7 @@ namespace SysML2.NET.Core.POCO.Systems.Interfaces
     using SysML2.NET.Core.POCO.Core.Types;
     using SysML2.NET.Core.POCO.Kernel.Associations;
     using SysML2.NET.Core.POCO.Kernel.Classes;
+    using SysML2.NET.Core.POCO.Kernel.Connectors;
     using SysML2.NET.Core.POCO.Kernel.Structures;
     using SysML2.NET.Core.POCO.Root.Annotations;
     using SysML2.NET.Core.POCO.Root.Elements;
@@ -60,23 +61,19 @@ namespace SysML2.NET.Core.POCO.Systems.Interfaces
     /// The <see cref="InterfaceUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IInterfaceUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class InterfaceUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="interfaceUsage">
+        /// <param name="interfaceUsageSubject">
         /// The subject <see cref="IInterfaceUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IInterfaceDefinition> ComputeInterfaceDefinition(this IInterfaceUsage interfaceUsage)
+        internal static List<IInterfaceDefinition> ComputeInterfaceDefinition(this IInterfaceUsage interfaceUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/IntersectingExtensions.cs
+++ b/SysML2.NET/Extend/IntersectingExtensions.cs
@@ -31,23 +31,19 @@ namespace SysML2.NET.Core.POCO.Core.Types
     /// The <see cref="IntersectingExtensions"/> class provides extensions methods for
     /// the <see cref="IIntersecting"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class IntersectingExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="intersecting">
+        /// <param name="intersectingSubject">
         /// The subject <see cref="IIntersecting"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IType ComputeTypeIntersected(this IIntersecting intersecting)
+        internal static IType ComputeTypeIntersected(this IIntersecting intersectingSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/InvariantExtensions.cs
+++ b/SysML2.NET/Extend/InvariantExtensions.cs
@@ -20,16 +20,21 @@
 
 namespace SysML2.NET.Core.POCO.Kernel.Functions
 {
-    using System.Diagnostics.CodeAnalysis;
+    using System;
+    using System.Collections.Generic;
+
+    using SysML2.NET.Core.Core.Types;
+    using SysML2.NET.Core.POCO.Core.Features;
+    using SysML2.NET.Core.POCO.Core.Types;
+    using SysML2.NET.Core.POCO.Kernel.Behaviors;
+    using SysML2.NET.Core.POCO.Root.Annotations;
+    using SysML2.NET.Core.POCO.Root.Elements;
+    using SysML2.NET.Core.POCO.Root.Namespaces;
 
     /// <summary>
     /// The <see cref="InvariantExtensions"/> class provides extensions methods for
     /// the <see cref="IInvariant"/> interface
     /// </summary>
-    [SuppressMessage(
-        "Major Code Smell",
-        "S2094:Classes should not be empty",
-        Justification = "Extension class intentionally empty; methods are generated conditionally.")]
     internal static class InvariantExtensions
     {
     }

--- a/SysML2.NET/Extend/InvocationExpressionExtensions.cs
+++ b/SysML2.NET/Extend/InvocationExpressionExtensions.cs
@@ -1,0 +1,80 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="InvocationExpressionExtensions.cs" company="Starion Group S.A.">
+//
+//    Copyright (C) 2022-2026 Starion Group S.A.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Core.POCO.Kernel.Expressions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using SysML2.NET.Core.Core.Types;
+    using SysML2.NET.Core.POCO.Core.Features;
+    using SysML2.NET.Core.POCO.Core.Types;
+    using SysML2.NET.Core.POCO.Kernel.Behaviors;
+    using SysML2.NET.Core.POCO.Kernel.Functions;
+    using SysML2.NET.Core.POCO.Root.Annotations;
+    using SysML2.NET.Core.POCO.Root.Elements;
+    using SysML2.NET.Core.POCO.Root.Namespaces;
+
+    /// <summary>
+    /// The <see cref="InvocationExpressionExtensions"/> class provides extensions methods for
+    /// the <see cref="IInvocationExpression"/> interface
+    /// </summary>
+    internal static class InvocationExpressionExtensions
+    {
+        /// <summary>
+        /// An InvocationExpression is model-level evaluable if all its argument Expressions are model-level
+        /// evaluable and its function is model-level evaluable.
+        /// </summary>
+        /// <param name="invocationExpressionSubject">
+        /// The subject <see cref="IInvocationExpression"/>
+        /// </param>
+        /// <param name="visited">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeRedefinedModelLevelEvaluableOperation(this IInvocationExpression invocationExpressionSubject, IFeature visited)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Apply the Function that is the type of this InvocationExpression to the argument values resulting
+        /// from evaluating each of the argument Expressions on the given target. If the application is not
+        /// possible, then return an empty sequence.
+        /// </summary>
+        /// <param name="invocationExpressionSubject">
+        /// The subject <see cref="IInvocationExpression"/>
+        /// </param>
+        /// <param name="target">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IElement
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IElement ComputeRedefinedEvaluateOperation(this IInvocationExpression invocationExpressionSubject, IElement target)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+    }
+}

--- a/SysML2.NET/Extend/ItemUsageExtensions.cs
+++ b/SysML2.NET/Extend/ItemUsageExtensions.cs
@@ -59,23 +59,19 @@ namespace SysML2.NET.Core.POCO.Systems.Items
     /// The <see cref="ItemUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IItemUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ItemUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="itemUsage">
+        /// <param name="itemUsageSubject">
         /// The subject <see cref="IItemUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IStructure> ComputeItemDefinition(this IItemUsage itemUsage)
+        internal static List<IStructure> ComputeItemDefinition(this IItemUsage itemUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/LibraryPackageExtensions.cs
+++ b/SysML2.NET/Extend/LibraryPackageExtensions.cs
@@ -20,17 +20,33 @@
 
 namespace SysML2.NET.Core.POCO.Kernel.Packages
 {
-    using System.Diagnostics.CodeAnalysis;
+    using System;
+    using System.Collections.Generic;
+
+    using SysML2.NET.Core.POCO.Kernel.Functions;
+    using SysML2.NET.Core.POCO.Root.Annotations;
+    using SysML2.NET.Core.POCO.Root.Elements;
+    using SysML2.NET.Core.POCO.Root.Namespaces;
 
     /// <summary>
     /// The <see cref="LibraryPackageExtensions"/> class provides extensions methods for
     /// the <see cref="ILibraryPackage"/> interface
     /// </summary>
-    [SuppressMessage(
-        "Major Code Smell",
-        "S2094:Classes should not be empty",
-        Justification = "Extension class intentionally empty; methods are generated conditionally.")]
     internal static class LibraryPackageExtensions
     {
+        /// <summary>
+        /// The libraryNamespace for a LibraryPackage is itself.
+        /// </summary>
+        /// <param name="libraryPackageSubject">
+        /// The subject <see cref="ILibraryPackage"/>
+        /// </param>
+        /// <returns>
+        /// The expected INamespace
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static INamespace ComputeRedefinedLibraryNamespaceOperation(this ILibraryPackage libraryPackageSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/LiteralBooleanExtensions.cs
+++ b/SysML2.NET/Extend/LiteralBooleanExtensions.cs
@@ -20,16 +20,22 @@
 
 namespace SysML2.NET.Core.POCO.Kernel.Expressions
 {
-    using System.Diagnostics.CodeAnalysis;
+    using System;
+    using System.Collections.Generic;
+
+    using SysML2.NET.Core.Core.Types;
+    using SysML2.NET.Core.POCO.Core.Features;
+    using SysML2.NET.Core.POCO.Core.Types;
+    using SysML2.NET.Core.POCO.Kernel.Behaviors;
+    using SysML2.NET.Core.POCO.Kernel.Functions;
+    using SysML2.NET.Core.POCO.Root.Annotations;
+    using SysML2.NET.Core.POCO.Root.Elements;
+    using SysML2.NET.Core.POCO.Root.Namespaces;
 
     /// <summary>
     /// The <see cref="LiteralBooleanExtensions"/> class provides extensions methods for
     /// the <see cref="ILiteralBoolean"/> interface
     /// </summary>
-    [SuppressMessage(
-        "Major Code Smell",
-        "S2094:Classes should not be empty",
-        Justification = "Extension class intentionally empty; methods are generated conditionally.")]
     internal static class LiteralBooleanExtensions
     {
     }

--- a/SysML2.NET/Extend/LiteralExpressionExtensions.cs
+++ b/SysML2.NET/Extend/LiteralExpressionExtensions.cs
@@ -1,0 +1,77 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="LiteralExpressionExtensions.cs" company="Starion Group S.A.">
+//
+//    Copyright (C) 2022-2026 Starion Group S.A.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Core.POCO.Kernel.Expressions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using SysML2.NET.Core.Core.Types;
+    using SysML2.NET.Core.POCO.Core.Features;
+    using SysML2.NET.Core.POCO.Core.Types;
+    using SysML2.NET.Core.POCO.Kernel.Behaviors;
+    using SysML2.NET.Core.POCO.Kernel.Functions;
+    using SysML2.NET.Core.POCO.Root.Annotations;
+    using SysML2.NET.Core.POCO.Root.Elements;
+    using SysML2.NET.Core.POCO.Root.Namespaces;
+
+    /// <summary>
+    /// The <see cref="LiteralExpressionExtensions"/> class provides extensions methods for
+    /// the <see cref="ILiteralExpression"/> interface
+    /// </summary>
+    internal static class LiteralExpressionExtensions
+    {
+        /// <summary>
+        /// A LiteralExpression is always model-level evaluable.
+        /// </summary>
+        /// <param name="literalExpressionSubject">
+        /// The subject <see cref="ILiteralExpression"/>
+        /// </param>
+        /// <param name="visited">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeRedefinedModelLevelEvaluableOperation(this ILiteralExpression literalExpressionSubject, IFeature visited)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// The model-level value of a LiteralExpression is itself.
+        /// </summary>
+        /// <param name="literalExpressionSubject">
+        /// The subject <see cref="ILiteralExpression"/>
+        /// </param>
+        /// <param name="target">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IElement
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IElement ComputeRedefinedEvaluateOperation(this ILiteralExpression literalExpressionSubject, IElement target)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+    }
+}

--- a/SysML2.NET/Extend/LiteralIntegerExtensions.cs
+++ b/SysML2.NET/Extend/LiteralIntegerExtensions.cs
@@ -20,16 +20,22 @@
 
 namespace SysML2.NET.Core.POCO.Kernel.Expressions
 {
-    using System.Diagnostics.CodeAnalysis;
-    
+    using System;
+    using System.Collections.Generic;
+
+    using SysML2.NET.Core.Core.Types;
+    using SysML2.NET.Core.POCO.Core.Features;
+    using SysML2.NET.Core.POCO.Core.Types;
+    using SysML2.NET.Core.POCO.Kernel.Behaviors;
+    using SysML2.NET.Core.POCO.Kernel.Functions;
+    using SysML2.NET.Core.POCO.Root.Annotations;
+    using SysML2.NET.Core.POCO.Root.Elements;
+    using SysML2.NET.Core.POCO.Root.Namespaces;
+
     /// <summary>
     /// The <see cref="LiteralIntegerExtensions"/> class provides extensions methods for
     /// the <see cref="ILiteralInteger"/> interface
     /// </summary>
-    [SuppressMessage(
-        "Major Code Smell",
-        "S2094:Classes should not be empty",
-        Justification = "Extension class intentionally empty; methods are generated conditionally.")]
     internal static class LiteralIntegerExtensions
     {
     }

--- a/SysML2.NET/Extend/LiteralRationalExtensions.cs
+++ b/SysML2.NET/Extend/LiteralRationalExtensions.cs
@@ -20,16 +20,22 @@
 
 namespace SysML2.NET.Core.POCO.Kernel.Expressions
 {
-    using System.Diagnostics.CodeAnalysis;
+    using System;
+    using System.Collections.Generic;
+
+    using SysML2.NET.Core.Core.Types;
+    using SysML2.NET.Core.POCO.Core.Features;
+    using SysML2.NET.Core.POCO.Core.Types;
+    using SysML2.NET.Core.POCO.Kernel.Behaviors;
+    using SysML2.NET.Core.POCO.Kernel.Functions;
+    using SysML2.NET.Core.POCO.Root.Annotations;
+    using SysML2.NET.Core.POCO.Root.Elements;
+    using SysML2.NET.Core.POCO.Root.Namespaces;
 
     /// <summary>
     /// The <see cref="LiteralRationalExtensions"/> class provides extensions methods for
     /// the <see cref="ILiteralRational"/> interface
     /// </summary>
-    [SuppressMessage(
-        "Major Code Smell",
-        "S2094:Classes should not be empty",
-        Justification = "Extension class intentionally empty; methods are generated conditionally.")]
     internal static class LiteralRationalExtensions
     {
     }

--- a/SysML2.NET/Extend/LiteralStringExtensions.cs
+++ b/SysML2.NET/Extend/LiteralStringExtensions.cs
@@ -20,16 +20,22 @@
 
 namespace SysML2.NET.Core.POCO.Kernel.Expressions
 {
-    using System.Diagnostics.CodeAnalysis;
+    using System;
+    using System.Collections.Generic;
+
+    using SysML2.NET.Core.Core.Types;
+    using SysML2.NET.Core.POCO.Core.Features;
+    using SysML2.NET.Core.POCO.Core.Types;
+    using SysML2.NET.Core.POCO.Kernel.Behaviors;
+    using SysML2.NET.Core.POCO.Kernel.Functions;
+    using SysML2.NET.Core.POCO.Root.Annotations;
+    using SysML2.NET.Core.POCO.Root.Elements;
+    using SysML2.NET.Core.POCO.Root.Namespaces;
 
     /// <summary>
     /// The <see cref="LiteralStringExtensions"/> class provides extensions methods for
     /// the <see cref="ILiteralString"/> interface
     /// </summary>
-    [SuppressMessage(
-        "Major Code Smell",
-        "S2094:Classes should not be empty",
-        Justification = "Extension class intentionally empty; methods are generated conditionally.")]
     internal static class LiteralStringExtensions
     {
     }

--- a/SysML2.NET/Extend/LoopActionUsageExtensions.cs
+++ b/SysML2.NET/Extend/LoopActionUsageExtensions.cs
@@ -59,24 +59,19 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
     /// The <see cref="LoopActionUsageExtensions"/> class provides extensions methods for
     /// the <see cref="ILoopActionUsage"/> interface
     /// </summary>
-   
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class LoopActionUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="loopActionUsage">
+        /// <param name="loopActionUsageSubject">
         /// The subject <see cref="ILoopActionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IActionUsage ComputeBodyAction(this ILoopActionUsage loopActionUsage)
+        internal static IActionUsage ComputeBodyAction(this ILoopActionUsage loopActionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/MembershipExtensions.cs
+++ b/SysML2.NET/Extend/MembershipExtensions.cs
@@ -31,23 +31,19 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
     /// The <see cref="MembershipExtensions"/> class provides extensions methods for
     /// the <see cref="IMembership"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class MembershipExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="membership">
+        /// <param name="membershipSubject">
         /// The subject <see cref="IMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static string ComputeMemberElementId(this IMembership membership)
+        internal static string ComputeMemberElementId(this IMembership membershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -55,17 +51,38 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="membership">
+        /// <param name="membershipSubject">
         /// The subject <see cref="IMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static INamespace ComputeMembershipOwningNamespace(this IMembership membership)
+        internal static INamespace ComputeMembershipOwningNamespace(this IMembership membershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// Whether this Membership is distinguishable from a given other Membership. By default, this is true
+        /// if this Membership has no memberShortName or memberName; or each of the memberShortName and
+        /// memberName are different than both of those of the other Membership; or neither of the metaclasses
+        /// of the memberElement of this Membership and the memberElement of the other Membership conform to the
+        /// other. But this may be overridden in specializations of Membership.
+        /// </summary>
+        /// <param name="membershipSubject">
+        /// The subject <see cref="IMembership"/>
+        /// </param>
+        /// <param name="other">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeIsDistinguishableFromOperation(this IMembership membershipSubject, IMembership other)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/MembershipImportExtensions.cs
+++ b/SysML2.NET/Extend/MembershipImportExtensions.cs
@@ -20,17 +20,37 @@
 
 namespace SysML2.NET.Core.POCO.Root.Namespaces
 {
-    using System.Diagnostics.CodeAnalysis;
+    using System;
+    using System.Collections.Generic;
+
+    using SysML2.NET.Core.Root.Namespaces;
+    using SysML2.NET.Core.POCO.Root.Annotations;
+    using SysML2.NET.Core.POCO.Root.Elements;
 
     /// <summary>
     /// The <see cref="MembershipImportExtensions"/> class provides extensions methods for
     /// the <see cref="IMembershipImport"/> interface
     /// </summary>
-    [SuppressMessage(
-        "Major Code Smell",
-        "S2094:Classes should not be empty",
-        Justification = "Extension class intentionally empty; methods are generated conditionally.")]
     internal static class MembershipImportExtensions
     {
+        /// <summary>
+        /// Returns at least the importedMembership. If isRecursive = true and the memberElement of the
+        /// importedMembership is a Namespace, then Memberships are also recursively imported from that
+        /// Namespace.
+        /// </summary>
+        /// <param name="membershipImportSubject">
+        /// The subject <see cref="IMembershipImport"/>
+        /// </param>
+        /// <param name="excluded">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IMembership ComputeRedefinedImportedMembershipsOperation(this IMembershipImport membershipImportSubject, INamespace excluded)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/MetadataAccessExpressionExtensions.cs
+++ b/SysML2.NET/Extend/MetadataAccessExpressionExtensions.cs
@@ -28,6 +28,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
     using SysML2.NET.Core.POCO.Core.Types;
     using SysML2.NET.Core.POCO.Kernel.Behaviors;
     using SysML2.NET.Core.POCO.Kernel.Functions;
+    using SysML2.NET.Core.POCO.Kernel.Metadata;
     using SysML2.NET.Core.POCO.Root.Annotations;
     using SysML2.NET.Core.POCO.Root.Elements;
     using SysML2.NET.Core.POCO.Root.Namespaces;
@@ -36,26 +37,78 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
     /// The <see cref="MetadataAccessExpressionExtensions"/> class provides extensions methods for
     /// the <see cref="IMetadataAccessExpression"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class MetadataAccessExpressionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="metadataAccessExpression">
+        /// <param name="metadataAccessExpressionSubject">
         /// The subject <see cref="IMetadataAccessExpression"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IElement ComputeReferencedElement(this IMetadataAccessExpression metadataAccessExpression)
+        internal static IElement ComputeReferencedElement(this IMetadataAccessExpression metadataAccessExpressionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// A MetadataAccessExpression is always model-level evaluable.
+        /// </summary>
+        /// <param name="metadataAccessExpressionSubject">
+        /// The subject <see cref="IMetadataAccessExpression"/>
+        /// </param>
+        /// <param name="visited">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeRedefinedModelLevelEvaluableOperation(this IMetadataAccessExpression metadataAccessExpressionSubject, IFeature visited)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return the ownedElements of the referencedElement that are MetadataFeatures and have the
+        /// referencedElement as an annotatedElement, plus a MetadataFeature whose annotatedElement is the
+        /// referencedElement, whose metaclass is the reflective Metaclass corresponding to the MOF class of the
+        /// referencedElement and whose ownedFeatures are bound to the values of the MOF properties of the
+        /// referencedElement.
+        /// </summary>
+        /// <param name="metadataAccessExpressionSubject">
+        /// The subject <see cref="IMetadataAccessExpression"/>
+        /// </param>
+        /// <param name="target">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IElement
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IElement ComputeRedefinedEvaluateOperation(this IMetadataAccessExpression metadataAccessExpressionSubject, IElement target)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return a MetadataFeature whose annotatedElement is the referencedElement, whose metaclass is the
+        /// reflective Metaclass corresponding to the MOF class of the referencedElement and whose ownedFeatures
+        /// are bound to the MOF properties of the referencedElement.
+        /// </summary>
+        /// <param name="metadataAccessExpressionSubject">
+        /// The subject <see cref="IMetadataAccessExpression"/>
+        /// </param>
+        /// <returns>
+        /// The expected IMetadataFeature
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IMetadataFeature ComputeMetaclassFeatureOperation(this IMetadataAccessExpression metadataAccessExpressionSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/MetadataFeatureExtensions.cs
+++ b/SysML2.NET/Extend/MetadataFeatureExtensions.cs
@@ -34,26 +34,88 @@ namespace SysML2.NET.Core.POCO.Kernel.Metadata
     /// The <see cref="MetadataFeatureExtensions"/> class provides extensions methods for
     /// the <see cref="IMetadataFeature"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class MetadataFeatureExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="metadataFeature">
+        /// <param name="metadataFeatureSubject">
         /// The subject <see cref="IMetadataFeature"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IMetaclass ComputeMetaclass(this IMetadataFeature metadataFeature)
+        internal static IMetaclass ComputeMetaclass(this IMetadataFeature metadataFeatureSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// If the given baseFeature is a feature of this MetadataFeature, or is directly or indirectly
+        /// redefined by a feature, then return the result of evaluating the appropriate (model-level evaluable)
+        /// value Expression for it (if any), with the MetadataFeature as the target.
+        /// </summary>
+        /// <param name="metadataFeatureSubject">
+        /// The subject <see cref="IMetadataFeature"/>
+        /// </param>
+        /// <param name="baseFeature">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IElement
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IElement ComputeEvaluateFeatureOperation(this IMetadataFeature metadataFeatureSubject, IFeature baseFeature)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Check if this MetadataFeature has a metaclass which is a kind of SemanticMetadata.
+        /// </summary>
+        /// <param name="metadataFeatureSubject">
+        /// The subject <see cref="IMetadataFeature"/>
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeIsSemanticOperation(this IMetadataFeature metadataFeatureSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Check if this MetadataFeature has a metaclass that is a kind of KerML::Element (that is, it is from
+        /// the reflective abstract syntax model).
+        /// </summary>
+        /// <param name="metadataFeatureSubject">
+        /// The subject <see cref="IMetadataFeature"/>
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeIsSyntacticOperation(this IMetadataFeature metadataFeatureSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// If this MetadataFeature reflectively represents a model element, then return the corresponding
+        /// Element instance from the MOF abstract syntax representation of the model.
+        /// </summary>
+        /// <param name="metadataFeatureSubject">
+        /// The subject <see cref="IMetadataFeature"/>
+        /// </param>
+        /// <returns>
+        /// The expected IElement
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IElement ComputeSyntaxElementOperation(this IMetadataFeature metadataFeatureSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/MetadataUsageExtensions.cs
+++ b/SysML2.NET/Extend/MetadataUsageExtensions.cs
@@ -60,23 +60,19 @@ namespace SysML2.NET.Core.POCO.Systems.Metadata
     /// The <see cref="MetadataUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IMetadataUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class MetadataUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="metadataUsage">
+        /// <param name="metadataUsageSubject">
         /// The subject <see cref="IMetadataUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IMetaclass ComputeMetadataDefinition(this IMetadataUsage metadataUsage)
+        internal static IMetaclass ComputeMetadataDefinition(this IMetadataUsage metadataUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/MultiplicityRangeExtensions.cs
+++ b/SysML2.NET/Extend/MultiplicityRangeExtensions.cs
@@ -35,23 +35,19 @@ namespace SysML2.NET.Core.POCO.Kernel.Multiplicities
     /// The <see cref="MultiplicityRangeExtensions"/> class provides extensions methods for
     /// the <see cref="IMultiplicityRange"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class MultiplicityRangeExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="multiplicityRange">
+        /// <param name="multiplicityRangeSubject">
         /// The subject <see cref="IMultiplicityRange"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IExpression> ComputeBound(this IMultiplicityRange multiplicityRange)
+        internal static List<IExpression> ComputeBound(this IMultiplicityRange multiplicityRangeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -59,14 +55,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Multiplicities
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="multiplicityRange">
+        /// <param name="multiplicityRangeSubject">
         /// The subject <see cref="IMultiplicityRange"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IExpression ComputeLowerBound(this IMultiplicityRange multiplicityRange)
+        internal static IExpression ComputeLowerBound(this IMultiplicityRange multiplicityRangeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -74,17 +70,57 @@ namespace SysML2.NET.Core.POCO.Kernel.Multiplicities
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="multiplicityRange">
+        /// <param name="multiplicityRangeSubject">
         /// The subject <see cref="IMultiplicityRange"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IExpression ComputeUpperBound(this IMultiplicityRange multiplicityRange)
+        internal static IExpression ComputeUpperBound(this IMultiplicityRange multiplicityRangeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// Check whether this MultiplicityRange represents the range bounded by the given values lower and
+        /// upper, presuming the lowerBound and upperBound Expressions are model-level evaluable.
+        /// </summary>
+        /// <param name="multiplicityRangeSubject">
+        /// The subject <see cref="IMultiplicityRange"/>
+        /// </param>
+        /// <param name="lower">
+        /// No documentation provided
+        /// </param>
+        /// <param name="upper">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeHasBoundsOperation(this IMultiplicityRange multiplicityRangeSubject, int lower, string upper)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Evaluate the given bound Expression (at model level) and return the result represented as a MOF
+        /// UnlimitedNatural value.
+        /// </summary>
+        /// <param name="multiplicityRangeSubject">
+        /// The subject <see cref="IMultiplicityRange"/>
+        /// </param>
+        /// <param name="bound">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static string ComputeValueOfOperation(this IMultiplicityRange multiplicityRangeSubject, IExpression bound)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/NamespaceExtensions.cs
+++ b/SysML2.NET/Extend/NamespaceExtensions.cs
@@ -23,6 +23,7 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
     using System;
     using System.Collections.Generic;
 
+    using SysML2.NET.Core.Root.Namespaces;
     using SysML2.NET.Core.POCO.Root.Annotations;
     using SysML2.NET.Core.POCO.Root.Elements;
 
@@ -30,23 +31,19 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
     /// The <see cref="NamespaceExtensions"/> class provides extensions methods for
     /// the <see cref="INamespace"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class NamespaceExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="namespace">
+        /// <param name="namespaceSubject">
         /// The subject <see cref="INamespace"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IMembership> ComputeImportedMembership(this INamespace @namespace)
+        internal static List<IMembership> ComputeImportedMembership(this INamespace namespaceSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -54,14 +51,14 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="namespace">
+        /// <param name="namespaceSubject">
         /// The subject <see cref="INamespace"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IElement> ComputeMember(this INamespace @namespace)
+        internal static List<IElement> ComputeMember(this INamespace namespaceSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -69,14 +66,14 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="namespace">
+        /// <param name="namespaceSubject">
         /// The subject <see cref="INamespace"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IMembership> ComputeMembership(this INamespace @namespace)
+        internal static List<IMembership> ComputeMembership(this INamespace namespaceSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -84,14 +81,14 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="namespace">
+        /// <param name="namespaceSubject">
         /// The subject <see cref="INamespace"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IImport> ComputeOwnedImport(this INamespace @namespace)
+        internal static List<IImport> ComputeOwnedImport(this INamespace namespaceSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -99,14 +96,14 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="namespace">
+        /// <param name="namespaceSubject">
         /// The subject <see cref="INamespace"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IElement> ComputeOwnedMember(this INamespace @namespace)
+        internal static List<IElement> ComputeOwnedMember(this INamespace namespaceSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -114,14 +111,244 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="namespace">
+        /// <param name="namespaceSubject">
         /// The subject <see cref="INamespace"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IMembership> ComputeOwnedMembership(this INamespace @namespace)
+        internal static List<IMembership> ComputeOwnedMembership(this INamespace namespaceSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return the names of the given element as it is known in this Namespace.
+        /// </summary>
+        /// <param name="namespaceSubject">
+        /// The subject <see cref="INamespace"/>
+        /// </param>
+        /// <param name="element">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static string ComputeNamesOfOperation(this INamespace namespaceSubject, IElement element)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Returns this visibility of mem relative to this Namespace. If mem is an importedMembership, this is
+        /// the visibility of its Import. Otherwise it is the visibility of the Membership itself.
+        /// </summary>
+        /// <param name="namespaceSubject">
+        /// The subject <see cref="INamespace"/>
+        /// </param>
+        /// <param name="mem">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected VisibilityKind
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static VisibilityKind ComputeVisibilityOfOperation(this INamespace namespaceSubject, IMembership mem)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// If includeAll = true, then return all the Memberships of this Namespace. Otherwise, return only the
+        /// publicly visible Memberships of this Namespace, including ownedMemberships that have a visibility of
+        /// public and Memberships imported with a visibility of public. If isRecursive = true, also recursively
+        /// include all visible Memberships of any public owned Namespaces, or, if IncludeAll = true, all
+        /// Memberships of all owned Namespaces. When computing imported Memberships, ignore this Namespace and
+        /// any Namespaces in the given excluded set.
+        /// </summary>
+        /// <param name="namespaceSubject">
+        /// The subject <see cref="INamespace"/>
+        /// </param>
+        /// <param name="excluded">
+        /// No documentation provided
+        /// </param>
+        /// <param name="isRecursive">
+        /// No documentation provided
+        /// </param>
+        /// <param name="includeAll">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IMembership ComputeVisibleMembershipsOperation(this INamespace namespaceSubject, INamespace excluded, bool isRecursive, bool includeAll)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Derive the imported Memberships of this Namespace as the importedMembership of all ownedImports,
+        /// excluding those Imports whose importOwningNamespace is in the excluded set, and excluding
+        /// Memberships that have distinguisibility collisions with each other or with any ownedMembership.
+        /// </summary>
+        /// <param name="namespaceSubject">
+        /// The subject <see cref="INamespace"/>
+        /// </param>
+        /// <param name="excluded">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IMembership ComputeImportedMembershipsOperation(this INamespace namespaceSubject, INamespace excluded)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// If visibility is not null, return the Memberships of this Namespace with the given visibility,
+        /// including ownedMemberships with the given visibility and Memberships imported with the given
+        /// visibility. If visibility is null, return all ownedMemberships and imported Memberships regardless
+        /// of visibility. When computing imported Memberships, ignore this Namespace and any Namespaces in the
+        /// given excluded set.
+        /// </summary>
+        /// <param name="namespaceSubject">
+        /// The subject <see cref="INamespace"/>
+        /// </param>
+        /// <param name="visibility">
+        /// No documentation provided
+        /// </param>
+        /// <param name="excluded">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IMembership ComputeMembershipsOfVisibilityOperation(this INamespace namespaceSubject, VisibilityKind visibility, INamespace excluded)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Resolve the given qualified name to the named Membership (if any), starting with this Namespace as
+        /// the local scope. The qualified name string must conform to the concrete syntax of the KerML textual
+        /// notation. According to the KerML name resolution rules every qualified name will resolve to either a
+        /// single Membership, or to none.
+        /// </summary>
+        /// <param name="namespaceSubject">
+        /// The subject <see cref="INamespace"/>
+        /// </param>
+        /// <param name="qualifiedName">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IMembership ComputeResolveOperation(this INamespace namespaceSubject, string qualifiedName)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Resolve the given qualified name to the named Membership (if any) in the effective global Namespace
+        /// that is the outermost naming scope. The qualified name string must conform to the concrete syntax of
+        /// the KerML textual notation.
+        /// </summary>
+        /// <param name="namespaceSubject">
+        /// The subject <see cref="INamespace"/>
+        /// </param>
+        /// <param name="qualifiedName">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IMembership ComputeResolveGlobalOperation(this INamespace namespaceSubject, string qualifiedName)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Resolve a simple name starting with this Namespace as the local scope, and continuing with
+        /// containing outer scopes as necessary. However, if this Namespace is a root Namespace, then the
+        /// resolution is done directly in global scope.
+        /// </summary>
+        /// <param name="namespaceSubject">
+        /// The subject <see cref="INamespace"/>
+        /// </param>
+        /// <param name="name">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IMembership ComputeResolveLocalOperation(this INamespace namespaceSubject, string name)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Resolve a simple name from the visible Memberships of this Namespace.
+        /// </summary>
+        /// <param name="namespaceSubject">
+        /// The subject <see cref="INamespace"/>
+        /// </param>
+        /// <param name="name">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IMembership ComputeResolveVisibleOperation(this INamespace namespaceSubject, string name)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return a string with valid KerML syntax representing the qualification part of a given
+        /// qualifiedName, that is, a qualified name with all the segment names of the given name except the
+        /// last. If the given qualifiedName has only one segment, then return null.
+        /// </summary>
+        /// <param name="namespaceSubject">
+        /// The subject <see cref="INamespace"/>
+        /// </param>
+        /// <param name="qualifiedName">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static string ComputeQualificationOfOperation(this INamespace namespaceSubject, string qualifiedName)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return the simple name that is the last segment name of the given qualifiedName. If this segment
+        /// name has the form of a KerML unrestricted name, then "unescape" it by removing the surrounding
+        /// single quotes and replacing all escape sequences with the specified character.
+        /// </summary>
+        /// <param name="namespaceSubject">
+        /// The subject <see cref="INamespace"/>
+        /// </param>
+        /// <param name="qualifiedName">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static string ComputeUnqualifiedNameOfOperation(this INamespace namespaceSubject, string qualifiedName)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/NamespaceImportExtensions.cs
+++ b/SysML2.NET/Extend/NamespaceImportExtensions.cs
@@ -20,17 +20,37 @@
 
 namespace SysML2.NET.Core.POCO.Root.Namespaces
 {
-    using System.Diagnostics.CodeAnalysis;
+    using System;
+    using System.Collections.Generic;
+
+    using SysML2.NET.Core.Root.Namespaces;
+    using SysML2.NET.Core.POCO.Root.Annotations;
+    using SysML2.NET.Core.POCO.Root.Elements;
 
     /// <summary>
     /// The <see cref="NamespaceImportExtensions"/> class provides extensions methods for
     /// the <see cref="INamespaceImport"/> interface
     /// </summary>
-    [SuppressMessage(
-        "Major Code Smell",
-        "S2094:Classes should not be empty",
-        Justification = "Extension class intentionally empty; methods are generated conditionally.")]
     internal static class NamespaceImportExtensions
     {
+        /// <summary>
+        /// Returns at least the visible Memberships of the importedNamespace. If isRecursive = true, then
+        /// Memberships are also recursively imported from any ownedMembers of the importedNamespace that are
+        /// themselves Namespaces.
+        /// </summary>
+        /// <param name="namespaceImportSubject">
+        /// The subject <see cref="INamespaceImport"/>
+        /// </param>
+        /// <param name="excluded">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IMembership ComputeRedefinedImportedMembershipsOperation(this INamespaceImport namespaceImportSubject, INamespace excluded)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/NullExpressionExtensions.cs
+++ b/SysML2.NET/Extend/NullExpressionExtensions.cs
@@ -1,0 +1,77 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="NullExpressionExtensions.cs" company="Starion Group S.A.">
+//
+//    Copyright (C) 2022-2026 Starion Group S.A.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Core.POCO.Kernel.Expressions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using SysML2.NET.Core.Core.Types;
+    using SysML2.NET.Core.POCO.Core.Features;
+    using SysML2.NET.Core.POCO.Core.Types;
+    using SysML2.NET.Core.POCO.Kernel.Behaviors;
+    using SysML2.NET.Core.POCO.Kernel.Functions;
+    using SysML2.NET.Core.POCO.Root.Annotations;
+    using SysML2.NET.Core.POCO.Root.Elements;
+    using SysML2.NET.Core.POCO.Root.Namespaces;
+
+    /// <summary>
+    /// The <see cref="NullExpressionExtensions"/> class provides extensions methods for
+    /// the <see cref="INullExpression"/> interface
+    /// </summary>
+    internal static class NullExpressionExtensions
+    {
+        /// <summary>
+        /// A NullExpression is always model-level evaluable.
+        /// </summary>
+        /// <param name="nullExpressionSubject">
+        /// The subject <see cref="INullExpression"/>
+        /// </param>
+        /// <param name="visited">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeRedefinedModelLevelEvaluableOperation(this INullExpression nullExpressionSubject, IFeature visited)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// The model-level value of a NullExpression is an empty sequence.
+        /// </summary>
+        /// <param name="nullExpressionSubject">
+        /// The subject <see cref="INullExpression"/>
+        /// </param>
+        /// <param name="target">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IElement
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IElement ComputeRedefinedEvaluateOperation(this INullExpression nullExpressionSubject, IElement target)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+    }
+}

--- a/SysML2.NET/Extend/ObjectiveMembershipExtensions.cs
+++ b/SysML2.NET/Extend/ObjectiveMembershipExtensions.cs
@@ -35,23 +35,19 @@ namespace SysML2.NET.Core.POCO.Systems.Cases
     /// The <see cref="ObjectiveMembershipExtensions"/> class provides extensions methods for
     /// the <see cref="IObjectiveMembership"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ObjectiveMembershipExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="objectiveMembership">
+        /// <param name="objectiveMembershipSubject">
         /// The subject <see cref="IObjectiveMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IRequirementUsage ComputeOwnedObjectiveRequirement(this IObjectiveMembership objectiveMembership)
+        internal static IRequirementUsage ComputeOwnedObjectiveRequirement(this IObjectiveMembership objectiveMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/OccurrenceDefinitionExtensions.cs
+++ b/SysML2.NET/Extend/OccurrenceDefinitionExtensions.cs
@@ -20,16 +20,42 @@
 
 namespace SysML2.NET.Core.POCO.Systems.Occurrences
 {
-    using System.Diagnostics.CodeAnalysis;
-    
+    using System;
+    using System.Collections.Generic;
+
+    using SysML2.NET.Core.POCO.Core.Classifiers;
+    using SysML2.NET.Core.POCO.Core.Features;
+    using SysML2.NET.Core.POCO.Core.Types;
+    using SysML2.NET.Core.POCO.Kernel.Classes;
+    using SysML2.NET.Core.POCO.Root.Annotations;
+    using SysML2.NET.Core.POCO.Root.Elements;
+    using SysML2.NET.Core.POCO.Root.Namespaces;
+    using SysML2.NET.Core.POCO.Systems.Actions;
+    using SysML2.NET.Core.POCO.Systems.Allocations;
+    using SysML2.NET.Core.POCO.Systems.AnalysisCases;
+    using SysML2.NET.Core.POCO.Systems.Attributes;
+    using SysML2.NET.Core.POCO.Systems.Calculations;
+    using SysML2.NET.Core.POCO.Systems.Cases;
+    using SysML2.NET.Core.POCO.Systems.Connections;
+    using SysML2.NET.Core.POCO.Systems.Constraints;
+    using SysML2.NET.Core.POCO.Systems.DefinitionAndUsage;
+    using SysML2.NET.Core.POCO.Systems.Enumerations;
+    using SysML2.NET.Core.POCO.Systems.Flows;
+    using SysML2.NET.Core.POCO.Systems.Interfaces;
+    using SysML2.NET.Core.POCO.Systems.Items;
+    using SysML2.NET.Core.POCO.Systems.Metadata;
+    using SysML2.NET.Core.POCO.Systems.Parts;
+    using SysML2.NET.Core.POCO.Systems.Ports;
+    using SysML2.NET.Core.POCO.Systems.Requirements;
+    using SysML2.NET.Core.POCO.Systems.States;
+    using SysML2.NET.Core.POCO.Systems.UseCases;
+    using SysML2.NET.Core.POCO.Systems.VerificationCases;
+    using SysML2.NET.Core.POCO.Systems.Views;
+
     /// <summary>
     /// The <see cref="OccurrenceDefinitionExtensions"/> class provides extensions methods for
     /// the <see cref="IOccurrenceDefinition"/> interface
     /// </summary>
-    [SuppressMessage(
-        "Major Code Smell",
-        "S2094:Classes should not be empty",
-        Justification = "Extension class intentionally empty; methods are generated conditionally.")]
     internal static class OccurrenceDefinitionExtensions
     {
     }

--- a/SysML2.NET/Extend/OccurrenceUsageExtensions.cs
+++ b/SysML2.NET/Extend/OccurrenceUsageExtensions.cs
@@ -58,23 +58,19 @@ namespace SysML2.NET.Core.POCO.Systems.Occurrences
     /// The <see cref="OccurrenceUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IOccurrenceUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class OccurrenceUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="occurrenceUsage">
+        /// <param name="occurrenceUsageSubject">
         /// The subject <see cref="IOccurrenceUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IOccurrenceDefinition ComputeIndividualDefinition(this IOccurrenceUsage occurrenceUsage)
+        internal static IOccurrenceDefinition ComputeIndividualDefinition(this IOccurrenceUsage occurrenceUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -82,14 +78,14 @@ namespace SysML2.NET.Core.POCO.Systems.Occurrences
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="occurrenceUsage">
+        /// <param name="occurrenceUsageSubject">
         /// The subject <see cref="IOccurrenceUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IClass> ComputeOccurrenceDefinition(this IOccurrenceUsage occurrenceUsage)
+        internal static List<IClass> ComputeOccurrenceDefinition(this IOccurrenceUsage occurrenceUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/OperatorExpressionExtensions.cs
+++ b/SysML2.NET/Extend/OperatorExpressionExtensions.cs
@@ -20,17 +20,38 @@
 
 namespace SysML2.NET.Core.POCO.Kernel.Expressions
 {
-    using System.Diagnostics.CodeAnalysis;
-    
+    using System;
+    using System.Collections.Generic;
+
+    using SysML2.NET.Core.Core.Types;
+    using SysML2.NET.Core.POCO.Core.Features;
+    using SysML2.NET.Core.POCO.Core.Types;
+    using SysML2.NET.Core.POCO.Kernel.Behaviors;
+    using SysML2.NET.Core.POCO.Kernel.Functions;
+    using SysML2.NET.Core.POCO.Root.Annotations;
+    using SysML2.NET.Core.POCO.Root.Elements;
+    using SysML2.NET.Core.POCO.Root.Namespaces;
+
     /// <summary>
     /// The <see cref="OperatorExpressionExtensions"/> class provides extensions methods for
     /// the <see cref="IOperatorExpression"/> interface
     /// </summary>
-    [SuppressMessage(
-        "Major Code Smell",
-        "S2094:Classes should not be empty",
-        Justification = "Extension class intentionally empty; methods are generated conditionally.")]
     internal static class OperatorExpressionExtensions
     {
+        /// <summary>
+        /// The instantiatedType of an OperatorExpression is the resolution of it's operator from one of the
+        /// packages BaseFunctions, DataFunctions, or ControlFunctions from the Kernel Function Library.
+        /// </summary>
+        /// <param name="operatorExpressionSubject">
+        /// The subject <see cref="IOperatorExpression"/>
+        /// </param>
+        /// <returns>
+        /// The expected IType
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IType ComputeRedefinedInstantiatedTypeOperation(this IOperatorExpression operatorExpressionSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/OwningMembershipExtensions.cs
+++ b/SysML2.NET/Extend/OwningMembershipExtensions.cs
@@ -31,23 +31,19 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
     /// The <see cref="OwningMembershipExtensions"/> class provides extensions methods for
     /// the <see cref="IOwningMembership"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class OwningMembershipExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="owningMembership">
+        /// <param name="owningMembershipSubject">
         /// The subject <see cref="IOwningMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IElement ComputeOwnedMemberElement(this IOwningMembership owningMembership)
+        internal static IElement ComputeOwnedMemberElement(this IOwningMembership owningMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -55,14 +51,14 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="owningMembership">
+        /// <param name="owningMembershipSubject">
         /// The subject <see cref="IOwningMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static string ComputeOwnedMemberElementId(this IOwningMembership owningMembership)
+        internal static string ComputeOwnedMemberElementId(this IOwningMembership owningMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -70,14 +66,14 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="owningMembership">
+        /// <param name="owningMembershipSubject">
         /// The subject <see cref="IOwningMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static string ComputeOwnedMemberName(this IOwningMembership owningMembership)
+        internal static string ComputeOwnedMemberName(this IOwningMembership owningMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -85,17 +81,33 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="owningMembership">
+        /// <param name="owningMembershipSubject">
         /// The subject <see cref="IOwningMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static string ComputeOwnedMemberShortName(this IOwningMembership owningMembership)
+        internal static string ComputeOwnedMemberShortName(this IOwningMembership owningMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// If the ownedMemberElement of this OwningMembership has a non-null qualifiedName, then return the
+        /// string constructed by appending to that qualifiedName the string "/owningMembership". Otherwise,
+        /// return the path of the OwningMembership as specified for a Relationship in general.
+        /// </summary>
+        /// <param name="owningMembershipSubject">
+        /// The subject <see cref="IOwningMembership"/>
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static string ComputeRedefinedPathOperation(this IOwningMembership owningMembershipSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/PackageExtensions.cs
+++ b/SysML2.NET/Extend/PackageExtensions.cs
@@ -32,26 +32,57 @@ namespace SysML2.NET.Core.POCO.Kernel.Packages
     /// The <see cref="PackageExtensions"/> class provides extensions methods for
     /// the <see cref="IPackage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class PackageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="package">
+        /// <param name="packageSubject">
         /// The subject <see cref="IPackage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IExpression> ComputeFilterCondition(this IPackage package)
+        internal static List<IExpression> ComputeFilterCondition(this IPackage packageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// Exclude Elements that do not meet all the filterConditions.
+        /// </summary>
+        /// <param name="packageSubject">
+        /// The subject <see cref="IPackage"/>
+        /// </param>
+        /// <param name="excluded">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IMembership ComputeRedefinedImportedMembershipsOperation(this IPackage packageSubject, INamespace excluded)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Determine whether the given element meets all the filterConditions.
+        /// </summary>
+        /// <param name="packageSubject">
+        /// The subject <see cref="IPackage"/>
+        /// </param>
+        /// <param name="element">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeIncludeAsMemberOperation(this IPackage packageSubject, IElement element)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/ParameterMembershipExtensions.cs
+++ b/SysML2.NET/Extend/ParameterMembershipExtensions.cs
@@ -23,6 +23,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Behaviors
     using System;
     using System.Collections.Generic;
 
+    using SysML2.NET.Core.Core.Types;
     using SysML2.NET.Core.Root.Namespaces;
     using SysML2.NET.Core.POCO.Core.Features;
     using SysML2.NET.Core.POCO.Core.Types;
@@ -34,26 +35,36 @@ namespace SysML2.NET.Core.POCO.Kernel.Behaviors
     /// The <see cref="ParameterMembershipExtensions"/> class provides extensions methods for
     /// the <see cref="IParameterMembership"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ParameterMembershipExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="parameterMembership">
+        /// <param name="parameterMembershipSubject">
         /// The subject <see cref="IParameterMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeOwnedMemberParameter(this IParameterMembership parameterMembership)
+        internal static IFeature ComputeOwnedMemberParameter(this IParameterMembership parameterMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// Return the required value of the direction of the ownedMemberParameter. By default, this is in.
+        /// </summary>
+        /// <param name="parameterMembershipSubject">
+        /// The subject <see cref="IParameterMembership"/>
+        /// </param>
+        /// <returns>
+        /// The expected FeatureDirectionKind
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static FeatureDirectionKind ComputeParameterDirectionOperation(this IParameterMembership parameterMembershipSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/PartUsageExtensions.cs
+++ b/SysML2.NET/Extend/PartUsageExtensions.cs
@@ -59,23 +59,19 @@ namespace SysML2.NET.Core.POCO.Systems.Parts
     /// The <see cref="PartUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IPartUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class PartUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="partUsage">
+        /// <param name="partUsageSubject">
         /// The subject <see cref="IPartUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IPartDefinition> ComputePartDefinition(this IPartUsage partUsage)
+        internal static List<IPartDefinition> ComputePartDefinition(this IPartUsage partUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/PerformActionUsageExtensions.cs
+++ b/SysML2.NET/Extend/PerformActionUsageExtensions.cs
@@ -59,26 +59,38 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
     /// The <see cref="PerformActionUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IPerformActionUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class PerformActionUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="performActionUsage">
+        /// <param name="performActionUsageSubject">
         /// The subject <see cref="IPerformActionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IActionUsage ComputePerformedAction(this IPerformActionUsage performActionUsage)
+        internal static IActionUsage ComputePerformedAction(this IPerformActionUsage performActionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// The naming Feature of a PerformActionUsage is its performedAction, if this is different than the
+        /// PerformActionUsage. If the PerformActionUsage is its own performedAction, then the naming Feature is
+        /// the same as the usual default for a Usage.
+        /// </summary>
+        /// <param name="performActionUsageSubject">
+        /// The subject <see cref="IPerformActionUsage"/>
+        /// </param>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IFeature ComputeRedefinedNamingFeatureOperation(this IPerformActionUsage performActionUsageSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/PortConjugationExtensions.cs
+++ b/SysML2.NET/Extend/PortConjugationExtensions.cs
@@ -32,23 +32,19 @@ namespace SysML2.NET.Core.POCO.Systems.Ports
     /// The <see cref="PortConjugationExtensions"/> class provides extensions methods for
     /// the <see cref="IPortConjugation"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class PortConjugationExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="portConjugation">
+        /// <param name="portConjugationSubject">
         /// The subject <see cref="IPortConjugation"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IConjugatedPortDefinition ComputeConjugatedPortDefinition(this IPortConjugation portConjugation)
+        internal static IConjugatedPortDefinition ComputeConjugatedPortDefinition(this IPortConjugation portConjugationSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/PortDefinitionExtensions.cs
+++ b/SysML2.NET/Extend/PortDefinitionExtensions.cs
@@ -56,23 +56,19 @@ namespace SysML2.NET.Core.POCO.Systems.Ports
     /// The <see cref="PortDefinitionExtensions"/> class provides extensions methods for
     /// the <see cref="IPortDefinition"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class PortDefinitionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="portDefinition">
+        /// <param name="portDefinitionSubject">
         /// The subject <see cref="IPortDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IConjugatedPortDefinition ComputeConjugatedPortDefinition(this IPortDefinition portDefinition)
+        internal static IConjugatedPortDefinition ComputeConjugatedPortDefinition(this IPortDefinition portDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/PortUsageExtensions.cs
+++ b/SysML2.NET/Extend/PortUsageExtensions.cs
@@ -58,23 +58,19 @@ namespace SysML2.NET.Core.POCO.Systems.Ports
     /// The <see cref="PortUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IPortUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class PortUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="portUsage">
+        /// <param name="portUsageSubject">
         /// The subject <see cref="IPortUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IPortDefinition> ComputePortDefinition(this IPortUsage portUsage)
+        internal static List<IPortDefinition> ComputePortDefinition(this IPortUsage portUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/RedefinitionExtensions.cs
+++ b/SysML2.NET/Extend/RedefinitionExtensions.cs
@@ -20,16 +20,18 @@
 
 namespace SysML2.NET.Core.POCO.Core.Features
 {
-    using System.Diagnostics.CodeAnalysis;
+    using System;
+    using System.Collections.Generic;
+
+    using SysML2.NET.Core.POCO.Core.Types;
+    using SysML2.NET.Core.POCO.Root.Annotations;
+    using SysML2.NET.Core.POCO.Root.Elements;
+    using SysML2.NET.Core.POCO.Root.Namespaces;
 
     /// <summary>
     /// The <see cref="RedefinitionExtensions"/> class provides extensions methods for
     /// the <see cref="IRedefinition"/> interface
     /// </summary>
-    [SuppressMessage(
-        "Major Code Smell",
-        "S2094:Classes should not be empty",
-        Justification = "Extension class intentionally empty; methods are generated conditionally.")]
     internal static class RedefinitionExtensions
     {
     }

--- a/SysML2.NET/Extend/ReferenceSubsettingExtensions.cs
+++ b/SysML2.NET/Extend/ReferenceSubsettingExtensions.cs
@@ -32,23 +32,19 @@ namespace SysML2.NET.Core.POCO.Core.Features
     /// The <see cref="ReferenceSubsettingExtensions"/> class provides extensions methods for
     /// the <see cref="IReferenceSubsetting"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ReferenceSubsettingExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="referenceSubsetting">
+        /// <param name="referenceSubsettingSubject">
         /// The subject <see cref="IReferenceSubsetting"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeReferencingFeature(this IReferenceSubsetting referenceSubsetting)
+        internal static IFeature ComputeReferencingFeature(this IReferenceSubsetting referenceSubsettingSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/ReferenceUsageExtensions.cs
+++ b/SysML2.NET/Extend/ReferenceUsageExtensions.cs
@@ -56,26 +56,37 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
     /// The <see cref="ReferenceUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IReferenceUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ReferenceUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="referenceUsage">
+        /// <param name="referenceUsageSubject">
         /// The subject <see cref="IReferenceUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static bool ComputeIsReference(this IReferenceUsage referenceUsage)
+        internal static bool ComputeIsReference(this IReferenceUsage referenceUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// If this ReferenceUsage is the payload parameter of a TransitionUsage, then its naming Feature is the
+        /// payloadParameter of the triggerAction of that TransitionUsage (if any).
+        /// </summary>
+        /// <param name="referenceUsageSubject">
+        /// The subject <see cref="IReferenceUsage"/>
+        /// </param>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IFeature ComputeRedefinedNamingFeatureOperation(this IReferenceUsage referenceUsageSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/RelationshipExtensions.cs
+++ b/SysML2.NET/Extend/RelationshipExtensions.cs
@@ -30,26 +30,55 @@ namespace SysML2.NET.Core.POCO.Root.Elements
     /// The <see cref="RelationshipExtensions"/> class provides extensions methods for
     /// the <see cref="IRelationship"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class RelationshipExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="relationship">
+        /// <param name="relationshipSubject">
         /// The subject <see cref="IRelationship"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IElement> ComputeRelatedElement(this IRelationship relationship)
+        internal static List<IElement> ComputeRelatedElement(this IRelationship relationshipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// Return whether this Relationship has either an owningRelatedElement or owningRelationship that is a
+        /// library element.
+        /// </summary>
+        /// <param name="relationshipSubject">
+        /// The subject <see cref="IRelationship"/>
+        /// </param>
+        /// <returns>
+        /// The expected INamespace
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static INamespace ComputeRedefinedLibraryNamespaceOperation(this IRelationship relationshipSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// If the owningRelationship of the Relationship is null but its owningRelatedElement is non-null,
+        /// construct the path using the position of the Relationship in the list of ownedRelationships of its
+        /// owningRelatedElement. Otherwise, return the path of the Relationship as specified for an Element in
+        /// general.
+        /// </summary>
+        /// <param name="relationshipSubject">
+        /// The subject <see cref="IRelationship"/>
+        /// </param>
+        /// <returns>
+        /// The expected string
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static string ComputeRedefinedPathOperation(this IRelationship relationshipSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/RenderingDefinitionExtensions.cs
+++ b/SysML2.NET/Extend/RenderingDefinitionExtensions.cs
@@ -55,23 +55,19 @@ namespace SysML2.NET.Core.POCO.Systems.Views
     /// The <see cref="RenderingDefinitionExtensions"/> class provides extensions methods for
     /// the <see cref="IRenderingDefinition"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class RenderingDefinitionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="renderingDefinition">
+        /// <param name="renderingDefinitionSubject">
         /// The subject <see cref="IRenderingDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IRenderingUsage> ComputeRendering(this IRenderingDefinition renderingDefinition)
+        internal static List<IRenderingUsage> ComputeRendering(this IRenderingDefinition renderingDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/RenderingUsageExtensions.cs
+++ b/SysML2.NET/Extend/RenderingUsageExtensions.cs
@@ -59,23 +59,19 @@ namespace SysML2.NET.Core.POCO.Systems.Views
     /// The <see cref="RenderingUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IRenderingUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class RenderingUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="renderingUsage">
+        /// <param name="renderingUsageSubject">
         /// The subject <see cref="IRenderingUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IRenderingDefinition ComputeRenderingDefinition(this IRenderingUsage renderingUsage)
+        internal static IRenderingDefinition ComputeRenderingDefinition(this IRenderingUsage renderingUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/RequirementConstraintMembershipExtensions.cs
+++ b/SysML2.NET/Extend/RequirementConstraintMembershipExtensions.cs
@@ -36,23 +36,19 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
     /// The <see cref="RequirementConstraintMembershipExtensions"/> class provides extensions methods for
     /// the <see cref="IRequirementConstraintMembership"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class RequirementConstraintMembershipExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementConstraintMembership">
+        /// <param name="requirementConstraintMembershipSubject">
         /// The subject <see cref="IRequirementConstraintMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IConstraintUsage ComputeOwnedConstraint(this IRequirementConstraintMembership requirementConstraintMembership)
+        internal static IConstraintUsage ComputeOwnedConstraint(this IRequirementConstraintMembership requirementConstraintMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -60,14 +56,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementConstraintMembership">
+        /// <param name="requirementConstraintMembershipSubject">
         /// The subject <see cref="IRequirementConstraintMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IConstraintUsage ComputeReferencedConstraint(this IRequirementConstraintMembership requirementConstraintMembership)
+        internal static IConstraintUsage ComputeReferencedConstraint(this IRequirementConstraintMembership requirementConstraintMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/RequirementDefinitionExtensions.cs
+++ b/SysML2.NET/Extend/RequirementDefinitionExtensions.cs
@@ -57,23 +57,19 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
     /// The <see cref="RequirementDefinitionExtensions"/> class provides extensions methods for
     /// the <see cref="IRequirementDefinition"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class RequirementDefinitionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementDefinition">
+        /// <param name="requirementDefinitionSubject">
         /// The subject <see cref="IRequirementDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IPartUsage> ComputeActorParameter(this IRequirementDefinition requirementDefinition)
+        internal static List<IPartUsage> ComputeActorParameter(this IRequirementDefinition requirementDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -81,14 +77,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementDefinition">
+        /// <param name="requirementDefinitionSubject">
         /// The subject <see cref="IRequirementDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IConstraintUsage> ComputeAssumedConstraint(this IRequirementDefinition requirementDefinition)
+        internal static List<IConstraintUsage> ComputeAssumedConstraint(this IRequirementDefinition requirementDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -96,14 +92,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementDefinition">
+        /// <param name="requirementDefinitionSubject">
         /// The subject <see cref="IRequirementDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IConcernUsage> ComputeFramedConcern(this IRequirementDefinition requirementDefinition)
+        internal static List<IConcernUsage> ComputeFramedConcern(this IRequirementDefinition requirementDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -111,14 +107,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementDefinition">
+        /// <param name="requirementDefinitionSubject">
         /// The subject <see cref="IRequirementDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IConstraintUsage> ComputeRequiredConstraint(this IRequirementDefinition requirementDefinition)
+        internal static List<IConstraintUsage> ComputeRequiredConstraint(this IRequirementDefinition requirementDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -126,14 +122,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementDefinition">
+        /// <param name="requirementDefinitionSubject">
         /// The subject <see cref="IRequirementDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IPartUsage> ComputeStakeholderParameter(this IRequirementDefinition requirementDefinition)
+        internal static List<IPartUsage> ComputeStakeholderParameter(this IRequirementDefinition requirementDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -141,14 +137,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementDefinition">
+        /// <param name="requirementDefinitionSubject">
         /// The subject <see cref="IRequirementDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IUsage ComputeSubjectParameter(this IRequirementDefinition requirementDefinition)
+        internal static IUsage ComputeSubjectParameter(this IRequirementDefinition requirementDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -156,14 +152,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementDefinition">
+        /// <param name="requirementDefinitionSubject">
         /// The subject <see cref="IRequirementDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<string> ComputeText(this IRequirementDefinition requirementDefinition)
+        internal static List<string> ComputeText(this IRequirementDefinition requirementDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/RequirementUsageExtensions.cs
+++ b/SysML2.NET/Extend/RequirementUsageExtensions.cs
@@ -60,23 +60,19 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
     /// The <see cref="RequirementUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IRequirementUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class RequirementUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementUsage">
+        /// <param name="requirementUsageSubject">
         /// The subject <see cref="IRequirementUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IPartUsage> ComputeActorParameter(this IRequirementUsage requirementUsage)
+        internal static List<IPartUsage> ComputeActorParameter(this IRequirementUsage requirementUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -84,14 +80,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementUsage">
+        /// <param name="requirementUsageSubject">
         /// The subject <see cref="IRequirementUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IConstraintUsage> ComputeAssumedConstraint(this IRequirementUsage requirementUsage)
+        internal static List<IConstraintUsage> ComputeAssumedConstraint(this IRequirementUsage requirementUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -99,14 +95,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementUsage">
+        /// <param name="requirementUsageSubject">
         /// The subject <see cref="IRequirementUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IConcernUsage> ComputeFramedConcern(this IRequirementUsage requirementUsage)
+        internal static List<IConcernUsage> ComputeFramedConcern(this IRequirementUsage requirementUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -114,14 +110,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementUsage">
+        /// <param name="requirementUsageSubject">
         /// The subject <see cref="IRequirementUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IConstraintUsage> ComputeRequiredConstraint(this IRequirementUsage requirementUsage)
+        internal static List<IConstraintUsage> ComputeRequiredConstraint(this IRequirementUsage requirementUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -129,14 +125,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementUsage">
+        /// <param name="requirementUsageSubject">
         /// The subject <see cref="IRequirementUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IRequirementDefinition ComputeRequirementDefinition(this IRequirementUsage requirementUsage)
+        internal static IRequirementDefinition ComputeRequirementDefinition(this IRequirementUsage requirementUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -144,14 +140,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementUsage">
+        /// <param name="requirementUsageSubject">
         /// The subject <see cref="IRequirementUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IPartUsage> ComputeStakeholderParameter(this IRequirementUsage requirementUsage)
+        internal static List<IPartUsage> ComputeStakeholderParameter(this IRequirementUsage requirementUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -159,14 +155,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementUsage">
+        /// <param name="requirementUsageSubject">
         /// The subject <see cref="IRequirementUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IUsage ComputeSubjectParameter(this IRequirementUsage requirementUsage)
+        internal static IUsage ComputeSubjectParameter(this IRequirementUsage requirementUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -174,14 +170,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementUsage">
+        /// <param name="requirementUsageSubject">
         /// The subject <see cref="IRequirementUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<string> ComputeText(this IRequirementUsage requirementUsage)
+        internal static List<string> ComputeText(this IRequirementUsage requirementUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/RequirementVerificationMembershipExtensions.cs
+++ b/SysML2.NET/Extend/RequirementVerificationMembershipExtensions.cs
@@ -37,23 +37,19 @@ namespace SysML2.NET.Core.POCO.Systems.VerificationCases
     /// The <see cref="RequirementVerificationMembershipExtensions"/> class provides extensions methods for
     /// the <see cref="IRequirementVerificationMembership"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class RequirementVerificationMembershipExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementVerificationMembership">
+        /// <param name="requirementVerificationMembershipSubject">
         /// The subject <see cref="IRequirementVerificationMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IRequirementUsage ComputeOwnedRequirement(this IRequirementVerificationMembership requirementVerificationMembership)
+        internal static IRequirementUsage ComputeOwnedRequirement(this IRequirementVerificationMembership requirementVerificationMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -61,14 +57,14 @@ namespace SysML2.NET.Core.POCO.Systems.VerificationCases
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="requirementVerificationMembership">
+        /// <param name="requirementVerificationMembershipSubject">
         /// The subject <see cref="IRequirementVerificationMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IRequirementUsage ComputeVerifiedRequirement(this IRequirementVerificationMembership requirementVerificationMembership)
+        internal static IRequirementUsage ComputeVerifiedRequirement(this IRequirementVerificationMembership requirementVerificationMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/ResultExpressionMembershipExtensions.cs
+++ b/SysML2.NET/Extend/ResultExpressionMembershipExtensions.cs
@@ -34,23 +34,19 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
     /// The <see cref="ResultExpressionMembershipExtensions"/> class provides extensions methods for
     /// the <see cref="IResultExpressionMembership"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ResultExpressionMembershipExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="resultExpressionMembership">
+        /// <param name="resultExpressionMembershipSubject">
         /// The subject <see cref="IResultExpressionMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IExpression ComputeOwnedResultExpression(this IResultExpressionMembership resultExpressionMembership)
+        internal static IExpression ComputeOwnedResultExpression(this IResultExpressionMembership resultExpressionMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/ReturnParameterMembershipExtensions.cs
+++ b/SysML2.NET/Extend/ReturnParameterMembershipExtensions.cs
@@ -1,0 +1,57 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ReturnParameterMembershipExtensions.cs" company="Starion Group S.A.">
+//
+//    Copyright (C) 2022-2026 Starion Group S.A.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Core.POCO.Kernel.Functions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using SysML2.NET.Core.Core.Types;
+    using SysML2.NET.Core.Root.Namespaces;
+    using SysML2.NET.Core.POCO.Core.Features;
+    using SysML2.NET.Core.POCO.Core.Types;
+    using SysML2.NET.Core.POCO.Kernel.Behaviors;
+    using SysML2.NET.Core.POCO.Root.Annotations;
+    using SysML2.NET.Core.POCO.Root.Elements;
+    using SysML2.NET.Core.POCO.Root.Namespaces;
+
+    /// <summary>
+    /// The <see cref="ReturnParameterMembershipExtensions"/> class provides extensions methods for
+    /// the <see cref="IReturnParameterMembership"/> interface
+    /// </summary>
+    internal static class ReturnParameterMembershipExtensions
+    {
+        /// <summary>
+        /// The ownedMemberParameter of a ReturnParameterMembership must have direction out. (This is a leaf
+        /// operation that cannot be further redefined.)
+        /// </summary>
+        /// <param name="returnParameterMembershipSubject">
+        /// The subject <see cref="IReturnParameterMembership"/>
+        /// </param>
+        /// <returns>
+        /// The expected FeatureDirectionKind
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static FeatureDirectionKind ComputeRedefinedParameterDirectionOperation(this IReturnParameterMembership returnParameterMembershipSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+    }
+}

--- a/SysML2.NET/Extend/SatisfyRequirementUsageExtensions.cs
+++ b/SysML2.NET/Extend/SatisfyRequirementUsageExtensions.cs
@@ -60,23 +60,19 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
     /// The <see cref="SatisfyRequirementUsageExtensions"/> class provides extensions methods for
     /// the <see cref="ISatisfyRequirementUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class SatisfyRequirementUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="satisfyRequirementUsage">
+        /// <param name="satisfyRequirementUsageSubject">
         /// The subject <see cref="ISatisfyRequirementUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IRequirementUsage ComputeSatisfiedRequirement(this ISatisfyRequirementUsage satisfyRequirementUsage)
+        internal static IRequirementUsage ComputeSatisfiedRequirement(this ISatisfyRequirementUsage satisfyRequirementUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -84,14 +80,14 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="satisfyRequirementUsage">
+        /// <param name="satisfyRequirementUsageSubject">
         /// The subject <see cref="ISatisfyRequirementUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeSatisfyingFeature(this ISatisfyRequirementUsage satisfyRequirementUsage)
+        internal static IFeature ComputeSatisfyingFeature(this ISatisfyRequirementUsage satisfyRequirementUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/SelectExpressionExtensions.cs
+++ b/SysML2.NET/Extend/SelectExpressionExtensions.cs
@@ -20,16 +20,22 @@
 
 namespace SysML2.NET.Core.POCO.Kernel.Expressions
 {
-    using System.Diagnostics.CodeAnalysis;
+    using System;
+    using System.Collections.Generic;
+
+    using SysML2.NET.Core.Core.Types;
+    using SysML2.NET.Core.POCO.Core.Features;
+    using SysML2.NET.Core.POCO.Core.Types;
+    using SysML2.NET.Core.POCO.Kernel.Behaviors;
+    using SysML2.NET.Core.POCO.Kernel.Functions;
+    using SysML2.NET.Core.POCO.Root.Annotations;
+    using SysML2.NET.Core.POCO.Root.Elements;
+    using SysML2.NET.Core.POCO.Root.Namespaces;
 
     /// <summary>
     /// The <see cref="SelectExpressionExtensions"/> class provides extensions methods for
     /// the <see cref="ISelectExpression"/> interface
     /// </summary>
-    [SuppressMessage(
-        "Major Code Smell",
-        "S2094:Classes should not be empty",
-        Justification = "Extension class intentionally empty; methods are generated conditionally.")]
     internal static class SelectExpressionExtensions
     {
     }

--- a/SysML2.NET/Extend/SendActionUsageExtensions.cs
+++ b/SysML2.NET/Extend/SendActionUsageExtensions.cs
@@ -60,23 +60,19 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
     /// The <see cref="SendActionUsageExtensions"/> class provides extensions methods for
     /// the <see cref="ISendActionUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class SendActionUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="sendActionUsage">
+        /// <param name="sendActionUsageSubject">
         /// The subject <see cref="ISendActionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IExpression ComputePayloadArgument(this ISendActionUsage sendActionUsage)
+        internal static IExpression ComputePayloadArgument(this ISendActionUsage sendActionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -84,14 +80,14 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="sendActionUsage">
+        /// <param name="sendActionUsageSubject">
         /// The subject <see cref="ISendActionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IExpression ComputeReceiverArgument(this ISendActionUsage sendActionUsage)
+        internal static IExpression ComputeReceiverArgument(this ISendActionUsage sendActionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -99,14 +95,14 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="sendActionUsage">
+        /// <param name="sendActionUsageSubject">
         /// The subject <see cref="ISendActionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IExpression ComputeSenderArgument(this ISendActionUsage sendActionUsage)
+        internal static IExpression ComputeSenderArgument(this ISendActionUsage sendActionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/SpecializationExtensions.cs
+++ b/SysML2.NET/Extend/SpecializationExtensions.cs
@@ -31,23 +31,19 @@ namespace SysML2.NET.Core.POCO.Core.Types
     /// The <see cref="SpecializationExtensions"/> class provides extensions methods for
     /// the <see cref="ISpecialization"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class SpecializationExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="specialization">
+        /// <param name="specializationSubject">
         /// The subject <see cref="ISpecialization"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IType ComputeOwningType(this ISpecialization specialization)
+        internal static IType ComputeOwningType(this ISpecialization specializationSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/StakeholderMembershipExtensions.cs
+++ b/SysML2.NET/Extend/StakeholderMembershipExtensions.cs
@@ -36,23 +36,19 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
     /// The <see cref="StakeholderMembershipExtensions"/> class provides extensions methods for
     /// the <see cref="IStakeholderMembership"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class StakeholderMembershipExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="stakeholderMembership">
+        /// <param name="stakeholderMembershipSubject">
         /// The subject <see cref="IStakeholderMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IPartUsage ComputeOwnedStakeholderParameter(this IStakeholderMembership stakeholderMembership)
+        internal static IPartUsage ComputeOwnedStakeholderParameter(this IStakeholderMembership stakeholderMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/StateDefinitionExtensions.cs
+++ b/SysML2.NET/Extend/StateDefinitionExtensions.cs
@@ -56,23 +56,19 @@ namespace SysML2.NET.Core.POCO.Systems.States
     /// The <see cref="StateDefinitionExtensions"/> class provides extensions methods for
     /// the <see cref="IStateDefinition"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class StateDefinitionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="stateDefinition">
+        /// <param name="stateDefinitionSubject">
         /// The subject <see cref="IStateDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IActionUsage ComputeDoAction(this IStateDefinition stateDefinition)
+        internal static IActionUsage ComputeDoAction(this IStateDefinition stateDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -80,14 +76,14 @@ namespace SysML2.NET.Core.POCO.Systems.States
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="stateDefinition">
+        /// <param name="stateDefinitionSubject">
         /// The subject <see cref="IStateDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IActionUsage ComputeEntryAction(this IStateDefinition stateDefinition)
+        internal static IActionUsage ComputeEntryAction(this IStateDefinition stateDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -95,14 +91,14 @@ namespace SysML2.NET.Core.POCO.Systems.States
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="stateDefinition">
+        /// <param name="stateDefinitionSubject">
         /// The subject <see cref="IStateDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IActionUsage ComputeExitAction(this IStateDefinition stateDefinition)
+        internal static IActionUsage ComputeExitAction(this IStateDefinition stateDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -110,14 +106,14 @@ namespace SysML2.NET.Core.POCO.Systems.States
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="stateDefinition">
+        /// <param name="stateDefinitionSubject">
         /// The subject <see cref="IStateDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IStateUsage> ComputeState(this IStateDefinition stateDefinition)
+        internal static List<IStateUsage> ComputeState(this IStateDefinition stateDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/StateSubactionMembershipExtensions.cs
+++ b/SysML2.NET/Extend/StateSubactionMembershipExtensions.cs
@@ -36,23 +36,19 @@ namespace SysML2.NET.Core.POCO.Systems.States
     /// The <see cref="StateSubactionMembershipExtensions"/> class provides extensions methods for
     /// the <see cref="IStateSubactionMembership"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class StateSubactionMembershipExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="stateSubactionMembership">
+        /// <param name="stateSubactionMembershipSubject">
         /// The subject <see cref="IStateSubactionMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IActionUsage ComputeAction(this IStateSubactionMembership stateSubactionMembership)
+        internal static IActionUsage ComputeAction(this IStateSubactionMembership stateSubactionMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/StateUsageExtensions.cs
+++ b/SysML2.NET/Extend/StateUsageExtensions.cs
@@ -59,23 +59,19 @@ namespace SysML2.NET.Core.POCO.Systems.States
     /// The <see cref="StateUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IStateUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class StateUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="stateUsage">
+        /// <param name="stateUsageSubject">
         /// The subject <see cref="IStateUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IActionUsage ComputeDoAction(this IStateUsage stateUsage)
+        internal static IActionUsage ComputeDoAction(this IStateUsage stateUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -83,14 +79,14 @@ namespace SysML2.NET.Core.POCO.Systems.States
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="stateUsage">
+        /// <param name="stateUsageSubject">
         /// The subject <see cref="IStateUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IActionUsage ComputeEntryAction(this IStateUsage stateUsage)
+        internal static IActionUsage ComputeEntryAction(this IStateUsage stateUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -98,14 +94,14 @@ namespace SysML2.NET.Core.POCO.Systems.States
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="stateUsage">
+        /// <param name="stateUsageSubject">
         /// The subject <see cref="IStateUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IActionUsage ComputeExitAction(this IStateUsage stateUsage)
+        internal static IActionUsage ComputeExitAction(this IStateUsage stateUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -113,17 +109,37 @@ namespace SysML2.NET.Core.POCO.Systems.States
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="stateUsage">
+        /// <param name="stateUsageSubject">
         /// The subject <see cref="IStateUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IBehavior> ComputeStateDefinition(this IStateUsage stateUsage)
+        internal static List<IBehavior> ComputeStateDefinition(this IStateUsage stateUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// Check if this StateUsage is composite and has an owningType that is a StateDefinition or StateUsage
+        /// with the given value of isParallel, but is not an entryAction, doAction, or exitAction. If so, then
+        /// it represents a StateAction that is a substate or exclusiveState (for isParallel = false) of another
+        /// StateAction.
+        /// </summary>
+        /// <param name="stateUsageSubject">
+        /// The subject <see cref="IStateUsage"/>
+        /// </param>
+        /// <param name="isParallel">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeIsSubstateUsageOperation(this IStateUsage stateUsageSubject, bool isParallel)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/StepExtensions.cs
+++ b/SysML2.NET/Extend/StepExtensions.cs
@@ -34,23 +34,19 @@ namespace SysML2.NET.Core.POCO.Kernel.Behaviors
     /// The <see cref="StepExtensions"/> class provides extensions methods for
     /// the <see cref="IStep"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class StepExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="step">
+        /// <param name="stepSubject">
         /// The subject <see cref="IStep"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IBehavior> ComputeBehavior(this IStep step)
+        internal static List<IBehavior> ComputeBehavior(this IStep stepSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -58,14 +54,14 @@ namespace SysML2.NET.Core.POCO.Kernel.Behaviors
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="step">
+        /// <param name="stepSubject">
         /// The subject <see cref="IStep"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeature> ComputeParameter(this IStep step)
+        internal static List<IFeature> ComputeParameter(this IStep stepSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/SubclassificationExtensions.cs
+++ b/SysML2.NET/Extend/SubclassificationExtensions.cs
@@ -32,23 +32,19 @@ namespace SysML2.NET.Core.POCO.Core.Classifiers
     /// The <see cref="SubclassificationExtensions"/> class provides extensions methods for
     /// the <see cref="ISubclassification"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class SubclassificationExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="subclassification">
+        /// <param name="subclassificationSubject">
         /// The subject <see cref="ISubclassification"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IClassifier ComputeOwningClassifier(this ISubclassification subclassification)
+        internal static IClassifier ComputeOwningClassifier(this ISubclassification subclassificationSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/SubjectMembershipExtensions.cs
+++ b/SysML2.NET/Extend/SubjectMembershipExtensions.cs
@@ -36,23 +36,19 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
     /// The <see cref="SubjectMembershipExtensions"/> class provides extensions methods for
     /// the <see cref="ISubjectMembership"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class SubjectMembershipExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="subjectMembership">
+        /// <param name="subjectMembershipSubject">
         /// The subject <see cref="ISubjectMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IUsage ComputeOwnedSubjectParameter(this ISubjectMembership subjectMembership)
+        internal static IUsage ComputeOwnedSubjectParameter(this ISubjectMembership subjectMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/SubsettingExtensions.cs
+++ b/SysML2.NET/Extend/SubsettingExtensions.cs
@@ -32,23 +32,19 @@ namespace SysML2.NET.Core.POCO.Core.Features
     /// The <see cref="SubsettingExtensions"/> class provides extensions methods for
     /// the <see cref="ISubsetting"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class SubsettingExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="subsetting">
+        /// <param name="subsettingSubject">
         /// The subject <see cref="ISubsetting"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeOwningFeature(this ISubsetting subsetting)
+        internal static IFeature ComputeOwningFeature(this ISubsetting subsettingSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/TerminateActionUsageExtensions.cs
+++ b/SysML2.NET/Extend/TerminateActionUsageExtensions.cs
@@ -60,23 +60,19 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
     /// The <see cref="TerminateActionUsageExtensions"/> class provides extensions methods for
     /// the <see cref="ITerminateActionUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class TerminateActionUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="terminateActionUsage">
+        /// <param name="terminateActionUsageSubject">
         /// The subject <see cref="ITerminateActionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IExpression ComputeTerminatedOccurrenceArgument(this ITerminateActionUsage terminateActionUsage)
+        internal static IExpression ComputeTerminatedOccurrenceArgument(this ITerminateActionUsage terminateActionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/TextualRepresentationExtensions.cs
+++ b/SysML2.NET/Extend/TextualRepresentationExtensions.cs
@@ -30,23 +30,19 @@ namespace SysML2.NET.Core.POCO.Root.Annotations
     /// The <see cref="TextualRepresentationExtensions"/> class provides extensions methods for
     /// the <see cref="ITextualRepresentation"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class TextualRepresentationExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="textualRepresentation">
+        /// <param name="textualRepresentationSubject">
         /// The subject <see cref="ITextualRepresentation"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IElement ComputeRepresentedElement(this ITextualRepresentation textualRepresentation)
+        internal static IElement ComputeRepresentedElement(this ITextualRepresentation textualRepresentationSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/TransitionFeatureMembershipExtensions.cs
+++ b/SysML2.NET/Extend/TransitionFeatureMembershipExtensions.cs
@@ -36,23 +36,19 @@ namespace SysML2.NET.Core.POCO.Systems.States
     /// The <see cref="TransitionFeatureMembershipExtensions"/> class provides extensions methods for
     /// the <see cref="ITransitionFeatureMembership"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class TransitionFeatureMembershipExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="transitionFeatureMembership">
+        /// <param name="transitionFeatureMembershipSubject">
         /// The subject <see cref="ITransitionFeatureMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IStep ComputeTransitionFeature(this ITransitionFeatureMembership transitionFeatureMembership)
+        internal static IStep ComputeTransitionFeature(this ITransitionFeatureMembership transitionFeatureMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/TransitionUsageExtensions.cs
+++ b/SysML2.NET/Extend/TransitionUsageExtensions.cs
@@ -61,23 +61,19 @@ namespace SysML2.NET.Core.POCO.Systems.States
     /// The <see cref="TransitionUsageExtensions"/> class provides extensions methods for
     /// the <see cref="ITransitionUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class TransitionUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="transitionUsage">
+        /// <param name="transitionUsageSubject">
         /// The subject <see cref="ITransitionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IActionUsage> ComputeEffectAction(this ITransitionUsage transitionUsage)
+        internal static List<IActionUsage> ComputeEffectAction(this ITransitionUsage transitionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -85,14 +81,14 @@ namespace SysML2.NET.Core.POCO.Systems.States
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="transitionUsage">
+        /// <param name="transitionUsageSubject">
         /// The subject <see cref="ITransitionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IExpression> ComputeGuardExpression(this ITransitionUsage transitionUsage)
+        internal static List<IExpression> ComputeGuardExpression(this ITransitionUsage transitionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -100,14 +96,14 @@ namespace SysML2.NET.Core.POCO.Systems.States
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="transitionUsage">
+        /// <param name="transitionUsageSubject">
         /// The subject <see cref="ITransitionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IActionUsage ComputeSource(this ITransitionUsage transitionUsage)
+        internal static IActionUsage ComputeSource(this ITransitionUsage transitionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -115,14 +111,14 @@ namespace SysML2.NET.Core.POCO.Systems.States
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="transitionUsage">
+        /// <param name="transitionUsageSubject">
         /// The subject <see cref="ITransitionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static ISuccession ComputeSuccession(this ITransitionUsage transitionUsage)
+        internal static ISuccession ComputeSuccession(this ITransitionUsage transitionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -130,14 +126,14 @@ namespace SysML2.NET.Core.POCO.Systems.States
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="transitionUsage">
+        /// <param name="transitionUsageSubject">
         /// The subject <see cref="ITransitionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IActionUsage ComputeTarget(this ITransitionUsage transitionUsage)
+        internal static IActionUsage ComputeTarget(this ITransitionUsage transitionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -145,17 +141,48 @@ namespace SysML2.NET.Core.POCO.Systems.States
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="transitionUsage">
+        /// <param name="transitionUsageSubject">
         /// The subject <see cref="ITransitionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IAcceptActionUsage> ComputeTriggerAction(this ITransitionUsage transitionUsage)
+        internal static List<IAcceptActionUsage> ComputeTriggerAction(this ITransitionUsage transitionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// Return the payloadParameter of the triggerAction of this TransitionUsage, if it has one.
+        /// </summary>
+        /// <param name="transitionUsageSubject">
+        /// The subject <see cref="ITransitionUsage"/>
+        /// </param>
+        /// <returns>
+        /// The expected IReferenceUsage
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IReferenceUsage ComputeTriggerPayloadParameterOperation(this ITransitionUsage transitionUsageSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return the Feature to be used as the source of the succession of this TransitionUsage, which is the
+        /// first member of the TransitionUsage that is a Feature, that is owned by the TransitionUsage via a
+        /// Membership that is not a FeatureMembership, and whose featureTarget is an ActionUsage.
+        /// </summary>
+        /// <param name="transitionUsageSubject">
+        /// The subject <see cref="ITransitionUsage"/>
+        /// </param>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IFeature ComputeSourceFeatureOperation(this ITransitionUsage transitionUsageSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/TriggerInvocationExpressionExtensions.cs
+++ b/SysML2.NET/Extend/TriggerInvocationExpressionExtensions.cs
@@ -38,11 +38,23 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
     /// The <see cref="TriggerInvocationExpressionExtensions"/> class provides extensions methods for
     /// the <see cref="ITriggerInvocationExpression"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class TriggerInvocationExpressionExtensions
     {
+        /// <summary>
+        /// Return one of the Functions TriggerWhen, TriggerAt or TriggerAfter, from the Kernel Semantic Library
+        /// Triggers package, depending on whether the kind of this TriggerInvocationExpression is when, at or
+        /// after, respectively.
+        /// </summary>
+        /// <param name="triggerInvocationExpressionSubject">
+        /// The subject <see cref="ITriggerInvocationExpression"/>
+        /// </param>
+        /// <returns>
+        /// The expected IType
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IType ComputeRedefinedInstantiatedTypeOperation(this ITriggerInvocationExpression triggerInvocationExpressionSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/TypeExtensions.cs
+++ b/SysML2.NET/Extend/TypeExtensions.cs
@@ -23,6 +23,7 @@ namespace SysML2.NET.Core.POCO.Core.Types
     using System;
     using System.Collections.Generic;
 
+    using SysML2.NET.Core.Core.Types;
     using SysML2.NET.Core.POCO.Core.Features;
     using SysML2.NET.Core.POCO.Root.Annotations;
     using SysML2.NET.Core.POCO.Root.Elements;
@@ -32,23 +33,19 @@ namespace SysML2.NET.Core.POCO.Core.Types
     /// The <see cref="TypeExtensions"/> class provides extensions methods for
     /// the <see cref="IType"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class TypeExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="type">
+        /// <param name="typeSubject">
         /// The subject <see cref="IType"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IType> ComputeDifferencingType(this IType type)
+        internal static List<IType> ComputeDifferencingType(this IType typeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -56,14 +53,14 @@ namespace SysML2.NET.Core.POCO.Core.Types
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="type">
+        /// <param name="typeSubject">
         /// The subject <see cref="IType"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeature> ComputeDirectedFeature(this IType type)
+        internal static List<IFeature> ComputeDirectedFeature(this IType typeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -71,14 +68,14 @@ namespace SysML2.NET.Core.POCO.Core.Types
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="type">
+        /// <param name="typeSubject">
         /// The subject <see cref="IType"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeature> ComputeEndFeature(this IType type)
+        internal static List<IFeature> ComputeEndFeature(this IType typeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -86,14 +83,14 @@ namespace SysML2.NET.Core.POCO.Core.Types
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="type">
+        /// <param name="typeSubject">
         /// The subject <see cref="IType"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeature> ComputeFeature(this IType type)
+        internal static List<IFeature> ComputeFeature(this IType typeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -101,14 +98,14 @@ namespace SysML2.NET.Core.POCO.Core.Types
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="type">
+        /// <param name="typeSubject">
         /// The subject <see cref="IType"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeatureMembership> ComputeFeatureMembership(this IType type)
+        internal static List<IFeatureMembership> ComputeFeatureMembership(this IType typeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -116,14 +113,14 @@ namespace SysML2.NET.Core.POCO.Core.Types
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="type">
+        /// <param name="typeSubject">
         /// The subject <see cref="IType"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeature> ComputeInheritedFeature(this IType type)
+        internal static List<IFeature> ComputeInheritedFeature(this IType typeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -131,14 +128,14 @@ namespace SysML2.NET.Core.POCO.Core.Types
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="type">
+        /// <param name="typeSubject">
         /// The subject <see cref="IType"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IMembership> ComputeInheritedMembership(this IType type)
+        internal static List<IMembership> ComputeInheritedMembership(this IType typeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -146,14 +143,14 @@ namespace SysML2.NET.Core.POCO.Core.Types
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="type">
+        /// <param name="typeSubject">
         /// The subject <see cref="IType"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeature> ComputeInput(this IType type)
+        internal static List<IFeature> ComputeInput(this IType typeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -161,14 +158,14 @@ namespace SysML2.NET.Core.POCO.Core.Types
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="type">
+        /// <param name="typeSubject">
         /// The subject <see cref="IType"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IType> ComputeIntersectingType(this IType type)
+        internal static List<IType> ComputeIntersectingType(this IType typeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -176,14 +173,14 @@ namespace SysML2.NET.Core.POCO.Core.Types
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="type">
+        /// <param name="typeSubject">
         /// The subject <see cref="IType"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static bool ComputeIsConjugated(this IType type)
+        internal static bool ComputeIsConjugated(this IType typeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -191,14 +188,14 @@ namespace SysML2.NET.Core.POCO.Core.Types
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="type">
+        /// <param name="typeSubject">
         /// The subject <see cref="IType"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IMultiplicity ComputeMultiplicity(this IType type)
+        internal static IMultiplicity ComputeMultiplicity(this IType typeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -206,14 +203,14 @@ namespace SysML2.NET.Core.POCO.Core.Types
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="type">
+        /// <param name="typeSubject">
         /// The subject <see cref="IType"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeature> ComputeOutput(this IType type)
+        internal static List<IFeature> ComputeOutput(this IType typeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -221,14 +218,14 @@ namespace SysML2.NET.Core.POCO.Core.Types
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="type">
+        /// <param name="typeSubject">
         /// The subject <see cref="IType"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IConjugation ComputeOwnedConjugator(this IType type)
+        internal static IConjugation ComputeOwnedConjugator(this IType typeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -236,14 +233,14 @@ namespace SysML2.NET.Core.POCO.Core.Types
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="type">
+        /// <param name="typeSubject">
         /// The subject <see cref="IType"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IDifferencing> ComputeOwnedDifferencing(this IType type)
+        internal static List<IDifferencing> ComputeOwnedDifferencing(this IType typeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -251,14 +248,14 @@ namespace SysML2.NET.Core.POCO.Core.Types
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="type">
+        /// <param name="typeSubject">
         /// The subject <see cref="IType"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IDisjoining> ComputeOwnedDisjoining(this IType type)
+        internal static List<IDisjoining> ComputeOwnedDisjoining(this IType typeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -266,14 +263,14 @@ namespace SysML2.NET.Core.POCO.Core.Types
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="type">
+        /// <param name="typeSubject">
         /// The subject <see cref="IType"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeature> ComputeOwnedEndFeature(this IType type)
+        internal static List<IFeature> ComputeOwnedEndFeature(this IType typeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -281,14 +278,14 @@ namespace SysML2.NET.Core.POCO.Core.Types
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="type">
+        /// <param name="typeSubject">
         /// The subject <see cref="IType"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeature> ComputeOwnedFeature(this IType type)
+        internal static List<IFeature> ComputeOwnedFeature(this IType typeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -296,14 +293,14 @@ namespace SysML2.NET.Core.POCO.Core.Types
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="type">
+        /// <param name="typeSubject">
         /// The subject <see cref="IType"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFeatureMembership> ComputeOwnedFeatureMembership(this IType type)
+        internal static List<IFeatureMembership> ComputeOwnedFeatureMembership(this IType typeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -311,14 +308,14 @@ namespace SysML2.NET.Core.POCO.Core.Types
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="type">
+        /// <param name="typeSubject">
         /// The subject <see cref="IType"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IIntersecting> ComputeOwnedIntersecting(this IType type)
+        internal static List<IIntersecting> ComputeOwnedIntersecting(this IType typeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -326,14 +323,14 @@ namespace SysML2.NET.Core.POCO.Core.Types
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="type">
+        /// <param name="typeSubject">
         /// The subject <see cref="IType"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<ISpecialization> ComputeOwnedSpecialization(this IType type)
+        internal static List<ISpecialization> ComputeOwnedSpecialization(this IType typeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -341,14 +338,14 @@ namespace SysML2.NET.Core.POCO.Core.Types
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="type">
+        /// <param name="typeSubject">
         /// The subject <see cref="IType"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IUnioning> ComputeOwnedUnioning(this IType type)
+        internal static List<IUnioning> ComputeOwnedUnioning(this IType typeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -356,17 +353,312 @@ namespace SysML2.NET.Core.POCO.Core.Types
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="type">
+        /// <param name="typeSubject">
         /// The subject <see cref="IType"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IType> ComputeUnioningType(this IType type)
+        internal static List<IType> ComputeUnioningType(this IType typeSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// The visible Memberships of a Type include inheritedMemberships.
+        /// </summary>
+        /// <param name="typeSubject">
+        /// The subject <see cref="IType"/>
+        /// </param>
+        /// <param name="excluded">
+        /// No documentation provided
+        /// </param>
+        /// <param name="isRecursive">
+        /// No documentation provided
+        /// </param>
+        /// <param name="includeAll">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IMembership ComputeRedefinedVisibleMembershipsOperation(this IType typeSubject, INamespace excluded, bool isRecursive, bool includeAll)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return the Memberships inheritable from supertypes of this Type with redefined Features removed.
+        /// When computing inheritable Memberships, exclude Imports of excludedNamespaces, Specializations of
+        /// excludedTypes, and, if excludeImplied = true, all implied Specializations.
+        /// </summary>
+        /// <param name="typeSubject">
+        /// The subject <see cref="IType"/>
+        /// </param>
+        /// <param name="excludedNamespaces">
+        /// No documentation provided
+        /// </param>
+        /// <param name="excludedTypes">
+        /// No documentation provided
+        /// </param>
+        /// <param name="excludeImplied">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IMembership ComputeInheritedMembershipsOperation(this IType typeSubject, INamespace excludedNamespaces, IType excludedTypes, bool excludeImplied)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return all the non-private Memberships of all the supertypes of this Type, excluding any supertypes
+        /// that are this Type or are in the given set of excludedTypes. If excludeImplied = true, then also
+        /// transitively exclude any supertypes from implied Specializations.
+        /// </summary>
+        /// <param name="typeSubject">
+        /// The subject <see cref="IType"/>
+        /// </param>
+        /// <param name="excludedNamespaces">
+        /// No documentation provided
+        /// </param>
+        /// <param name="excludedTypes">
+        /// No documentation provided
+        /// </param>
+        /// <param name="excludeImplied">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IMembership ComputeInheritableMembershipsOperation(this IType typeSubject, INamespace excludedNamespaces, IType excludedTypes, bool excludeImplied)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return the public, protected and inherited Memberships of this Type. When computing imported
+        /// Memberships, exclude the given set of excludedNamespaces. When computing inherited Memberships,
+        /// exclude Types in the given set of excludedTypes. If excludeImplied = true, then also exclude any
+        /// supertypes from implied Specializations.
+        /// </summary>
+        /// <param name="typeSubject">
+        /// The subject <see cref="IType"/>
+        /// </param>
+        /// <param name="excludedNamespaces">
+        /// No documentation provided
+        /// </param>
+        /// <param name="excludedTypes">
+        /// No documentation provided
+        /// </param>
+        /// <param name="excludeImplied">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IMembership ComputeNonPrivateMembershipsOperation(this IType typeSubject, INamespace excludedNamespaces, IType excludedTypes, bool excludeImplied)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return a subset of memberships, removing those Memberships whose memberElements are Features and for
+        /// which either of the following two conditions holds:                            <ol>                 
+        ///           <li>The memberElement of the Membership is included in redefined Features of another
+        /// Membership in memberships.</li>                            <li>One of the redefined Features of the
+        /// Membership is a directly redefinedFeature of an ownedFeature of this Type.</li>                     
+        ///       </ol>                            For this purpose, the redefined Features of a Membership
+        /// whose memberElement is a Feature includes the memberElement and all Features directly or indirectly
+        /// redefined by the memberElement.
+        /// </summary>
+        /// <param name="typeSubject">
+        /// The subject <see cref="IType"/>
+        /// </param>
+        /// <param name="memberships">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IMembership
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IMembership ComputeRemoveRedefinedFeaturesOperation(this IType typeSubject, IMembership memberships)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// If the memberElement of the given membership is a Feature, then return all Features directly or
+        /// indirectly redefined by the memberElement.
+        /// </summary>
+        /// <param name="typeSubject">
+        /// The subject <see cref="IType"/>
+        /// </param>
+        /// <param name="membership">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IFeature ComputeAllRedefinedFeaturesOfOperation(this IType typeSubject, IMembership membership)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// If the given feature is a feature of this Type, then return its direction relative to this Type,
+        /// taking conjugation into account.
+        /// </summary>
+        /// <param name="typeSubject">
+        /// The subject <see cref="IType"/>
+        /// </param>
+        /// <param name="feature">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected FeatureDirectionKind
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static FeatureDirectionKind ComputeDirectionOfOperation(this IType typeSubject, IFeature feature)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return the direction of the given feature relative to this Type, excluding a given set of Types from
+        /// the search of supertypes of this Type.
+        /// </summary>
+        /// <param name="typeSubject">
+        /// The subject <see cref="IType"/>
+        /// </param>
+        /// <param name="feature">
+        /// No documentation provided
+        /// </param>
+        /// <param name="excluded">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected FeatureDirectionKind
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static FeatureDirectionKind ComputeDirectionOfExcludingOperation(this IType typeSubject, IFeature feature, IType excluded)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// If this Type is conjugated, then return just the originalType of the Conjugation. Otherwise, return
+        /// the general Types from all ownedSpecializations of this type, if excludeImplied = false, or all
+        /// non-implied ownedSpecializations, if excludeImplied = true.
+        /// </summary>
+        /// <param name="typeSubject">
+        /// The subject <see cref="IType"/>
+        /// </param>
+        /// <param name="excludeImplied">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected IType
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IType ComputeSupertypesOperation(this IType typeSubject, bool excludeImplied)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return this Type and all Types that are directly or transitively supertypes of this Type (as
+        /// determined by the supertypes operation with excludeImplied = false).
+        /// </summary>
+        /// <param name="typeSubject">
+        /// The subject <see cref="IType"/>
+        /// </param>
+        /// <returns>
+        /// The expected IType
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IType ComputeAllSupertypesOperation(this IType typeSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Check whether this Type is a direct or indirect specialization of the given supertype.
+        /// </summary>
+        /// <param name="typeSubject">
+        /// The subject <see cref="IType"/>
+        /// </param>
+        /// <param name="supertype">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeSpecializesOperation(this IType typeSubject, IType supertype)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Check whether this Type is a direct or indirect specialization of the named library Type.
+        /// libraryTypeName must conform to the syntax of a KerML qualified name and must resolve to a Type in
+        /// global scope.
+        /// </summary>
+        /// <param name="typeSubject">
+        /// The subject <see cref="IType"/>
+        /// </param>
+        /// <param name="libraryTypeName">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeSpecializesFromLibraryOperation(this IType typeSubject, string libraryTypeName)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// By default, this Type is compatible with an otherType if it directly or indirectly specializes the
+        /// otherType.
+        /// </summary>
+        /// <param name="typeSubject">
+        /// The subject <see cref="IType"/>
+        /// </param>
+        /// <param name="otherType">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeIsCompatibleWithOperation(this IType typeSubject, IType otherType)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// Return the owned or inherited Multiplicities for this Type<./code>.
+        /// </summary>
+        /// <param name="typeSubject">
+        /// The subject <see cref="IType"/>
+        /// </param>
+        /// <returns>
+        /// The expected IMultiplicity
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IMultiplicity ComputeMultiplicitiesOperation(this IType typeSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/TypeFeaturingExtensions.cs
+++ b/SysML2.NET/Extend/TypeFeaturingExtensions.cs
@@ -32,23 +32,19 @@ namespace SysML2.NET.Core.POCO.Core.Features
     /// The <see cref="TypeFeaturingExtensions"/> class provides extensions methods for
     /// the <see cref="ITypeFeaturing"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class TypeFeaturingExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="typeFeaturing">
+        /// <param name="typeFeaturingSubject">
         /// The subject <see cref="ITypeFeaturing"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IFeature ComputeOwningFeatureOfType(this ITypeFeaturing typeFeaturing)
+        internal static IFeature ComputeOwningFeatureOfType(this ITypeFeaturing typeFeaturingSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/UnioningExtensions.cs
+++ b/SysML2.NET/Extend/UnioningExtensions.cs
@@ -31,23 +31,19 @@ namespace SysML2.NET.Core.POCO.Core.Types
     /// The <see cref="UnioningExtensions"/> class provides extensions methods for
     /// the <see cref="IUnioning"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class UnioningExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="unioning">
+        /// <param name="unioningSubject">
         /// The subject <see cref="IUnioning"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IType ComputeTypeUnioned(this IUnioning unioning)
+        internal static IType ComputeTypeUnioned(this IUnioning unioningSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/UsageExtensions.cs
+++ b/SysML2.NET/Extend/UsageExtensions.cs
@@ -56,23 +56,19 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
     /// The <see cref="UsageExtensions"/> class provides extensions methods for
     /// the <see cref="IUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class UsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IClassifier> ComputeDefinition(this IUsage usage)
+        internal static List<IClassifier> ComputeDefinition(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -80,14 +76,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IUsage> ComputeDirectedUsage(this IUsage usage)
+        internal static List<IUsage> ComputeDirectedUsage(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -95,14 +91,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static bool ComputeIsReference(this IUsage usage)
+        internal static bool ComputeIsReference(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -110,14 +106,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static bool ComputeMayTimeVary(this IUsage usage)
+        internal static bool ComputeMayTimeVary(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -125,14 +121,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IActionUsage> ComputeNestedAction(this IUsage usage)
+        internal static List<IActionUsage> ComputeNestedAction(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -140,14 +136,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IAllocationUsage> ComputeNestedAllocation(this IUsage usage)
+        internal static List<IAllocationUsage> ComputeNestedAllocation(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -155,14 +151,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IAnalysisCaseUsage> ComputeNestedAnalysisCase(this IUsage usage)
+        internal static List<IAnalysisCaseUsage> ComputeNestedAnalysisCase(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -170,14 +166,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IAttributeUsage> ComputeNestedAttribute(this IUsage usage)
+        internal static List<IAttributeUsage> ComputeNestedAttribute(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -185,14 +181,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<ICalculationUsage> ComputeNestedCalculation(this IUsage usage)
+        internal static List<ICalculationUsage> ComputeNestedCalculation(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -200,14 +196,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<ICaseUsage> ComputeNestedCase(this IUsage usage)
+        internal static List<ICaseUsage> ComputeNestedCase(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -215,14 +211,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IConcernUsage> ComputeNestedConcern(this IUsage usage)
+        internal static List<IConcernUsage> ComputeNestedConcern(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -230,14 +226,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IConnectorAsUsage> ComputeNestedConnection(this IUsage usage)
+        internal static List<IConnectorAsUsage> ComputeNestedConnection(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -245,14 +241,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IConstraintUsage> ComputeNestedConstraint(this IUsage usage)
+        internal static List<IConstraintUsage> ComputeNestedConstraint(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -260,14 +256,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IEnumerationUsage> ComputeNestedEnumeration(this IUsage usage)
+        internal static List<IEnumerationUsage> ComputeNestedEnumeration(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -275,14 +271,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IFlowUsage> ComputeNestedFlow(this IUsage usage)
+        internal static List<IFlowUsage> ComputeNestedFlow(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -290,14 +286,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IInterfaceUsage> ComputeNestedInterface(this IUsage usage)
+        internal static List<IInterfaceUsage> ComputeNestedInterface(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -305,14 +301,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IItemUsage> ComputeNestedItem(this IUsage usage)
+        internal static List<IItemUsage> ComputeNestedItem(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -320,14 +316,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IMetadataUsage> ComputeNestedMetadata(this IUsage usage)
+        internal static List<IMetadataUsage> ComputeNestedMetadata(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -335,14 +331,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IOccurrenceUsage> ComputeNestedOccurrence(this IUsage usage)
+        internal static List<IOccurrenceUsage> ComputeNestedOccurrence(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -350,14 +346,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IPartUsage> ComputeNestedPart(this IUsage usage)
+        internal static List<IPartUsage> ComputeNestedPart(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -365,14 +361,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IPortUsage> ComputeNestedPort(this IUsage usage)
+        internal static List<IPortUsage> ComputeNestedPort(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -380,14 +376,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IReferenceUsage> ComputeNestedReference(this IUsage usage)
+        internal static List<IReferenceUsage> ComputeNestedReference(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -395,14 +391,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IRenderingUsage> ComputeNestedRendering(this IUsage usage)
+        internal static List<IRenderingUsage> ComputeNestedRendering(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -410,14 +406,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IRequirementUsage> ComputeNestedRequirement(this IUsage usage)
+        internal static List<IRequirementUsage> ComputeNestedRequirement(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -425,14 +421,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IStateUsage> ComputeNestedState(this IUsage usage)
+        internal static List<IStateUsage> ComputeNestedState(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -440,14 +436,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<ITransitionUsage> ComputeNestedTransition(this IUsage usage)
+        internal static List<ITransitionUsage> ComputeNestedTransition(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -455,14 +451,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IUsage> ComputeNestedUsage(this IUsage usage)
+        internal static List<IUsage> ComputeNestedUsage(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -470,14 +466,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IUseCaseUsage> ComputeNestedUseCase(this IUsage usage)
+        internal static List<IUseCaseUsage> ComputeNestedUseCase(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -485,14 +481,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IVerificationCaseUsage> ComputeNestedVerificationCase(this IUsage usage)
+        internal static List<IVerificationCaseUsage> ComputeNestedVerificationCase(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -500,14 +496,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IViewUsage> ComputeNestedView(this IUsage usage)
+        internal static List<IViewUsage> ComputeNestedView(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -515,14 +511,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IViewpointUsage> ComputeNestedViewpoint(this IUsage usage)
+        internal static List<IViewpointUsage> ComputeNestedViewpoint(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -530,14 +526,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IDefinition ComputeOwningDefinition(this IUsage usage)
+        internal static IDefinition ComputeOwningDefinition(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -545,14 +541,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IUsage ComputeOwningUsage(this IUsage usage)
+        internal static IUsage ComputeOwningUsage(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -560,14 +556,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IUsage> ComputeUsage(this IUsage usage)
+        internal static List<IUsage> ComputeUsage(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -575,14 +571,14 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IUsage> ComputeVariant(this IUsage usage)
+        internal static List<IUsage> ComputeVariant(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -590,17 +586,48 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="usage">
+        /// <param name="usageSubject">
         /// The subject <see cref="IUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IVariantMembership> ComputeVariantMembership(this IUsage usage)
+        internal static List<IVariantMembership> ComputeVariantMembership(this IUsage usageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// If this Usage is a variant, then its naming Feature is the referencedFeature of its
+        /// ownedReferenceSubsetting.
+        /// </summary>
+        /// <param name="usageSubject">
+        /// The subject <see cref="IUsage"/>
+        /// </param>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IFeature ComputeRedefinedNamingFeatureOperation(this IUsage usageSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
+
+        /// <summary>
+        /// If ownedReferenceSubsetting is not null, return the featureTarget of the referencedFeature of the
+        /// ownedReferenceSubsetting.
+        /// </summary>
+        /// <param name="usageSubject">
+        /// The subject <see cref="IUsage"/>
+        /// </param>
+        /// <returns>
+        /// The expected IFeature
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static IFeature ComputeReferencedFeatureTargetOperation(this IUsage usageSubject)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/UseCaseDefinitionExtensions.cs
+++ b/SysML2.NET/Extend/UseCaseDefinitionExtensions.cs
@@ -57,23 +57,19 @@ namespace SysML2.NET.Core.POCO.Systems.UseCases
     /// The <see cref="UseCaseDefinitionExtensions"/> class provides extensions methods for
     /// the <see cref="IUseCaseDefinition"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class UseCaseDefinitionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="useCaseDefinition">
+        /// <param name="useCaseDefinitionSubject">
         /// The subject <see cref="IUseCaseDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IUseCaseUsage> ComputeIncludedUseCase(this IUseCaseDefinition useCaseDefinition)
+        internal static List<IUseCaseUsage> ComputeIncludedUseCase(this IUseCaseDefinition useCaseDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/UseCaseUsageExtensions.cs
+++ b/SysML2.NET/Extend/UseCaseUsageExtensions.cs
@@ -60,23 +60,19 @@ namespace SysML2.NET.Core.POCO.Systems.UseCases
     /// The <see cref="UseCaseUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IUseCaseUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class UseCaseUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="useCaseUsage">
+        /// <param name="useCaseUsageSubject">
         /// The subject <see cref="IUseCaseUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IUseCaseUsage> ComputeIncludedUseCase(this IUseCaseUsage useCaseUsage)
+        internal static List<IUseCaseUsage> ComputeIncludedUseCase(this IUseCaseUsage useCaseUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -84,14 +80,14 @@ namespace SysML2.NET.Core.POCO.Systems.UseCases
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="useCaseUsage">
+        /// <param name="useCaseUsageSubject">
         /// The subject <see cref="IUseCaseUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IUseCaseDefinition ComputeUseCaseDefinition(this IUseCaseUsage useCaseUsage)
+        internal static IUseCaseDefinition ComputeUseCaseDefinition(this IUseCaseUsage useCaseUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/VariantMembershipExtensions.cs
+++ b/SysML2.NET/Extend/VariantMembershipExtensions.cs
@@ -32,23 +32,19 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
     /// The <see cref="VariantMembershipExtensions"/> class provides extensions methods for
     /// the <see cref="IVariantMembership"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class VariantMembershipExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="variantMembership">
+        /// <param name="variantMembershipSubject">
         /// The subject <see cref="IVariantMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IUsage ComputeOwnedVariantUsage(this IVariantMembership variantMembership)
+        internal static IUsage ComputeOwnedVariantUsage(this IVariantMembership variantMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/VerificationCaseDefinitionExtensions.cs
+++ b/SysML2.NET/Extend/VerificationCaseDefinitionExtensions.cs
@@ -57,23 +57,19 @@ namespace SysML2.NET.Core.POCO.Systems.VerificationCases
     /// The <see cref="VerificationCaseDefinitionExtensions"/> class provides extensions methods for
     /// the <see cref="IVerificationCaseDefinition"/> interface
     /// </summary>
-   
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]internal static class VerificationCaseDefinitionExtensions
+    internal static class VerificationCaseDefinitionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="verificationCaseDefinition">
+        /// <param name="verificationCaseDefinitionSubject">
         /// The subject <see cref="IVerificationCaseDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IRequirementUsage> ComputeVerifiedRequirement(this IVerificationCaseDefinition verificationCaseDefinition)
+        internal static List<IRequirementUsage> ComputeVerifiedRequirement(this IVerificationCaseDefinition verificationCaseDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/VerificationCaseUsageExtensions.cs
+++ b/SysML2.NET/Extend/VerificationCaseUsageExtensions.cs
@@ -60,23 +60,19 @@ namespace SysML2.NET.Core.POCO.Systems.VerificationCases
     /// The <see cref="VerificationCaseUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IVerificationCaseUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class VerificationCaseUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="verificationCaseUsage">
+        /// <param name="verificationCaseUsageSubject">
         /// The subject <see cref="IVerificationCaseUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IVerificationCaseDefinition ComputeVerificationCaseDefinition(this IVerificationCaseUsage verificationCaseUsage)
+        internal static IVerificationCaseDefinition ComputeVerificationCaseDefinition(this IVerificationCaseUsage verificationCaseUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -84,14 +80,14 @@ namespace SysML2.NET.Core.POCO.Systems.VerificationCases
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="verificationCaseUsage">
+        /// <param name="verificationCaseUsageSubject">
         /// The subject <see cref="IVerificationCaseUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IRequirementUsage> ComputeVerifiedRequirement(this IVerificationCaseUsage verificationCaseUsage)
+        internal static List<IRequirementUsage> ComputeVerifiedRequirement(this IVerificationCaseUsage verificationCaseUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/ViewDefinitionExtensions.cs
+++ b/SysML2.NET/Extend/ViewDefinitionExtensions.cs
@@ -56,23 +56,19 @@ namespace SysML2.NET.Core.POCO.Systems.Views
     /// The <see cref="ViewDefinitionExtensions"/> class provides extensions methods for
     /// the <see cref="IViewDefinition"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ViewDefinitionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="viewDefinition">
+        /// <param name="viewDefinitionSubject">
         /// The subject <see cref="IViewDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IViewpointUsage> ComputeSatisfiedViewpoint(this IViewDefinition viewDefinition)
+        internal static List<IViewpointUsage> ComputeSatisfiedViewpoint(this IViewDefinition viewDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -80,14 +76,14 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="viewDefinition">
+        /// <param name="viewDefinitionSubject">
         /// The subject <see cref="IViewDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IViewUsage> ComputeView(this IViewDefinition viewDefinition)
+        internal static List<IViewUsage> ComputeView(this IViewDefinition viewDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -95,14 +91,14 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="viewDefinition">
+        /// <param name="viewDefinitionSubject">
         /// The subject <see cref="IViewDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IExpression> ComputeViewCondition(this IViewDefinition viewDefinition)
+        internal static List<IExpression> ComputeViewCondition(this IViewDefinition viewDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -110,14 +106,14 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="viewDefinition">
+        /// <param name="viewDefinitionSubject">
         /// The subject <see cref="IViewDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IRenderingUsage ComputeViewRendering(this IViewDefinition viewDefinition)
+        internal static IRenderingUsage ComputeViewRendering(this IViewDefinition viewDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/ViewRenderingMembershipExtensions.cs
+++ b/SysML2.NET/Extend/ViewRenderingMembershipExtensions.cs
@@ -34,23 +34,19 @@ namespace SysML2.NET.Core.POCO.Systems.Views
     /// The <see cref="ViewRenderingMembershipExtensions"/> class provides extensions methods for
     /// the <see cref="IViewRenderingMembership"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ViewRenderingMembershipExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="viewRenderingMembership">
+        /// <param name="viewRenderingMembershipSubject">
         /// The subject <see cref="IViewRenderingMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IRenderingUsage ComputeOwnedRendering(this IViewRenderingMembership viewRenderingMembership)
+        internal static IRenderingUsage ComputeOwnedRendering(this IViewRenderingMembership viewRenderingMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -58,14 +54,14 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="viewRenderingMembership">
+        /// <param name="viewRenderingMembershipSubject">
         /// The subject <see cref="IViewRenderingMembership"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IRenderingUsage ComputeReferencedRendering(this IViewRenderingMembership viewRenderingMembership)
+        internal static IRenderingUsage ComputeReferencedRendering(this IViewRenderingMembership viewRenderingMembershipSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/ViewUsageExtensions.cs
+++ b/SysML2.NET/Extend/ViewUsageExtensions.cs
@@ -60,23 +60,19 @@ namespace SysML2.NET.Core.POCO.Systems.Views
     /// The <see cref="ViewUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IViewUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ViewUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="viewUsage">
+        /// <param name="viewUsageSubject">
         /// The subject <see cref="IViewUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IElement> ComputeExposedElement(this IViewUsage viewUsage)
+        internal static List<IElement> ComputeExposedElement(this IViewUsage viewUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -84,14 +80,14 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="viewUsage">
+        /// <param name="viewUsageSubject">
         /// The subject <see cref="IViewUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IViewpointUsage> ComputeSatisfiedViewpoint(this IViewUsage viewUsage)
+        internal static List<IViewpointUsage> ComputeSatisfiedViewpoint(this IViewUsage viewUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -99,14 +95,14 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="viewUsage">
+        /// <param name="viewUsageSubject">
         /// The subject <see cref="IViewUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IExpression> ComputeViewCondition(this IViewUsage viewUsage)
+        internal static List<IExpression> ComputeViewCondition(this IViewUsage viewUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -114,14 +110,14 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="viewUsage">
+        /// <param name="viewUsageSubject">
         /// The subject <see cref="IViewUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IViewDefinition ComputeViewDefinition(this IViewUsage viewUsage)
+        internal static IViewDefinition ComputeViewDefinition(this IViewUsage viewUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -129,17 +125,34 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="viewUsage">
+        /// <param name="viewUsageSubject">
         /// The subject <see cref="IViewUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IRenderingUsage ComputeViewRendering(this IViewUsage viewUsage)
+        internal static IRenderingUsage ComputeViewRendering(this IViewUsage viewUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
 
+        /// <summary>
+        /// Determine whether the given element meets all the owned and inherited viewConditions.
+        /// </summary>
+        /// <param name="viewUsageSubject">
+        /// The subject <see cref="IViewUsage"/>
+        /// </param>
+        /// <param name="element">
+        /// No documentation provided
+        /// </param>
+        /// <returns>
+        /// The expected bool
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        internal static bool ComputeIncludeAsExposedOperation(this IViewUsage viewUsageSubject, IElement element)
+        {
+            throw new NotSupportedException("Create a GitHub issue when this method is required");
+        }
     }
 }

--- a/SysML2.NET/Extend/ViewpointDefinitionExtensions.cs
+++ b/SysML2.NET/Extend/ViewpointDefinitionExtensions.cs
@@ -57,23 +57,19 @@ namespace SysML2.NET.Core.POCO.Systems.Views
     /// The <see cref="ViewpointDefinitionExtensions"/> class provides extensions methods for
     /// the <see cref="IViewpointDefinition"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ViewpointDefinitionExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="viewpointDefinition">
+        /// <param name="viewpointDefinitionSubject">
         /// The subject <see cref="IViewpointDefinition"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IPartUsage> ComputeViewpointStakeholder(this IViewpointDefinition viewpointDefinition)
+        internal static List<IPartUsage> ComputeViewpointStakeholder(this IViewpointDefinition viewpointDefinitionSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/ViewpointUsageExtensions.cs
+++ b/SysML2.NET/Extend/ViewpointUsageExtensions.cs
@@ -60,23 +60,19 @@ namespace SysML2.NET.Core.POCO.Systems.Views
     /// The <see cref="ViewpointUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IViewpointUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class ViewpointUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="viewpointUsage">
+        /// <param name="viewpointUsageSubject">
         /// The subject <see cref="IViewpointUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IViewpointDefinition ComputeViewpointDefinition(this IViewpointUsage viewpointUsage)
+        internal static IViewpointDefinition ComputeViewpointDefinition(this IViewpointUsage viewpointUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -84,14 +80,14 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="viewpointUsage">
+        /// <param name="viewpointUsageSubject">
         /// The subject <see cref="IViewpointUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static List<IPartUsage> ComputeViewpointStakeholder(this IViewpointUsage viewpointUsage)
+        internal static List<IPartUsage> ComputeViewpointStakeholder(this IViewpointUsage viewpointUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/Extend/WhileLoopActionUsageExtensions.cs
+++ b/SysML2.NET/Extend/WhileLoopActionUsageExtensions.cs
@@ -60,23 +60,19 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
     /// The <see cref="WhileLoopActionUsageExtensions"/> class provides extensions methods for
     /// the <see cref="IWhileLoopActionUsage"/> interface
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Major Code Smell",
-        "S1192:Define a constant instead of using this literal",
-        Justification = "Placeholder message for unimplemented derived properties. Suppression to be removed after methods have been implemented")]
     internal static class WhileLoopActionUsageExtensions
     {
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="whileLoopActionUsage">
+        /// <param name="whileLoopActionUsageSubject">
         /// The subject <see cref="IWhileLoopActionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IExpression ComputeUntilArgument(this IWhileLoopActionUsage whileLoopActionUsage)
+        internal static IExpression ComputeUntilArgument(this IWhileLoopActionUsage whileLoopActionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }
@@ -84,14 +80,14 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         /// <summary>
         /// Computes the derived property.
         /// </summary>
-        /// <param name="whileLoopActionUsage">
+        /// <param name="whileLoopActionUsageSubject">
         /// The subject <see cref="IWhileLoopActionUsage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        internal static IExpression ComputeWhileArgument(this IWhileLoopActionUsage whileLoopActionUsage)
+        internal static IExpression ComputeWhileArgument(this IWhileLoopActionUsage whileLoopActionUsageSubject)
         {
             throw new NotSupportedException("Create a GitHub issue when this method is required");
         }

--- a/SysML2.NET/SysML2.NET.csproj
+++ b/SysML2.NET/SysML2.NET.csproj
@@ -35,10 +35,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Folder Include="Extend\" />
-    </ItemGroup>
-
-    <ItemGroup>
         <InternalsVisibleTo Include="SysML2.NET.Dal" />
         <InternalsVisibleTo Include="SysML2.NET.Dal.Tests" />
         <InternalsVisibleTo Include="SysML2.NET.Serializer.Json" />


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/SysML2.NET/pulls) open
- [x] I have verified that I am following the SysML2.NET [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/SysML2.NET/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #208 

POCO interfaces defines all specified operation.
POCO extend provide hand-coded placeholder for operation implementation.

Note: Moved from IReadOnlyCollection IReadOnlyList (for composite) to allow element access via index to improve performance
<!-- Thanks for contributing to SysML2.NET! -->