### PR TITLE
Fix #218: PackageExtension methods implemented

### DIFF
--- a/SysML2.NET.Tests/Extend/PackageExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/PackageExtensionsTestFixture.cs
@@ -23,16 +23,76 @@ namespace SysML2.NET.Tests.Extend
     using System;
     
     using NUnit.Framework;
-    
+
+    using SysML2.NET.Core.POCO.Kernel.Associations;
+    using SysML2.NET.Core.POCO.Kernel.Functions;
     using SysML2.NET.Core.POCO.Kernel.Packages;
+    using SysML2.NET.Core.POCO.Root.Annotations;
+    using SysML2.NET.Core.POCO.Root.Namespaces;
+    using SysML2.NET.Extensions;
+
+    using Type = SysML2.NET.Core.POCO.Core.Types.Type;
 
     [TestFixture]
     public class PackageExtensionsTestFixture
     {
         [Test]
-        public void ComputeFilterCondition_ThrowsNotSupportedException()
+        public void VerifyComputeFilterCondition()
         {
-            Assert.That(() => ((IPackage)null).ComputeFilterCondition(), Throws.TypeOf<NotSupportedException>());
+            Assert.That(() => ((IPackage)null).ComputeFilterCondition(), Throws.TypeOf<ArgumentNullException>());
+
+            var package = new Package();
+
+            Assert.That(package.ComputeFilterCondition(), Is.Empty);
+            var membership = new ElementFilterMembership();
+            var expression = new BooleanExpression();
+
+            var annotation = new Annotation();
+            var comment = new Comment();
+            
+            package.AssignOwnership(membership, expression);
+            package.AssignOwnership(annotation, comment);
+            
+            Assert.That(package.ComputeFilterCondition, Throws.InstanceOf<NotSupportedException>());
+        }
+
+        [Test]
+        public void VerifyComputeRedefinedImportedMembershipsOperation()
+        {
+            Assert.That(() => ((IPackage)null).ComputeRedefinedImportedMembershipsOperation([]), Throws.TypeOf<ArgumentNullException>());
+
+            var package = new Package();
+
+            Assert.That(package.ComputeRedefinedImportedMembershipsOperation([]), Is.Empty);
+
+            var importMember = new MembershipImport();
+            var type = new Type();
+            
+            package.AssignOwnership(importMember, type);
+            Assert.That(()=> package.ComputeRedefinedImportedMembershipsOperation([]), Throws.InstanceOf<NotSupportedException>());
+            
+            var membership = new ElementFilterMembership();
+            var expression = new BooleanExpression();
+            package.AssignOwnership(membership, expression);
+            Assert.That(()=> package.ComputeRedefinedImportedMembershipsOperation([]), Throws.InstanceOf<NotSupportedException>());
+        }
+
+        [Test]
+        public void VerifyComputeIncludeAsMemberOperation()
+        {
+            Assert.That(() => ((IPackage)null).ComputeIncludeAsMemberOperation(null), Throws.TypeOf<ArgumentNullException>());
+
+            var package = new Package();
+            Assert.That(package.ComputeIncludeAsMemberOperation(null), Is.False);
+
+            var element = new Type();
+            Assert.That(package.ComputeIncludeAsMemberOperation(element), Is.True);
+            var membership = new ElementFilterMembership();
+            var expression = new BooleanExpression();
+            
+            package.AssignOwnership(membership, expression);
+            
+            Assert.That(() => package.ComputeIncludeAsMemberOperation(element), Throws.TypeOf<NotSupportedException>());
         }
     }
 }

--- a/SysML2.NET/Extend/PackageExtensions.cs
+++ b/SysML2.NET/Extend/PackageExtensions.cs
@@ -22,6 +22,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Packages
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     using SysML2.NET.Core.POCO.Kernel.Functions;
     using SysML2.NET.Core.POCO.Root.Annotations;
@@ -37,16 +38,16 @@ namespace SysML2.NET.Core.POCO.Kernel.Packages
         /// <summary>
         /// Computes the derived property.
         /// </summary>
+        /// <remarks>OCL2: filterCondition = ownedMembership-> selectByKind(ElementFilterMembership).condition </remarks>
         /// <param name="packageSubject">
         /// The subject <see cref="IPackage"/>
         /// </param>
         /// <returns>
         /// the computed result
         /// </returns>
-        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         internal static List<IExpression> ComputeFilterCondition(this IPackage packageSubject)
         {
-            throw new NotSupportedException("Create a GitHub issue when this method is required");
+            return packageSubject == null ? throw new ArgumentNullException(nameof(packageSubject)) : [..packageSubject.ownedMembership.OfType<IElementFilterMembership>().Select(x => x.condition)];
         }
 
         /// <summary>
@@ -61,10 +62,23 @@ namespace SysML2.NET.Core.POCO.Kernel.Packages
         /// <returns>
         /// The expected collection of <see cref="IMembership" />
         /// </returns>
-        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         internal static List<IMembership> ComputeRedefinedImportedMembershipsOperation(this IPackage packageSubject, List<INamespace> excluded)
         {
-            throw new NotSupportedException("Create a GitHub issue when this method is required");
+            if (packageSubject == null)
+            {
+                throw new ArgumentNullException(nameof(packageSubject));
+            }
+
+            var importedMembership= packageSubject.ComputeImportedMembershipsOperation(excluded);
+            var filters = packageSubject.ComputeFilterCondition();
+
+            if (filters.Count == 0)
+            {
+                return importedMembership;
+            }
+
+            var validImportedMembership = importedMembership.Where(membership => filters.All(x => x.CheckCondition(membership))).ToList();
+            return validImportedMembership;
         }
 
         /// <summary>
@@ -79,10 +93,20 @@ namespace SysML2.NET.Core.POCO.Kernel.Packages
         /// <returns>
         /// The expected <see cref="bool" />
         /// </returns>
-        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         internal static bool ComputeIncludeAsMemberOperation(this IPackage packageSubject, IElement element)
         {
-            throw new NotSupportedException("Create a GitHub issue when this method is required");
+            if (packageSubject == null)
+            {
+                throw new ArgumentNullException(nameof(packageSubject));
+            }
+
+            if (element == null)
+            {
+                return false;
+            }
+
+            var filters = packageSubject.ComputeFilterCondition();
+            return filters.Count == 0 || filters.All(x => x.CheckCondition(element));
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/SysML2.NET/pulls) open
- [x] I have verified that I am following the SysML2.NET [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/SysML2.NET/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Provided implementation for extension methods for the IPackage interface
<!-- Thanks for contributing to SysML2.NET! -->