### PR TITLE
Fix membership qualifiedname output for textual notation

### DIFF
--- a/SysML2.NET.CodeGenerator/HandleBarHelpers/NoTargetRuleResolver.cs
+++ b/SysML2.NET.CodeGenerator/HandleBarHelpers/NoTargetRuleResolver.cs
@@ -1,20 +1,20 @@
 // -------------------------------------------------------------------------------------------------
 // <copyright file="NoTargetRuleResolver.cs" company="Starion Group S.A.">
-//
+// 
 //   Copyright 2022-2026 Starion Group S.A.
-//
+// 
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
-//
+// 
 //        http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 //    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-//
+// 
 // </copyright>
 // ------------------------------------------------------------------------------------------------
 

--- a/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleGenerationContext.cs
+++ b/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleGenerationContext.cs
@@ -98,6 +98,15 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
         public HashSet<string> EmittedHandCodedCalls { get; } = [];
 
         /// <summary>
+        /// Gets or sets a pending cursor move statement to be emitted inside the innermost
+        /// consumption block of <c>ProcessNonTerminalElement</c>. This is set by
+        /// <c>ProcessAssignmentElement</c> for <c>+=</c> assignments inside optional groups
+        /// (<c>?</c> quantifier), ensuring the cursor only advances when the element was
+        /// actually consumed by the builder call.
+        /// </summary>
+        public string PendingCursorMove { get; set; }
+
+        /// <summary>
         /// Determines whether the next sibling element is a terminal that uses <c>AppendLine</c>
         /// (e.g., <c>{</c>, <c>}</c>, <c>;</c>), in which case a trailing space would be unnecessary.
         /// </summary>

--- a/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.CollectionProcessing.cs
+++ b/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.CollectionProcessing.cs
@@ -1,20 +1,20 @@
 // -------------------------------------------------------------------------------------------------
 // <copyright file="RuleProcessor.CollectionProcessing.cs" company="Starion Group S.A.">
-//
+// 
 //   Copyright 2022-2026 Starion Group S.A.
-//
+// 
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
-//
+// 
 //        http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 //    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-//
+// 
 // </copyright>
 // ------------------------------------------------------------------------------------------------
 
@@ -71,9 +71,9 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                             cursorVariableName = cursorDefinition.CursorVariableName;
                         }
 
-                        var perItemCall = ResolveBuilderCall(umlClass, nonTerminalElement, typeTarget, ruleGenerationContext);
+                        var perItemCall = this.ResolveBuilderCall(umlClass, nonTerminalElement, typeTarget, ruleGenerationContext);
 
-                        var whileTypeExclusion = ResolveCollectionWhileTypeCondition(cursorVariableName, umlClass, referencedRule, ruleGenerationContext);
+                        var whileTypeExclusion = this.ResolveCollectionWhileTypeCondition(cursorVariableName, umlClass, referencedRule, ruleGenerationContext);
 
                         string whileCondition;
 
@@ -116,7 +116,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
                             if (assignmentTargetTypes?.Count == 1)
                             {
-                                var contentTypeGuard = ResolveContentTypeGuard(cursorVariableName, referencedRule, propertyName, umlClass, ruleGenerationContext);
+                                var contentTypeGuard = this.ResolveContentTypeGuard(cursorVariableName, referencedRule, propertyName, umlClass, ruleGenerationContext);
 
                                 if (!string.IsNullOrWhiteSpace(contentTypeGuard))
                                 {
@@ -149,7 +149,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                             var previousName = ruleGenerationContext.CurrentVariableName;
                             ruleGenerationContext.CallerRule = nonTerminalElement;
 
-                            ProcessAlternatives(writer, umlClass, referencedRule.Alternatives, ruleGenerationContext);
+                            this.ProcessAlternatives(writer, umlClass, referencedRule.Alternatives, ruleGenerationContext);
 
                             ruleGenerationContext.CallerRule = previousCaller;
                             ruleGenerationContext.CurrentVariableName = previousName;
@@ -164,7 +164,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
             var handCodedRuleName = nonTerminalElement.TextualNotationRule?.RuleName ?? nonTerminalElement.Name;
 
-            EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext, deduplicate: true);
+            this.EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext, true);
             writer.WriteSafeString(Environment.NewLine);
         }
 
@@ -302,7 +302,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
                     if (innerRule != null)
                     {
-                        return ResolveContentTypeGuard(cursorVariableName, innerRule, outerPropertyName, umlClass, ruleGenerationContext);
+                        return this.ResolveContentTypeGuard(cursorVariableName, innerRule, outerPropertyName, umlClass, ruleGenerationContext);
                     }
                 }
 
@@ -422,7 +422,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                 return false;
             }
 
-            var condition = GenerateInlineOptionalCondition(referencedRule, targetClass, ruleGenerationContext.AllRules, variableName);
+            var condition = this.GenerateInlineOptionalCondition(referencedRule, targetClass, ruleGenerationContext.AllRules, variableName);
 
             if (condition == null)
             {

--- a/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.CollectionProcessing.cs
+++ b/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.CollectionProcessing.cs
@@ -66,7 +66,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                         {
                             var cursorDefinition = new CursorDefinition { DefinedForProperty = targetProperty };
                             var propertyAccessName = targetProperty.QueryPropertyNameBasedOnUmlProperties();
-                            writer.WriteSafeString($"var {cursorDefinition.CursorVariableName} = cursorCache.GetOrCreateCursor({ruleGenerationContext.CurrentVariableName}.Id, \"{targetProperty.Name}\", {ruleGenerationContext.CurrentVariableName}.{propertyAccessName});{Environment.NewLine}");
+                            writer.WriteSafeString($"var {cursorDefinition.CursorVariableName} = writerContext.CursorCache.GetOrCreateCursor({ruleGenerationContext.CurrentVariableName}.Id, \"{targetProperty.Name}\", {ruleGenerationContext.CurrentVariableName}.{propertyAccessName});{Environment.NewLine}");
                             ruleGenerationContext.DefinedCursors.Add(cursorDefinition);
                             cursorVariableName = cursorDefinition.CursorVariableName;
                         }
@@ -350,7 +350,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
         {
             if (typeTarget == ruleGenerationContext.NamedElementToGenerate.Name)
             {
-                return $"Build{nonTerminalElement.Name}({ruleGenerationContext.CurrentVariableName}, cursorCache, stringBuilder);";
+                return $"Build{nonTerminalElement.Name}({ruleGenerationContext.CurrentVariableName}, writerContext, stringBuilder);";
             }
 
             var targetType = RuleQueryUtilities.FindNamedElement(umlClass.Cache, typeTarget);
@@ -359,13 +359,13 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
             {
                 if (umlClass.QueryAllGeneralClassifiers().Contains(targetClass))
                 {
-                    return $"{targetType.Name}TextualNotationBuilder.Build{nonTerminalElement.Name}({ruleGenerationContext.CurrentVariableName}, cursorCache, stringBuilder);";
+                    return $"{targetType.Name}TextualNotationBuilder.Build{nonTerminalElement.Name}({ruleGenerationContext.CurrentVariableName}, writerContext, stringBuilder);";
                 }
 
                 return null;
             }
 
-            return $"Build{nonTerminalElement.Name}({ruleGenerationContext.CurrentVariableName}, cursorCache, stringBuilder);";
+            return $"Build{nonTerminalElement.Name}({ruleGenerationContext.CurrentVariableName}, writerContext, stringBuilder);";
         }
 
         /// <summary>

--- a/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.ElementProcessing.cs
+++ b/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.ElementProcessing.cs
@@ -1,27 +1,26 @@
 // -------------------------------------------------------------------------------------------------
 // <copyright file="RuleProcessor.ElementProcessing.cs" company="Starion Group S.A.">
-//
+// 
 //   Copyright 2022-2026 Starion Group S.A.
-//
+// 
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
-//
+// 
 //        http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 //    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-//
+// 
 // </copyright>
 // ------------------------------------------------------------------------------------------------
 
 namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
 
     using HandlebarsDotNet;
@@ -29,7 +28,6 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
     using SysML2.NET.CodeGenerator.Extensions;
     using SysML2.NET.CodeGenerator.Grammar.Model;
 
-    using uml4net.CommonStructure;
     using uml4net.Extensions;
     using uml4net.StructuredClassifiers;
 
@@ -66,7 +64,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                         ruleGenerationContext.CurrentVariableName = "poco";
                     }
 
-                    ProcessNonTerminalElement(writer, umlClass, nonTerminalElement, ruleGenerationContext, isPartOfMultipleAlternative);
+                    this.ProcessNonTerminalElement(writer, umlClass, nonTerminalElement, ruleGenerationContext, isPartOfMultipleAlternative);
 
                     break;
                 case GroupElement groupElement:
@@ -93,7 +91,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
                                     if (targetClass != null)
                                     {
-                                        var contentGuard = ResolveContentTypeGuard(cursorToUse.CursorVariableName, referencedRule, assignmentElement.Property, umlClass, ruleGenerationContext);
+                                        var contentGuard = this.ResolveContentTypeGuard(cursorToUse.CursorVariableName, referencedRule, assignmentElement.Property, umlClass, ruleGenerationContext);
 
                                         if (!string.IsNullOrWhiteSpace(contentGuard))
                                         {
@@ -119,7 +117,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                         }
 
                         writer.WriteSafeString($"{{{Environment.NewLine}");
-                        ProcessAlternatives(writer, umlClass, groupElement.Alternatives, ruleGenerationContext);
+                        this.ProcessAlternatives(writer, umlClass, groupElement.Alternatives, ruleGenerationContext);
 
                         if (assignmentRule is AssignmentElement assignmentElementForMove)
                         {
@@ -186,7 +184,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                                     var previousCaller = ruleGenerationContext.CallerRule;
                                     ruleGenerationContext.CurrentVariableName = groupCaseVarName;
                                     ruleGenerationContext.CallerRule = groupOrderedElement.RuleElement;
-                                    ProcessNonTerminalElement(writer, groupOrderedElement.UmlClass, groupOrderedElement.RuleElement, ruleGenerationContext);
+                                    this.ProcessNonTerminalElement(writer, groupOrderedElement.UmlClass, groupOrderedElement.RuleElement, ruleGenerationContext);
                                     ruleGenerationContext.CurrentVariableName = previousVariableName;
                                     ruleGenerationContext.CallerRule = previousCaller;
 
@@ -200,18 +198,18 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                             else
                             {
                                 var handCodedRuleName = groupElement.TextualNotationRule?.RuleName ?? "Unknown";
-                                EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
+                                this.EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
                             }
                         }
                         else
                         {
                             var handCodedRuleName = groupElement.TextualNotationRule?.RuleName ?? "Unknown";
-                            EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
+                            this.EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
                         }
                     }
                     else
                     {
-                        ProcessAlternatives(writer, umlClass, groupElement.Alternatives, ruleGenerationContext);
+                        this.ProcessAlternatives(writer, umlClass, groupElement.Alternatives, ruleGenerationContext);
                     }
 
                     if (!groupElement.IsOptional && !ruleGenerationContext.IsNextElementNewLineTerminal() && !ruleGenerationContext.IsLastElement())
@@ -221,7 +219,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
                     break;
                 case AssignmentElement assignmentElement:
-                    ProcessAssignmentElement(writer, umlClass, ruleGenerationContext, assignmentElement, isPartOfMultipleAlternative);
+                    this.ProcessAssignmentElement(writer, umlClass, ruleGenerationContext, assignmentElement, isPartOfMultipleAlternative);
                     break;
                 case NonParsingAssignmentElement nonParsingAssignmentElement:
                     writer.WriteSafeString($"// NonParsing Assignment Element : {nonParsingAssignmentElement.PropertyName} {nonParsingAssignmentElement.Operator} {nonParsingAssignmentElement.Value} => Does not have to be process");
@@ -229,7 +227,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                 case ValueLiteralElement valueLiteralElement:
                     if (valueLiteralElement.QueryIsQualifiedName())
                     {
-                        writer.WriteSafeString($"stringBuilder.Append({ruleGenerationContext.CurrentVariableName}.qualifiedName);{Environment.NewLine}");
+                        writer.WriteSafeString($"SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder,{ruleGenerationContext.CurrentVariableName});{Environment.NewLine}");
 
                         if (!ruleGenerationContext.IsNextElementNewLineTerminal())
                         {
@@ -239,7 +237,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                     else
                     {
                         var handCodedRuleName = textualRuleElement.TextualNotationRule?.RuleName ?? "Unknown";
-                        EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
+                        this.EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
                     }
 
                     break;
@@ -276,7 +274,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                         ruleGenerationContext.CurrentVariableName = usedVariable;
                         var previousCaller = ruleGenerationContext.CallerRule;
                         ruleGenerationContext.CallerRule = assignmentElement;
-                        ProcessNonTerminalElement(writer, umlClass, nonTerminalElement, ruleGenerationContext);
+                        this.ProcessNonTerminalElement(writer, umlClass, nonTerminalElement, ruleGenerationContext);
                         ruleGenerationContext.CurrentVariableName = previousVariableName;
                         ruleGenerationContext.CallerRule = previousCaller;
 
@@ -289,7 +287,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                     {
                         var previousCaller = ruleGenerationContext.CallerRule;
                         ruleGenerationContext.CallerRule = assignmentElement;
-                        ProcessAlternatives(writer, umlClass, groupElement.Alternatives, ruleGenerationContext);
+                        this.ProcessAlternatives(writer, umlClass, groupElement.Alternatives, ruleGenerationContext);
                         ruleGenerationContext.CallerRule = previousCaller;
                     }
                     else if (assignmentElement.Value is ValueLiteralElement valueLiteralElement && valueLiteralElement.QueryIsQualifiedName())
@@ -298,14 +296,14 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
                         writer.WriteSafeString($"{Environment.NewLine}if({cursorToUse.CursorVariableName}.Current != null){Environment.NewLine}");
                         writer.WriteSafeString($"{{{Environment.NewLine}");
-                        writer.WriteSafeString($"stringBuilder.Append({cursorToUse.CursorVariableName}.Current.qualifiedName);{Environment.NewLine}");
+                        writer.WriteSafeString($"SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder,{cursorToUse.CursorVariableName}.Current);{Environment.NewLine}");
                         writer.WriteSafeString($"{cursorToUse.CursorVariableName}.Move();{Environment.NewLine}");
                         writer.WriteSafeString("}");
                     }
                     else
                     {
                         var handCodedRuleName = assignmentElement.TextualNotationRule?.RuleName ?? "Unknown";
-                        EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
+                        this.EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
                     }
                 }
                 else
@@ -367,7 +365,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                                     var previousCaller = ruleGenerationContext.CallerRule;
                                     ruleGenerationContext.CallerRule = nonTerminalElement;
                                     ruleGenerationContext.CurrentVariableName = $"poco.{targetPropertyName}";
-                                    ProcessNonTerminalElement(writer, targetProperty.Type as IClass, nonTerminalElement, ruleGenerationContext, isPartOfMultipleAlternative);
+                                    this.ProcessNonTerminalElement(writer, targetProperty.Type as IClass, nonTerminalElement, ruleGenerationContext, isPartOfMultipleAlternative);
                                     ruleGenerationContext.CurrentVariableName = "poco";
                                     ruleGenerationContext.CallerRule = previousCaller;
                                     break;
@@ -375,7 +373,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                                 case ValueLiteralElement valueLiteralElement when valueLiteralElement.QueryIsQualifiedName():
                                     if (isPartOfMultipleAlternative)
                                     {
-                                        writer.WriteSafeString($"stringBuilder.Append(poco.{targetPropertyName}.qualifiedName);{Environment.NewLine}");
+                                        writer.WriteSafeString($"SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder,poco.{targetPropertyName});{Environment.NewLine}");
 
                                         if (!ruleGenerationContext.IsNextElementNewLineTerminal())
                                         {
@@ -386,7 +384,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                                     {
                                         writer.WriteSafeString($"{Environment.NewLine}if (poco.{targetPropertyName} != null){Environment.NewLine}");
                                         writer.WriteSafeString($"{{{Environment.NewLine}");
-                                        writer.WriteSafeString($"stringBuilder.Append(poco.{targetPropertyName}.qualifiedName);{Environment.NewLine}");
+                                        writer.WriteSafeString($"SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder,poco.{targetPropertyName});{Environment.NewLine}");
 
                                         if (!ruleGenerationContext.IsNextElementNewLineTerminal())
                                         {
@@ -399,7 +397,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                                     break;
                                 default:
                                     var handCodedRuleName = assignmentElement.TextualNotationRule?.RuleName ?? "Unknown";
-                                    EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
+                                    this.EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
                                     break;
                             }
                         }
@@ -451,7 +449,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
             if (nonTerminalElement.IsCollection)
             {
-                EmitCollectionNonTerminalLoop(writer, umlClass, nonTerminalElement, referencedRule, typeTarget, ruleGenerationContext);
+                this.EmitCollectionNonTerminalLoop(writer, umlClass, nonTerminalElement, referencedRule, typeTarget, ruleGenerationContext);
 
                 if (emitPropertyNullGuard)
                 {
@@ -485,7 +483,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                             writer.WriteSafeString($"{{{Environment.NewLine}");
                         }
 
-                        var emittedCondition = TryEmitOptionalCondition(writer, nonTerminalElement, referencedRule, targetClass, ruleGenerationContext, ruleGenerationContext.CurrentVariableName);
+                        var emittedCondition = this.TryEmitOptionalCondition(writer, nonTerminalElement, referencedRule, targetClass, ruleGenerationContext, ruleGenerationContext.CurrentVariableName);
 
                         writer.WriteSafeString($"{targetType.Name}TextualNotationBuilder.Build{nonTerminalElement.Name}({ruleGenerationContext.CurrentVariableName}, cursorCache, stringBuilder);");
 
@@ -505,7 +503,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                         ruleGenerationContext.CallerRule = nonTerminalElement;
                         var previousName = ruleGenerationContext.CurrentVariableName;
 
-                        ProcessAlternatives(writer, umlClass, referencedRule?.Alternatives, ruleGenerationContext, isPartOfMultipleAlternative);
+                        this.ProcessAlternatives(writer, umlClass, referencedRule?.Alternatives, ruleGenerationContext, isPartOfMultipleAlternative);
                         ruleGenerationContext.CallerRule = previousCaller;
                         ruleGenerationContext.CurrentVariableName = previousName;
                     }
@@ -514,7 +512,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                 {
                     if (NoTargetRuleResolver.IsSharedRule(referencedRule, umlClass))
                     {
-                        EmitSharedNoTargetRuleCall(writer, umlClass, nonTerminalElement, referencedRule, ruleGenerationContext);
+                        this.EmitSharedNoTargetRuleCall(writer, umlClass, nonTerminalElement, referencedRule, ruleGenerationContext);
                     }
                     else
                     {
@@ -522,7 +520,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                         ruleGenerationContext.CallerRule = nonTerminalElement;
                         var previousName = ruleGenerationContext.CurrentVariableName;
 
-                        ProcessAlternatives(writer, umlClass, referencedRule?.Alternatives, ruleGenerationContext, isPartOfMultipleAlternative);
+                        this.ProcessAlternatives(writer, umlClass, referencedRule?.Alternatives, ruleGenerationContext, isPartOfMultipleAlternative);
                         ruleGenerationContext.CallerRule = previousCaller;
                         ruleGenerationContext.CurrentVariableName = previousName;
                     }
@@ -532,7 +530,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
             {
                 var variableToUse = referencedRule != null ? ruleGenerationContext.CurrentVariableName : "poco";
 
-                var emittedSameClassCondition = TryEmitOptionalCondition(writer, nonTerminalElement, referencedRule, umlClass, ruleGenerationContext, variableToUse);
+                var emittedSameClassCondition = this.TryEmitOptionalCondition(writer, nonTerminalElement, referencedRule, umlClass, ruleGenerationContext, variableToUse);
 
                 writer.WriteSafeString($"Build{nonTerminalElement.Name}({variableToUse}, cursorCache, stringBuilder);");
 
@@ -591,7 +589,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                     break;
                 }
                 case AssignmentElement containedAssignment:
-                    DeclareCursorIfRequired(writer, umlClass, containedAssignment, ruleGenerationContext);
+                    this.DeclareCursorIfRequired(writer, umlClass, containedAssignment, ruleGenerationContext);
                     break;
             }
         }
@@ -620,7 +618,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
             }
 
             var emittedCondition = effectiveTarget != null
-                                   && TryEmitOptionalCondition(writer, nonTerminalElement, referencedRule, effectiveTarget, ruleGenerationContext, ruleGenerationContext.CurrentVariableName);
+                                   && this.TryEmitOptionalCondition(writer, nonTerminalElement, referencedRule, effectiveTarget, ruleGenerationContext, ruleGenerationContext.CurrentVariableName);
 
             writer.WriteSafeString($"{RulesHelper.SharedBuilderClassName}.Build{nonTerminalElement.Name}({variableExpression}, cursorCache, stringBuilder);");
 

--- a/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.ElementProcessing.cs
+++ b/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.ElementProcessing.cs
@@ -153,7 +153,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                                 if (existingGroupCursor == null)
                                 {
                                     var groupPropertyAccessName = groupTargetProperty.QueryPropertyNameBasedOnUmlProperties();
-                                    writer.WriteSafeString($"var {groupCursorVarName} = cursorCache.GetOrCreateCursor(poco.Id, \"{groupTargetProperty.Name}\", poco.{groupPropertyAccessName});{Environment.NewLine}");
+                                    writer.WriteSafeString($"var {groupCursorVarName} = writerContext.CursorCache.GetOrCreateCursor(poco.Id, \"{groupTargetProperty.Name}\", poco.{groupPropertyAccessName});{Environment.NewLine}");
                                     var groupCursorDef = new CursorDefinition { DefinedForProperty = groupTargetProperty };
 
                                     foreach (var groupAssignment in groupAssignments)
@@ -227,7 +227,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                 case ValueLiteralElement valueLiteralElement:
                     if (valueLiteralElement.QueryIsQualifiedName())
                     {
-                        writer.WriteSafeString($"SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder,{ruleGenerationContext.CurrentVariableName});{Environment.NewLine}");
+                        writer.WriteSafeString($"SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder,{ruleGenerationContext.CurrentVariableName}, writerContext);{Environment.NewLine}");
 
                         if (!ruleGenerationContext.IsNextElementNewLineTerminal())
                         {
@@ -274,11 +274,21 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                         ruleGenerationContext.CurrentVariableName = usedVariable;
                         var previousCaller = ruleGenerationContext.CallerRule;
                         ruleGenerationContext.CallerRule = assignmentElement;
+
+                        var isInsideOptionalGroup = assignmentElement.Container is GroupElement { IsOptional: true, IsCollection: false };
+
+                        if (isInsideOptionalGroup)
+                        {
+                            ruleGenerationContext.PendingCursorMove = $"{Environment.NewLine}{cursorToUse.CursorVariableName}.Move();{Environment.NewLine}";
+                        }
+
                         this.ProcessNonTerminalElement(writer, umlClass, nonTerminalElement, ruleGenerationContext);
                         ruleGenerationContext.CurrentVariableName = previousVariableName;
                         ruleGenerationContext.CallerRule = previousCaller;
 
-                        if (!isPartOfMultipleAlternative && assignmentElement.Container is not GroupElement { IsCollection: true })
+                        if (!isPartOfMultipleAlternative
+                            && assignmentElement.Container is not GroupElement { IsCollection: true }
+                            && !isInsideOptionalGroup)
                         {
                             writer.WriteSafeString($"{cursorToUse.CursorVariableName}.Move();{Environment.NewLine}");
                         }
@@ -296,7 +306,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
                         writer.WriteSafeString($"{Environment.NewLine}if({cursorToUse.CursorVariableName}.Current != null){Environment.NewLine}");
                         writer.WriteSafeString($"{{{Environment.NewLine}");
-                        writer.WriteSafeString($"SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder,{cursorToUse.CursorVariableName}.Current);{Environment.NewLine}");
+                        writer.WriteSafeString($"SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder,{cursorToUse.CursorVariableName}.Current, writerContext);{Environment.NewLine}");
                         writer.WriteSafeString($"{cursorToUse.CursorVariableName}.Move();{Environment.NewLine}");
                         writer.WriteSafeString("}");
                     }
@@ -373,7 +383,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                                 case ValueLiteralElement valueLiteralElement when valueLiteralElement.QueryIsQualifiedName():
                                     if (isPartOfMultipleAlternative)
                                     {
-                                        writer.WriteSafeString($"SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder,poco.{targetPropertyName});{Environment.NewLine}");
+                                        writer.WriteSafeString($"SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder,poco.{targetPropertyName}, writerContext);{Environment.NewLine}");
 
                                         if (!ruleGenerationContext.IsNextElementNewLineTerminal())
                                         {
@@ -384,7 +394,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                                     {
                                         writer.WriteSafeString($"{Environment.NewLine}if (poco.{targetPropertyName} != null){Environment.NewLine}");
                                         writer.WriteSafeString($"{{{Environment.NewLine}");
-                                        writer.WriteSafeString($"SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder,poco.{targetPropertyName});{Environment.NewLine}");
+                                        writer.WriteSafeString($"SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder,poco.{targetPropertyName}, writerContext);{Environment.NewLine}");
 
                                         if (!ruleGenerationContext.IsNextElementNewLineTerminal())
                                         {
@@ -410,7 +420,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
             }
             else
             {
-                writer.WriteSafeString($"Build{assignmentElement.Property.CapitalizeFirstLetter()}(poco, cursorCache, stringBuilder);");
+                writer.WriteSafeString($"Build{assignmentElement.Property.CapitalizeFirstLetter()}(poco, writerContext, stringBuilder);");
             }
         }
 
@@ -485,11 +495,17 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
                         var emittedCondition = this.TryEmitOptionalCondition(writer, nonTerminalElement, referencedRule, targetClass, ruleGenerationContext, ruleGenerationContext.CurrentVariableName);
 
-                        writer.WriteSafeString($"{targetType.Name}TextualNotationBuilder.Build{nonTerminalElement.Name}({ruleGenerationContext.CurrentVariableName}, cursorCache, stringBuilder);");
+                        writer.WriteSafeString($"{targetType.Name}TextualNotationBuilder.Build{nonTerminalElement.Name}({ruleGenerationContext.CurrentVariableName}, writerContext, stringBuilder);");
 
                         if (emittedCondition)
                         {
                             writer.WriteSafeString($"{Environment.NewLine}}}");
+                        }
+
+                        if (!string.IsNullOrEmpty(ruleGenerationContext.PendingCursorMove))
+                        {
+                            writer.WriteSafeString(ruleGenerationContext.PendingCursorMove);
+                            ruleGenerationContext.PendingCursorMove = null;
                         }
 
                         if (emitCast)
@@ -532,12 +548,18 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
                 var emittedSameClassCondition = this.TryEmitOptionalCondition(writer, nonTerminalElement, referencedRule, umlClass, ruleGenerationContext, variableToUse);
 
-                writer.WriteSafeString($"Build{nonTerminalElement.Name}({variableToUse}, cursorCache, stringBuilder);");
+                writer.WriteSafeString($"Build{nonTerminalElement.Name}({variableToUse}, writerContext, stringBuilder);");
 
                 if (emittedSameClassCondition)
                 {
                     writer.WriteSafeString($"{Environment.NewLine}}}");
                 }
+            }
+
+            if (!string.IsNullOrEmpty(ruleGenerationContext.PendingCursorMove))
+            {
+                writer.WriteSafeString(ruleGenerationContext.PendingCursorMove);
+                ruleGenerationContext.PendingCursorMove = null;
             }
 
             if (emitPropertyNullGuard)
@@ -583,7 +605,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                     cursorToUse.ApplicableRuleElements.Add(assignmentElement);
 
                     var propertyAccessName = targetProperty.QueryPropertyNameBasedOnUmlProperties();
-                    writer.WriteSafeString($"var {cursorToUse.CursorVariableName} = cursorCache.GetOrCreateCursor(poco.Id, \"{targetProperty.Name}\", poco.{propertyAccessName});");
+                    writer.WriteSafeString($"var {cursorToUse.CursorVariableName} = writerContext.CursorCache.GetOrCreateCursor(poco.Id, \"{targetProperty.Name}\", poco.{propertyAccessName});");
                     writer.WriteSafeString(Environment.NewLine);
                     ruleGenerationContext.DefinedCursors.Add(cursorToUse);
                     break;
@@ -620,7 +642,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
             var emittedCondition = effectiveTarget != null
                                    && this.TryEmitOptionalCondition(writer, nonTerminalElement, referencedRule, effectiveTarget, ruleGenerationContext, ruleGenerationContext.CurrentVariableName);
 
-            writer.WriteSafeString($"{RulesHelper.SharedBuilderClassName}.Build{nonTerminalElement.Name}({variableExpression}, cursorCache, stringBuilder);");
+            writer.WriteSafeString($"{RulesHelper.SharedBuilderClassName}.Build{nonTerminalElement.Name}({variableExpression}, writerContext, stringBuilder);");
 
             if (emittedCondition)
             {

--- a/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.PatternHandlers.cs
+++ b/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.PatternHandlers.cs
@@ -1,20 +1,20 @@
 // -------------------------------------------------------------------------------------------------
 // <copyright file="RuleProcessor.PatternHandlers.cs" company="Starion Group S.A.">
-//
+// 
 //   Copyright 2022-2026 Starion Group S.A.
-//
+// 
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
-//
+// 
 //        http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 //    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-//
+// 
 // </copyright>
 // ------------------------------------------------------------------------------------------------
 
@@ -58,14 +58,14 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                     return false;
                 }
 
-                var literals = ExtractLiteralAlternation(operatorAssignment.Value, ruleGenerationContext.AllRules);
+                var literals = this.ExtractLiteralAlternation(operatorAssignment.Value, ruleGenerationContext.AllRules);
 
                 if (literals == null || literals.Count == 0)
                 {
                     return false;
                 }
 
-                if (!AreAlternativeTailElementsProcessable(alternative.Elements, umlClass, ruleGenerationContext))
+                if (!this.AreAlternativeTailElementsProcessable(alternative.Elements, umlClass, ruleGenerationContext))
                 {
                     return false;
                 }
@@ -75,7 +75,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
             foreach (var alternative in alternatives)
             {
-                DeclareAllRequiredCursors(writer, umlClass, alternative, ruleGenerationContext);
+                this.DeclareAllRequiredCursors(writer, umlClass, alternative, ruleGenerationContext);
             }
 
             var variableName = ruleGenerationContext.CurrentVariableName ?? "poco";
@@ -99,7 +99,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                 for (var elementIndex = 1; elementIndex < alternative.Elements.Count; elementIndex++)
                 {
                     ruleGenerationContext.CurrentElementIndex = elementIndex;
-                    ProcessRuleElement(writer, umlClass, alternative.Elements[elementIndex], ruleGenerationContext);
+                    this.ProcessRuleElement(writer, umlClass, alternative.Elements[elementIndex], ruleGenerationContext);
                 }
 
                 ruleGenerationContext.CurrentSiblingElements = previousSiblings;
@@ -207,7 +207,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
             foreach (var alternative in alternatives)
             {
-                DeclareAllRequiredCursors(writer, umlClass, alternative, ruleGenerationContext);
+                this.DeclareAllRequiredCursors(writer, umlClass, alternative, ruleGenerationContext);
             }
 
             var cursor = ruleGenerationContext.DefinedCursors.FirstOrDefault(c => c.ApplicableRuleElements.Contains(emptyBranch.Assignment));
@@ -222,11 +222,11 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
             writer.WriteSafeString($"if ({cursorVarName}.Current is {typeName} {{ {discriminatorPropertyName}.Count: 0 }}){Environment.NewLine}");
             writer.WriteSafeString($"{{{Environment.NewLine}");
-            EmitAlternativeBody(writer, umlClass, emptyBranch.Alternative, ruleGenerationContext);
+            this.EmitAlternativeBody(writer, umlClass, emptyBranch.Alternative, ruleGenerationContext);
             writer.WriteSafeString($"}}{Environment.NewLine}");
             writer.WriteSafeString($"else if ({cursorVarName}.Current is {typeName}){Environment.NewLine}");
             writer.WriteSafeString($"{{{Environment.NewLine}");
-            EmitAlternativeBody(writer, umlClass, nonEmptyBranch.Alternative, ruleGenerationContext);
+            this.EmitAlternativeBody(writer, umlClass, nonEmptyBranch.Alternative, ruleGenerationContext);
             writer.WriteSafeString($"}}{Environment.NewLine}");
 
             return true;
@@ -304,14 +304,14 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
             {
                 var caseVarName = $"poco{targetClass.Name}";
                 writer.WriteSafeString($"case {targetClass.QueryFullyQualifiedTypeName()} {caseVarName}:{Environment.NewLine}");
-                EmitCompoundPocoTypeBranch(writer, umlClass, leadingNonTerminal, alternative, targetClass, caseVarName, ruleGenerationContext);
+                this.EmitCompoundPocoTypeBranch(writer, umlClass, leadingNonTerminal, alternative, targetClass, caseVarName, ruleGenerationContext);
                 writer.WriteSafeString($"break;{Environment.NewLine}");
             }
 
             if (defaultBranch.NonTerminal != null)
             {
                 writer.WriteSafeString($"default:{Environment.NewLine}");
-                EmitCompoundPocoTypeBranch(writer, umlClass, defaultBranch.NonTerminal, defaultBranch.Alternative, defaultBranch.TargetClass, "poco", ruleGenerationContext);
+                this.EmitCompoundPocoTypeBranch(writer, umlClass, defaultBranch.NonTerminal, defaultBranch.Alternative, defaultBranch.TargetClass, "poco", ruleGenerationContext);
                 writer.WriteSafeString($"break;{Environment.NewLine}");
             }
 
@@ -405,7 +405,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                 return false;
             }
 
-            DeclareAllRequiredCursors(writer, umlClass, alt1, ruleGenerationContext);
+            this.DeclareAllRequiredCursors(writer, umlClass, alt1, ruleGenerationContext);
 
             var variableName = ruleGenerationContext.CurrentVariableName ?? "poco";
             var collectionPropertyAccessor = collectionProperty.QueryPropertyNameBasedOnUmlProperties();
@@ -413,11 +413,11 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
             writer.WriteSafeString($"if ({variableName}.{collectionPropertyAccessor}.OfType<{referenceTypeName}>().Any()){Environment.NewLine}");
             writer.WriteSafeString($"{{{Environment.NewLine}");
-            EmitAlternativeBody(writer, umlClass, alt1, ruleGenerationContext);
+            this.EmitAlternativeBody(writer, umlClass, alt1, ruleGenerationContext);
             writer.WriteSafeString($"}}{Environment.NewLine}");
             writer.WriteSafeString($"else{Environment.NewLine}");
             writer.WriteSafeString($"{{{Environment.NewLine}");
-            EmitAlternativeBody(writer, umlClass, alt2, ruleGenerationContext);
+            this.EmitAlternativeBody(writer, umlClass, alt2, ruleGenerationContext);
             writer.WriteSafeString($"}}{Environment.NewLine}");
 
             return true;
@@ -500,7 +500,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
         private void ProcessMultiCollectionAssignment(EncodedTextWriter writer, IClass umlClass, IReadOnlyCollection<Alternatives> alternatives, RuleGenerationContext ruleGenerationContext)
         {
             var handCodedRuleName = alternatives.ElementAt(0).TextualNotationRule.RuleName;
-            EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
+            this.EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
         }
 
         /// <summary>
@@ -698,7 +698,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                         {
                             var handCodedRuleName = alternatives.ElementAt(0).TextualNotationRule?.RuleName ?? "Unknown";
 
-                            EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext, deduplicate: true);
+                            this.EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext, true);
 
                             break;
                         }
@@ -734,7 +734,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                         var previousCaller = ruleGenerationContext.CallerRule;
                         ruleGenerationContext.CallerRule = orderedNonTerminalElement.RuleElement;
 
-                        ProcessNonTerminalElement(writer, orderedNonTerminalElement.UmlClass, orderedNonTerminalElement.RuleElement, ruleGenerationContext);
+                        this.ProcessNonTerminalElement(writer, orderedNonTerminalElement.UmlClass, orderedNonTerminalElement.RuleElement, ruleGenerationContext);
 
                         ruleGenerationContext.CallerRule = previousCaller;
                         ruleGenerationContext.CurrentVariableName = previousVariableName;
@@ -806,7 +806,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
                                 var previousVariableName = ruleGenerationContext.CurrentVariableName;
                                 ruleGenerationContext.CurrentVariableName = orderedElement.UmlClass.Name.LowerCaseFirstLetter();
-                                ProcessNonTerminalElement(writer, orderedElement.UmlClass, orderedElement.RuleElement, ruleGenerationContext);
+                                this.ProcessNonTerminalElement(writer, orderedElement.UmlClass, orderedElement.RuleElement, ruleGenerationContext);
                                 ruleGenerationContext.CurrentVariableName = previousVariableName;
                                 writer.WriteSafeString($"{Environment.NewLine}{cursorVarName}.Move();{Environment.NewLine}");
                                 writer.WriteSafeString($"break;{Environment.NewLine}");
@@ -859,7 +859,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
                                 var previousVariableName = ruleGenerationContext.CurrentVariableName;
                                 ruleGenerationContext.CurrentVariableName = orderedElement.UmlClass.Name.LowerCaseFirstLetter();
-                                ProcessNonTerminalElement(writer, orderedElement.UmlClass, orderedElement.RuleElement, ruleGenerationContext);
+                                this.ProcessNonTerminalElement(writer, orderedElement.UmlClass, orderedElement.RuleElement, ruleGenerationContext);
                                 ruleGenerationContext.CurrentVariableName = previousVariableName;
                                 writer.WriteSafeString($"{Environment.NewLine}break;{Environment.NewLine}");
                             }
@@ -873,7 +873,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                     {
                         foreach (var alternative in alternatives)
                         {
-                            DeclareAllRequiredCursors(writer, umlClass, alternative, ruleGenerationContext);
+                            this.DeclareAllRequiredCursors(writer, umlClass, alternative, ruleGenerationContext);
                         }
 
                         var properties = umlClass.QueryAllProperties();
@@ -896,7 +896,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                             }
 
                             writer.WriteSafeString($"{{{Environment.NewLine}");
-                            ProcessAssignmentElement(writer, umlClass, ruleGenerationContext, assignment, true);
+                            this.ProcessAssignmentElement(writer, umlClass, ruleGenerationContext, assignment, true);
                             writer.WriteSafeString($"{Environment.NewLine}}}{Environment.NewLine}");
                         }
                     }
@@ -905,7 +905,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                 default:
                 {
                     var defaultHandCodedRuleName = alternatives.ElementAt(0).TextualNotationRule.RuleName;
-                    EmitHandCodedFallback(writer, defaultHandCodedRuleName, ruleGenerationContext);
+                    this.EmitHandCodedFallback(writer, defaultHandCodedRuleName, ruleGenerationContext);
                     break;
                 }
             }

--- a/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.PatternHandlers.cs
+++ b/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.PatternHandlers.cs
@@ -768,7 +768,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
                             if (existingCursor == null)
                             {
-                                writer.WriteSafeString($"var {cursorVarName} = cursorCache.GetOrCreateCursor(poco.Id, \"{targetProperty.Name}\", poco.{targetProperty.QueryPropertyNameBasedOnUmlProperties()});{Environment.NewLine}");
+                                writer.WriteSafeString($"var {cursorVarName} = writerContext.CursorCache.GetOrCreateCursor(poco.Id, \"{targetProperty.Name}\", poco.{targetProperty.QueryPropertyNameBasedOnUmlProperties()});{Environment.NewLine}");
                                 var cursorDef = new CursorDefinition { DefinedForProperty = targetProperty };
 
                                 foreach (var assignmentElement in assignmentElements)
@@ -826,7 +826,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
                             if (existingCursor == null)
                             {
-                                writer.WriteSafeString($"var {cursorVarName} = cursorCache.GetOrCreateCursor(poco.Id, \"{targetProperty.Name}\", poco.{targetProperty.QueryPropertyNameBasedOnUmlProperties()});{Environment.NewLine}");
+                                writer.WriteSafeString($"var {cursorVarName} = writerContext.CursorCache.GetOrCreateCursor(poco.Id, \"{targetProperty.Name}\", poco.{targetProperty.QueryPropertyNameBasedOnUmlProperties()});{Environment.NewLine}");
                                 var cursorDef = new CursorDefinition { DefinedForProperty = targetProperty };
 
                                 foreach (var assignmentElement in assignmentElements)
@@ -920,11 +920,11 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
             if (targetClass == umlClass)
             {
-                builderCall = $"Build{leadingNonTerminal.Name}({variableName}, cursorCache, stringBuilder);";
+                builderCall = $"Build{leadingNonTerminal.Name}({variableName}, writerContext, stringBuilder);";
             }
             else
             {
-                builderCall = $"{targetClass.Name}TextualNotationBuilder.Build{leadingNonTerminal.Name}({variableName}, cursorCache, stringBuilder);";
+                builderCall = $"{targetClass.Name}TextualNotationBuilder.Build{leadingNonTerminal.Name}({variableName}, writerContext, stringBuilder);";
             }
 
             writer.WriteSafeString($"{builderCall}{Environment.NewLine}");

--- a/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.PatternHandlers.cs
+++ b/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.PatternHandlers.cs
@@ -626,7 +626,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                                 for (var elementIndex = 0; elementIndex < unguardedElements.Count - 1; elementIndex++)
                                 {
                                     var element = unguardedElements[elementIndex];
-                                    whenGuards[element.RuleElement] = $"{{0}}.IsValidFor{element.RuleElement.Name}()";
+                                    whenGuards[element.RuleElement] = $"{{0}}.IsValidFor{element.RuleElement.Name}(writerContext)";
                                 }
                             }
                         }
@@ -801,7 +801,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                                 }
                                 else
                                 {
-                                    writer.WriteSafeString($"case {orderedElement.UmlClass.QueryFullyQualifiedTypeName()} {orderedElement.UmlClass.Name.LowerCaseFirstLetter()} when {orderedElement.UmlClass.Name.LowerCaseFirstLetter()}.IsValidFor{orderedElement.RuleElement.Name}():{Environment.NewLine}");
+                                    writer.WriteSafeString($"case {orderedElement.UmlClass.QueryFullyQualifiedTypeName()} {orderedElement.UmlClass.Name.LowerCaseFirstLetter()} when {orderedElement.UmlClass.Name.LowerCaseFirstLetter()}.IsValidFor{orderedElement.RuleElement.Name}(writerContext):{Environment.NewLine}");
                                 }
 
                                 var previousVariableName = ruleGenerationContext.CurrentVariableName;

--- a/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.cs
+++ b/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.cs
@@ -1,20 +1,20 @@
 // -------------------------------------------------------------------------------------------------
 // <copyright file="RuleProcessor.cs" company="Starion Group S.A.">
-//
+// 
 //   Copyright 2022-2026 Starion Group S.A.
-//
+// 
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
-//
+// 
 //        http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 //    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-//
+// 
 // </copyright>
 // ------------------------------------------------------------------------------------------------
 
@@ -29,7 +29,6 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
     using SysML2.NET.CodeGenerator.Extensions;
     using SysML2.NET.CodeGenerator.Grammar.Model;
 
-    using uml4net.CommonStructure;
     using uml4net.Extensions;
     using uml4net.StructuredClassifiers;
 
@@ -39,25 +38,6 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
     /// </summary>
     internal sealed partial class RuleProcessor
     {
-        /// <summary>
-        /// Emits a <c>Build{ruleName}HandCoded(variable, cursorCache, stringBuilder);</c> fallback call.
-        /// When <paramref name="deduplicate" /> is <c>true</c>, the call is only emitted if it has not
-        /// already been emitted for the same rule name in the current generation scope.
-        /// </summary>
-        /// <param name="writer">The <see cref="EncodedTextWriter" /> used to write output</param>
-        /// <param name="ruleName">The grammar rule name used to form the method name</param>
-        /// <param name="ruleGenerationContext">The current <see cref="RuleGenerationContext" /></param>
-        /// <param name="deduplicate">When <c>true</c>, suppress duplicate emissions via <see cref="RuleGenerationContext.EmittedHandCodedCalls" /></param>
-        private void EmitHandCodedFallback(EncodedTextWriter writer, string ruleName, RuleGenerationContext ruleGenerationContext, bool deduplicate = false)
-        {
-            if (deduplicate && !ruleGenerationContext.EmittedHandCodedCalls.Add(ruleName))
-            {
-                return;
-            }
-
-            writer.WriteSafeString($"Build{ruleName}HandCoded({ruleGenerationContext.CurrentVariableName ?? "poco"}, cursorCache, stringBuilder);");
-        }
-
         /// <summary>
         /// Core orchestration method that processes grammar alternatives and emits C# code.
         /// Dispatches to pattern handlers for recognized patterns, or falls back to element-by-element processing.
@@ -73,16 +53,88 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
             if (alternatives.Count == 1)
             {
-                ProcessSingleAlternative(writer, umlClass, alternatives.ElementAt(0), ruleGenerationContext, isPartOfMultipleAlternative);
+                this.ProcessSingleAlternative(writer, umlClass, alternatives.ElementAt(0), ruleGenerationContext, isPartOfMultipleAlternative);
             }
             else if (alternatives.All(x => x.Elements.Count == 1))
             {
-                ProcessSingleElementAlternatives(writer, umlClass, alternatives, ruleGenerationContext);
+                this.ProcessSingleElementAlternatives(writer, umlClass, alternatives, ruleGenerationContext);
             }
             else
             {
-                ProcessMultiElementAlternatives(writer, umlClass, alternatives, ruleGenerationContext);
+                this.ProcessMultiElementAlternatives(writer, umlClass, alternatives, ruleGenerationContext);
             }
+        }
+
+        /// <summary>
+        /// Emits the body of a single alternative by iterating its elements and delegating to <see cref="ProcessRuleElement" />.
+        /// </summary>
+        /// <param name="writer">The <see cref="EncodedTextWriter" /> used to write output</param>
+        /// <param name="umlClass">The current <see cref="IClass" /></param>
+        /// <param name="alternative">The <see cref="Alternatives" /> whose elements are emitted</param>
+        /// <param name="ruleGenerationContext">The current <see cref="RuleGenerationContext" /></param>
+        internal void EmitAlternativeBody(EncodedTextWriter writer, IClass umlClass, Alternatives alternative, RuleGenerationContext ruleGenerationContext)
+        {
+            var previousSiblings = ruleGenerationContext.CurrentSiblingElements;
+            var previousIndex = ruleGenerationContext.CurrentElementIndex;
+            ruleGenerationContext.CurrentSiblingElements = alternative.Elements;
+
+            for (var elementIndex = 0; elementIndex < alternative.Elements.Count; elementIndex++)
+            {
+                ruleGenerationContext.CurrentElementIndex = elementIndex;
+                this.ProcessRuleElement(writer, umlClass, alternative.Elements[elementIndex], ruleGenerationContext);
+            }
+
+            ruleGenerationContext.CurrentSiblingElements = previousSiblings;
+            ruleGenerationContext.CurrentElementIndex = previousIndex;
+        }
+
+        /// <summary>
+        /// Declares cursor variables for all enumerable properties referenced by assignment elements in the given alternative.
+        /// </summary>
+        /// <param name="writer">The <see cref="EncodedTextWriter" /> used to write output</param>
+        /// <param name="umlClass">The related <see cref="IClass" /></param>
+        /// <param name="alternatives">The <see cref="Alternatives" /> containing assignment elements</param>
+        /// <param name="ruleGenerationContext">The current <see cref="RuleGenerationContext" /></param>
+        internal void DeclareAllRequiredCursors(EncodedTextWriter writer, IClass umlClass, Alternatives alternatives, RuleGenerationContext ruleGenerationContext)
+        {
+            foreach (var ruleElement in alternatives.Elements)
+            {
+                switch (ruleElement)
+                {
+                    case AssignmentElement assignmentElement:
+                        this.DeclareCursorIfRequired(writer, umlClass, assignmentElement, ruleGenerationContext);
+                        break;
+                    case GroupElement groupElement:
+                        foreach (var groupElementAlternative in groupElement.Alternatives)
+                        {
+                            this.DeclareAllRequiredCursors(writer, umlClass, groupElementAlternative, ruleGenerationContext);
+                        }
+
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Emits a <c>Build{ruleName}HandCoded(variable, cursorCache, stringBuilder);</c> fallback call.
+        /// When <paramref name="deduplicate" /> is <c>true</c>, the call is only emitted if it has not
+        /// already been emitted for the same rule name in the current generation scope.
+        /// </summary>
+        /// <param name="writer">The <see cref="EncodedTextWriter" /> used to write output</param>
+        /// <param name="ruleName">The grammar rule name used to form the method name</param>
+        /// <param name="ruleGenerationContext">The current <see cref="RuleGenerationContext" /></param>
+        /// <param name="deduplicate">
+        /// When <c>true</c>, suppress duplicate emissions via
+        /// <see cref="RuleGenerationContext.EmittedHandCodedCalls" />
+        /// </param>
+        private void EmitHandCodedFallback(EncodedTextWriter writer, string ruleName, RuleGenerationContext ruleGenerationContext, bool deduplicate = false)
+        {
+            if (deduplicate && !ruleGenerationContext.EmittedHandCodedCalls.Add(ruleName))
+            {
+                return;
+            }
+
+            writer.WriteSafeString($"Build{ruleName}HandCoded({ruleGenerationContext.CurrentVariableName ?? "poco"}, cursorCache, stringBuilder);");
         }
 
         /// <summary>
@@ -97,7 +149,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
         private void ProcessSingleAlternative(EncodedTextWriter writer, IClass umlClass, Alternatives alternative, RuleGenerationContext ruleGenerationContext, bool isPartOfMultipleAlternative)
         {
             var elements = alternative.Elements;
-            DeclareAllRequiredCursors(writer, umlClass, alternative, ruleGenerationContext);
+            this.DeclareAllRequiredCursors(writer, umlClass, alternative, ruleGenerationContext);
 
             if (ruleGenerationContext.CallerRule is { IsOptional: true, IsCollection: false })
             {
@@ -139,7 +191,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                     {
                         ruleGenerationContext.CurrentElementIndex = elementIndex;
                         var previousCaller = ruleGenerationContext.CallerRule;
-                        ProcessRuleElement(writer, umlClass, elements[elementIndex], ruleGenerationContext);
+                        this.ProcessRuleElement(writer, umlClass, elements[elementIndex], ruleGenerationContext);
                         ruleGenerationContext.CallerRule = previousCaller;
                     }
 
@@ -157,7 +209,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
                         if (referencedRule != null)
                         {
-                            var condition = GenerateInlineOptionalCondition(referencedRule, umlClass, ruleGenerationContext.AllRules, "poco");
+                            var condition = this.GenerateInlineOptionalCondition(referencedRule, umlClass, ruleGenerationContext.AllRules, "poco");
 
                             if (condition != null)
                             {
@@ -184,7 +236,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                     for (var elementIndex = 0; elementIndex < elements.Count; elementIndex++)
                     {
                         ruleGenerationContext.CurrentElementIndex = elementIndex;
-                        ProcessRuleElement(writer, umlClass, elements[elementIndex], ruleGenerationContext);
+                        this.ProcessRuleElement(writer, umlClass, elements[elementIndex], ruleGenerationContext);
                     }
 
                     ruleGenerationContext.CurrentSiblingElements = previousSiblings;
@@ -208,7 +260,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                 {
                     ruleGenerationContext.CurrentElementIndex = elementIndex;
                     var previousCaller = ruleGenerationContext.CallerRule;
-                    ProcessRuleElement(writer, umlClass, elements[elementIndex], ruleGenerationContext, isPartOfMultipleAlternative);
+                    this.ProcessRuleElement(writer, umlClass, elements[elementIndex], ruleGenerationContext, isPartOfMultipleAlternative);
                     ruleGenerationContext.CallerRule = previousCaller;
                 }
 
@@ -229,7 +281,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
         {
             if (alternatives.ElementAt(0).Elements[0].TextualNotationRule.IsMultiCollectionAssignment)
             {
-                ProcessMultiCollectionAssignment(writer, umlClass, alternatives, ruleGenerationContext);
+                this.ProcessMultiCollectionAssignment(writer, umlClass, alternatives, ruleGenerationContext);
                 return;
             }
 
@@ -237,11 +289,11 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
             if (types.Count == 1)
             {
-                ProcessUnitypedAlternativesWithOneElement(writer, umlClass, alternatives, ruleGenerationContext);
+                this.ProcessUnitypedAlternativesWithOneElement(writer, umlClass, alternatives, ruleGenerationContext);
             }
             else
             {
-                ProcessMixedTypeSingleElementAlternatives(writer, umlClass, alternatives, ruleGenerationContext, types);
+                this.ProcessMixedTypeSingleElementAlternatives(writer, umlClass, alternatives, ruleGenerationContext, types);
             }
         }
 
@@ -260,7 +312,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
             {
                 foreach (var alternative in alternatives)
                 {
-                    DeclareAllRequiredCursors(writer, umlClass, alternative, ruleGenerationContext);
+                    this.DeclareAllRequiredCursors(writer, umlClass, alternative, ruleGenerationContext);
                 }
 
                 for (var alternativeIndex = 0; alternativeIndex < alternatives.Count; alternativeIndex++)
@@ -284,7 +336,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
                             if (targetProperty.QueryIsEnumerable())
                             {
-                                DeclareAllRequiredCursors(writer, umlClass, alternatives.ElementAt(0), ruleGenerationContext);
+                                this.DeclareAllRequiredCursors(writer, umlClass, alternatives.ElementAt(0), ruleGenerationContext);
 
                                 var iterator = ruleGenerationContext.DefinedCursors.Single(x => x.ApplicableRuleElements.Contains(assignmentElement));
 
@@ -297,14 +349,14 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                                 writer.WriteSafeString($"{{{Environment.NewLine}");
                             }
 
-                            ProcessAssignmentElement(writer, umlClass, ruleGenerationContext, assignmentElement, true);
+                            this.ProcessAssignmentElement(writer, umlClass, ruleGenerationContext, assignmentElement, true);
 
                             writer.WriteSafeString($"{Environment.NewLine}}}");
                             break;
 
                         case NonTerminalElement nonTerminalElement:
                             writer.WriteSafeString($"{{{Environment.NewLine}");
-                            ProcessNonTerminalElement(writer, umlClass, nonTerminalElement, ruleGenerationContext);
+                            this.ProcessNonTerminalElement(writer, umlClass, nonTerminalElement, ruleGenerationContext);
                             writer.WriteSafeString($"{Environment.NewLine}}}");
                             break;
                     }
@@ -312,7 +364,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
             }
             else if (types.SequenceEqual([typeof(NonTerminalElement), typeof(AssignmentElement)]))
             {
-                EmitNonTerminalThenAssignmentDispatch(writer, umlClass, alternatives, ruleGenerationContext);
+                this.EmitNonTerminalThenAssignmentDispatch(writer, umlClass, alternatives, ruleGenerationContext);
             }
             else if (alternatives.ElementAt(0).Elements[0] is TerminalElement terminalElement && alternatives.ElementAt(1).Elements[0] is AssignmentElement assignmentElement)
             {
@@ -320,18 +372,18 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
                 writer.WriteSafeString($"if(!{targetProperty.QueryIfStatementContentForNonEmpty("poco")}){Environment.NewLine}");
                 writer.WriteSafeString($"{{{Environment.NewLine}");
-                ProcessRuleElement(writer, umlClass, terminalElement, ruleGenerationContext);
+                this.ProcessRuleElement(writer, umlClass, terminalElement, ruleGenerationContext);
                 writer.WriteSafeString($"{Environment.NewLine}}}");
                 writer.WriteSafeString("else");
                 writer.WriteSafeString($"{Environment.NewLine}{{{Environment.NewLine}");
-                ProcessAssignmentElement(writer, umlClass, ruleGenerationContext, assignmentElement, true);
+                this.ProcessAssignmentElement(writer, umlClass, ruleGenerationContext, assignmentElement, true);
                 writer.WriteSafeString($"{Environment.NewLine}}}");
             }
             else
             {
                 var handCodedRuleName = alternatives.ElementAt(0).TextualNotationRule.RuleName;
 
-                EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext, deduplicate: true);
+                this.EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext, true);
             }
         }
 
@@ -353,7 +405,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
             if (referencedAssignmentNonTerminals.Count != assignmentElements.Count)
             {
                 var handCodedRuleName = alternatives.ElementAt(0).TextualNotationRule.RuleName;
-                EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
+                this.EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
                 return;
             }
 
@@ -395,7 +447,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
                 var previousVariableName = ruleGenerationContext.CurrentVariableName;
                 ruleGenerationContext.CurrentVariableName = assignmentVarName;
-                ProcessNonTerminalElement(writer, mappedElement.UmlClass, mappedElement.RuleElement, ruleGenerationContext);
+                this.ProcessNonTerminalElement(writer, mappedElement.UmlClass, mappedElement.RuleElement, ruleGenerationContext);
                 ruleGenerationContext.CurrentVariableName = previousVariableName;
 
                 writer.WriteSafeString($"{Environment.NewLine}{cursorVarName}.Move();{Environment.NewLine}");
@@ -411,7 +463,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                 ? nonTerminalReferencedRule.EffectiveTarget
                 : umlClass.Name;
 
-            var nonTerminalCall = ResolveBuilderCall(umlClass, nonTerminalElement, nonTerminalTypeTarget, ruleGenerationContext);
+            var nonTerminalCall = this.ResolveBuilderCall(umlClass, nonTerminalElement, nonTerminalTypeTarget, ruleGenerationContext);
 
             if (nonTerminalCall != null)
             {
@@ -422,7 +474,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                 var previousCaller = ruleGenerationContext.CallerRule;
                 var previousName = ruleGenerationContext.CurrentVariableName;
                 ruleGenerationContext.CallerRule = nonTerminalElement;
-                ProcessAlternatives(writer, umlClass, nonTerminalReferencedRule?.Alternatives, ruleGenerationContext);
+                this.ProcessAlternatives(writer, umlClass, nonTerminalReferencedRule?.Alternatives, ruleGenerationContext);
                 ruleGenerationContext.CallerRule = previousCaller;
                 ruleGenerationContext.CurrentVariableName = previousName;
             }
@@ -443,12 +495,12 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
             // When all alternatives consist exclusively of terminal elements (and optionally non-parsing assignments), handle via code-gen
             if (alternatives.All(alt => alt.Elements.Count > 0 && alt.Elements.All(element => element is TerminalElement or NonParsingAssignmentElement)))
             {
-                EmitTerminalOnlyAlternatives(writer, umlClass, alternatives, ruleGenerationContext);
+                this.EmitTerminalOnlyAlternatives(writer, umlClass, alternatives, ruleGenerationContext);
                 return;
             }
 
             // Detect pattern: property=[QualifiedName] | property=NonTerminal{containment+=property}
-            if (alternatives.Count == 2 && TryEmitQualifiedNameOrChainAlternatives(writer, umlClass, alternatives, ruleGenerationContext))
+            if (alternatives.Count == 2 && this.TryEmitQualifiedNameOrChainAlternatives(writer, umlClass, alternatives, ruleGenerationContext))
             {
                 return;
             }
@@ -459,34 +511,34 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
             if (hasTerminalOnlyFirstAlt && alternatives.Count == 2)
             {
-                EmitTerminalVsBodyAlternatives(writer, umlClass, alternatives, ruleGenerationContext);
+                this.EmitTerminalVsBodyAlternatives(writer, umlClass, alternatives, ruleGenerationContext);
             }
             else
             {
                 // Try each pattern handler in order; fall back to HandCoded if none match
-                if (TryHandleOperatorLiteralAlternation(writer, umlClass, alternatives, ruleGenerationContext))
+                if (this.TryHandleOperatorLiteralAlternation(writer, umlClass, alternatives, ruleGenerationContext))
                 {
                     return;
                 }
 
-                if (TryHandleEmptyVsNonEmptyMembership(writer, umlClass, alternatives, ruleGenerationContext))
+                if (this.TryHandleEmptyVsNonEmptyMembership(writer, umlClass, alternatives, ruleGenerationContext))
                 {
                     return;
                 }
 
-                if (TryHandlePocoTypeDispatchWithCompoundAlternatives(writer, umlClass, alternatives, ruleGenerationContext))
+                if (this.TryHandlePocoTypeDispatchWithCompoundAlternatives(writer, umlClass, alternatives, ruleGenerationContext))
                 {
                     return;
                 }
 
-                if (TryHandleReferenceOrInline(writer, umlClass, alternatives, ruleGenerationContext))
+                if (this.TryHandleReferenceOrInline(writer, umlClass, alternatives, ruleGenerationContext))
                 {
                     return;
                 }
 
                 var handCodedRuleName = alternatives.ElementAt(0).TextualNotationRule.RuleName;
 
-                EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext, deduplicate: true);
+                this.EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext, true);
             }
         }
 
@@ -639,7 +691,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
             writer.WriteSafeString($"}}{Environment.NewLine}");
             writer.WriteSafeString($"else if ({variableName}.{resolvedPropertyName} != null){Environment.NewLine}");
             writer.WriteSafeString($"{{{Environment.NewLine}");
-            writer.WriteSafeString($"stringBuilder.Append({variableName}.{resolvedPropertyName}.qualifiedName);{Environment.NewLine}");
+            writer.WriteSafeString($"SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder,{variableName}.{resolvedPropertyName});{Environment.NewLine}");
             writer.WriteSafeString($"stringBuilder.Append(' ');{Environment.NewLine}");
             writer.WriteSafeString($"}}{Environment.NewLine}");
 
@@ -669,7 +721,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
             if (allCollectionAssignments.Count > 0)
             {
-                EmitTerminalVsBodyWithCollectionAssignments(writer, umlClass, firstAlt, secondAlt, allCollectionAssignments, ruleGenerationContext);
+                this.EmitTerminalVsBodyWithCollectionAssignments(writer, umlClass, firstAlt, secondAlt, allCollectionAssignments, ruleGenerationContext);
             }
             else
             {
@@ -677,7 +729,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
                 if (collectionNonTerminals.Count > 0)
                 {
-                    EmitTerminalVsBodyWithCollectionNonTerminals(writer, umlClass, firstAlt, secondAlt, collectionNonTerminals, ruleGenerationContext);
+                    this.EmitTerminalVsBodyWithCollectionNonTerminals(writer, umlClass, firstAlt, secondAlt, collectionNonTerminals, ruleGenerationContext);
                 }
                 else
                 {
@@ -685,12 +737,12 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
                     if (nonCollectionNonTerminals.Count > 0)
                     {
-                        EmitTerminalVsBodyWithSingleNonTerminal(writer, umlClass, firstAlt, secondAlt, nonCollectionNonTerminals, ruleGenerationContext);
+                        this.EmitTerminalVsBodyWithSingleNonTerminal(writer, umlClass, firstAlt, secondAlt, nonCollectionNonTerminals, ruleGenerationContext);
                     }
                     else
                     {
                         var handCodedRuleName = firstAlt.TextualNotationRule.RuleName;
-                        EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
+                        this.EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
                     }
                 }
             }
@@ -716,11 +768,11 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                 writer.WriteSafeString($"else{Environment.NewLine}");
                 writer.WriteSafeString($"{{{Environment.NewLine}");
 
-                DeclareAllRequiredCursors(writer, umlClass, secondAlt, ruleGenerationContext);
+                this.DeclareAllRequiredCursors(writer, umlClass, secondAlt, ruleGenerationContext);
 
                 foreach (var element in secondAlt.Elements)
                 {
-                    ProcessRuleElement(writer, umlClass, element, ruleGenerationContext);
+                    this.ProcessRuleElement(writer, umlClass, element, ruleGenerationContext);
                 }
 
                 writer.WriteSafeString($"}}{Environment.NewLine}");
@@ -728,7 +780,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
             else
             {
                 var handCodedRuleName = firstAlt.TextualNotationRule.RuleName;
-                EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
+                this.EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
             }
         }
 
@@ -743,7 +795,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
             if (nonTerminalRule == null)
             {
                 var handCodedRuleName = firstAlt.TextualNotationRule.RuleName;
-                EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
+                this.EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
                 return;
             }
 
@@ -752,7 +804,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
             if (collectionPropertyNames.Count == 0)
             {
                 var handCodedRuleName = firstAlt.TextualNotationRule.RuleName;
-                EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
+                this.EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
                 return;
             }
 
@@ -763,7 +815,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
             if (targetProperty == null)
             {
                 var handCodedRuleName = firstAlt.TextualNotationRule.RuleName;
-                EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
+                this.EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
                 return;
             }
 
@@ -791,7 +843,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                         ? referencedRule.EffectiveTarget
                         : umlClass.Name;
 
-                    var perItemCall = ResolveBuilderCall(umlClass, collectionNonTerminal, typeTarget, ruleGenerationContext);
+                    var perItemCall = this.ResolveBuilderCall(umlClass, collectionNonTerminal, typeTarget, ruleGenerationContext);
 
                     writer.WriteSafeString($"while ({cursorVarName}.Current != null){Environment.NewLine}");
                     writer.WriteSafeString($"{{{Environment.NewLine}");
@@ -805,7 +857,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                         var previousCaller = ruleGenerationContext.CallerRule;
                         var previousName = ruleGenerationContext.CurrentVariableName;
                         ruleGenerationContext.CallerRule = collectionNonTerminal;
-                        ProcessAlternatives(writer, umlClass, referencedRule?.Alternatives, ruleGenerationContext);
+                        this.ProcessAlternatives(writer, umlClass, referencedRule?.Alternatives, ruleGenerationContext);
                         ruleGenerationContext.CallerRule = previousCaller;
                         ruleGenerationContext.CurrentVariableName = previousName;
                     }
@@ -814,7 +866,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                 }
                 else
                 {
-                    ProcessRuleElement(writer, umlClass, element, ruleGenerationContext);
+                    this.ProcessRuleElement(writer, umlClass, element, ruleGenerationContext);
                 }
             }
 
@@ -832,7 +884,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
             if (nonTerminalRule == null)
             {
                 var handCodedRuleName = firstAlt.TextualNotationRule.RuleName;
-                EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
+                this.EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
                 return;
             }
 
@@ -841,7 +893,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
             if (collectionPropertyNames.Count == 0)
             {
                 var handCodedRuleName = firstAlt.TextualNotationRule.RuleName;
-                EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
+                this.EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
                 return;
             }
 
@@ -852,7 +904,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
             if (targetProperty == null)
             {
                 var handCodedRuleName = firstAlt.TextualNotationRule.RuleName;
-                EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
+                this.EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
                 return;
             }
 
@@ -879,7 +931,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                         ? referencedRule.EffectiveTarget
                         : umlClass.Name;
 
-                    var perItemCall = ResolveBuilderCall(umlClass, singleNonTerminal, typeTarget, ruleGenerationContext);
+                    var perItemCall = this.ResolveBuilderCall(umlClass, singleNonTerminal, typeTarget, ruleGenerationContext);
 
                     writer.WriteSafeString($"if ({cursorVarName}.Current != null){Environment.NewLine}");
                     writer.WriteSafeString($"{{{Environment.NewLine}");
@@ -893,7 +945,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                         var previousCaller = ruleGenerationContext.CallerRule;
                         var previousName = ruleGenerationContext.CurrentVariableName;
                         ruleGenerationContext.CallerRule = singleNonTerminal;
-                        ProcessAlternatives(writer, umlClass, referencedRule?.Alternatives, ruleGenerationContext);
+                        this.ProcessAlternatives(writer, umlClass, referencedRule?.Alternatives, ruleGenerationContext);
                         ruleGenerationContext.CallerRule = previousCaller;
                         ruleGenerationContext.CurrentVariableName = previousName;
                     }
@@ -902,61 +954,11 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                 }
                 else
                 {
-                    ProcessRuleElement(writer, umlClass, element, ruleGenerationContext);
+                    this.ProcessRuleElement(writer, umlClass, element, ruleGenerationContext);
                 }
             }
 
             writer.WriteSafeString($"}}{Environment.NewLine}");
-        }
-
-        /// <summary>
-        /// Emits the body of a single alternative by iterating its elements and delegating to <see cref="ProcessRuleElement" />.
-        /// </summary>
-        /// <param name="writer">The <see cref="EncodedTextWriter" /> used to write output</param>
-        /// <param name="umlClass">The current <see cref="IClass" /></param>
-        /// <param name="alternative">The <see cref="Alternatives" /> whose elements are emitted</param>
-        /// <param name="ruleGenerationContext">The current <see cref="RuleGenerationContext" /></param>
-        internal void EmitAlternativeBody(EncodedTextWriter writer, IClass umlClass, Alternatives alternative, RuleGenerationContext ruleGenerationContext)
-        {
-            var previousSiblings = ruleGenerationContext.CurrentSiblingElements;
-            var previousIndex = ruleGenerationContext.CurrentElementIndex;
-            ruleGenerationContext.CurrentSiblingElements = alternative.Elements;
-
-            for (var elementIndex = 0; elementIndex < alternative.Elements.Count; elementIndex++)
-            {
-                ruleGenerationContext.CurrentElementIndex = elementIndex;
-                ProcessRuleElement(writer, umlClass, alternative.Elements[elementIndex], ruleGenerationContext);
-            }
-
-            ruleGenerationContext.CurrentSiblingElements = previousSiblings;
-            ruleGenerationContext.CurrentElementIndex = previousIndex;
-        }
-
-        /// <summary>
-        /// Declares cursor variables for all enumerable properties referenced by assignment elements in the given alternative.
-        /// </summary>
-        /// <param name="writer">The <see cref="EncodedTextWriter" /> used to write output</param>
-        /// <param name="umlClass">The related <see cref="IClass" /></param>
-        /// <param name="alternatives">The <see cref="Alternatives" /> containing assignment elements</param>
-        /// <param name="ruleGenerationContext">The current <see cref="RuleGenerationContext" /></param>
-        internal void DeclareAllRequiredCursors(EncodedTextWriter writer, IClass umlClass, Alternatives alternatives, RuleGenerationContext ruleGenerationContext)
-        {
-            foreach (var ruleElement in alternatives.Elements)
-            {
-                switch (ruleElement)
-                {
-                    case AssignmentElement assignmentElement:
-                        DeclareCursorIfRequired(writer, umlClass, assignmentElement, ruleGenerationContext);
-                        break;
-                    case GroupElement groupElement:
-                        foreach (var groupElementAlternative in groupElement.Alternatives)
-                        {
-                            DeclareAllRequiredCursors(writer, umlClass, groupElementAlternative, ruleGenerationContext);
-                        }
-
-                        break;
-                }
-            }
         }
     }
 }

--- a/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.cs
+++ b/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.cs
@@ -116,7 +116,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
         }
 
         /// <summary>
-        /// Emits a <c>Build{ruleName}HandCoded(variable, cursorCache, stringBuilder);</c> fallback call.
+        /// Emits a <c>Build{ruleName}HandCoded(variable, writerContext, stringBuilder);</c> fallback call.
         /// When <paramref name="deduplicate" /> is <c>true</c>, the call is only emitted if it has not
         /// already been emitted for the same rule name in the current generation scope.
         /// </summary>
@@ -134,7 +134,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                 return;
             }
 
-            writer.WriteSafeString($"Build{ruleName}HandCoded({ruleGenerationContext.CurrentVariableName ?? "poco"}, cursorCache, stringBuilder);");
+            writer.WriteSafeString($"Build{ruleName}HandCoded({ruleGenerationContext.CurrentVariableName ?? "poco"}, writerContext, stringBuilder);");
         }
 
         /// <summary>
@@ -415,7 +415,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
             if (existingCursor == null)
             {
-                writer.WriteSafeString($"var {cursorVarName} = cursorCache.GetOrCreateCursor(poco.Id, \"{targetProperty.Name}\", poco.{targetProperty.QueryPropertyNameBasedOnUmlProperties()});{Environment.NewLine}");
+                writer.WriteSafeString($"var {cursorVarName} = writerContext.CursorCache.GetOrCreateCursor(poco.Id, \"{targetProperty.Name}\", poco.{targetProperty.QueryPropertyNameBasedOnUmlProperties()});{Environment.NewLine}");
                 var cursorDef = new CursorDefinition { DefinedForProperty = targetProperty };
 
                 foreach (var assignmentElement in assignmentElements)
@@ -678,11 +678,11 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
             if (typeTarget == ruleGenerationContext.NamedElementToGenerate.Name)
             {
-                builderCallString = $"Build{chainNonTerminal.Name}({chainVarName}, cursorCache, stringBuilder);";
+                builderCallString = $"Build{chainNonTerminal.Name}({chainVarName}, writerContext, stringBuilder);";
             }
             else
             {
-                builderCallString = $"{typeTarget}TextualNotationBuilder.Build{chainNonTerminal.Name}({chainVarName}, cursorCache, stringBuilder);";
+                builderCallString = $"{typeTarget}TextualNotationBuilder.Build{chainNonTerminal.Name}({chainVarName}, writerContext, stringBuilder);";
             }
 
             writer.WriteSafeString($"if ({variableName}.{resolvedContainmentName}.Contains({variableName}.{resolvedPropertyName}) && {variableName}.{resolvedPropertyName} is {chainTypeName} {chainVarName}){Environment.NewLine}");
@@ -691,7 +691,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
             writer.WriteSafeString($"}}{Environment.NewLine}");
             writer.WriteSafeString($"else if ({variableName}.{resolvedPropertyName} != null){Environment.NewLine}");
             writer.WriteSafeString($"{{{Environment.NewLine}");
-            writer.WriteSafeString($"SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder,{variableName}.{resolvedPropertyName});{Environment.NewLine}");
+            writer.WriteSafeString($"SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder,{variableName}.{resolvedPropertyName}, writerContext);{Environment.NewLine}");
             writer.WriteSafeString($"stringBuilder.Append(' ');{Environment.NewLine}");
             writer.WriteSafeString($"}}{Environment.NewLine}");
 
@@ -760,7 +760,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
             if (targetProperty != null)
             {
                 var bodyPropertyAccess = targetProperty.QueryPropertyNameBasedOnUmlProperties();
-                writer.WriteSafeString($"if(cursorCache.GetOrCreateCursor(poco.Id, \"{targetProperty.Name}\", poco.{bodyPropertyAccess}).Current == null){Environment.NewLine}");
+                writer.WriteSafeString($"if(writerContext.CursorCache.GetOrCreateCursor(poco.Id, \"{targetProperty.Name}\", poco.{bodyPropertyAccess}).Current == null){Environment.NewLine}");
 
                 writer.WriteSafeString($"{{{Environment.NewLine}");
                 writer.WriteSafeString($"stringBuilder.AppendLine(\"{terminalValue}\");{Environment.NewLine}");
@@ -821,7 +821,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
             var propertyAccessName = targetProperty.QueryPropertyNameBasedOnUmlProperties();
 
-            writer.WriteSafeString($"if(cursorCache.GetOrCreateCursor(poco.Id, \"{targetProperty.Name}\", poco.{propertyAccessName}).Current == null){Environment.NewLine}");
+            writer.WriteSafeString($"if(writerContext.CursorCache.GetOrCreateCursor(poco.Id, \"{targetProperty.Name}\", poco.{propertyAccessName}).Current == null){Environment.NewLine}");
 
             writer.WriteSafeString($"{{{Environment.NewLine}");
             writer.WriteSafeString($"stringBuilder.AppendLine(\"{terminalValue}\");{Environment.NewLine}");
@@ -834,7 +834,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                 if (element is NonTerminalElement { IsCollection: true })
                 {
                     var cursorVarName = $"{targetProperty.Name.LowerCaseFirstLetter()}Cursor";
-                    writer.WriteSafeString($"var {cursorVarName} = cursorCache.GetOrCreateCursor(poco.Id, \"{targetProperty.Name}\", poco.{propertyAccessName});{Environment.NewLine}");
+                    writer.WriteSafeString($"var {cursorVarName} = writerContext.CursorCache.GetOrCreateCursor(poco.Id, \"{targetProperty.Name}\", poco.{propertyAccessName});{Environment.NewLine}");
 
                     var collectionNonTerminal = (NonTerminalElement)element;
                     var referencedRule = ruleGenerationContext.FindRule(collectionNonTerminal.Name);
@@ -910,7 +910,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
             var propertyAccessName = targetProperty.QueryPropertyNameBasedOnUmlProperties();
 
-            writer.WriteSafeString($"if(cursorCache.GetOrCreateCursor(poco.Id, \"{targetProperty.Name}\", poco.{propertyAccessName}).Current == null){Environment.NewLine}");
+            writer.WriteSafeString($"if(writerContext.CursorCache.GetOrCreateCursor(poco.Id, \"{targetProperty.Name}\", poco.{propertyAccessName}).Current == null){Environment.NewLine}");
 
             writer.WriteSafeString($"{{{Environment.NewLine}");
             writer.WriteSafeString($"stringBuilder.AppendLine(\"{terminalValue}\");{Environment.NewLine}");
@@ -923,7 +923,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                 if (element is NonTerminalElement { IsCollection: false } singleNonTerminal)
                 {
                     var cursorVarName = $"{targetProperty.Name.LowerCaseFirstLetter()}Cursor";
-                    writer.WriteSafeString($"var {cursorVarName} = cursorCache.GetOrCreateCursor(poco.Id, \"{targetProperty.Name}\", poco.{propertyAccessName});{Environment.NewLine}");
+                    writer.WriteSafeString($"var {cursorVarName} = writerContext.CursorCache.GetOrCreateCursor(poco.Id, \"{targetProperty.Name}\", poco.{propertyAccessName});{Environment.NewLine}");
 
                     var referencedRule = ruleGenerationContext.FindRule(singleNonTerminal.Name);
 

--- a/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleQueryUtilities.cs
+++ b/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleQueryUtilities.cs
@@ -1,20 +1,20 @@
 // -------------------------------------------------------------------------------------------------
 // <copyright file="RuleQueryUtilities.cs" company="Starion Group S.A.">
-//
+// 
 //   Copyright 2022-2026 Starion Group S.A.
-//
+// 
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
-//
+// 
 //        http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 //    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-//
+// 
 // </copyright>
 // ------------------------------------------------------------------------------------------------
 

--- a/SysML2.NET.CodeGenerator/HandleBarHelpers/TerminalWriter.cs
+++ b/SysML2.NET.CodeGenerator/HandleBarHelpers/TerminalWriter.cs
@@ -1,20 +1,20 @@
 // -------------------------------------------------------------------------------------------------
 // <copyright file="TerminalWriter.cs" company="Starion Group S.A.">
-//
+// 
 //   Copyright 2022-2026 Starion Group S.A.
-//
+// 
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
-//
+// 
 //        http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 //    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-//
+// 
 // </copyright>
 // ------------------------------------------------------------------------------------------------
 

--- a/SysML2.NET.CodeGenerator/Templates/Uml/core-textual-notation-builder-template.hbs
+++ b/SysML2.NET.CodeGenerator/Templates/Uml/core-textual-notation-builder-template.hbs
@@ -40,9 +40,9 @@ namespace SysML2.NET.TextualNotation
             /// <para>{{Rule.RawRule}}</para>
             /// </summary>
             /// <param name="poco">The <see cref="{{ #NamedElement.WriteFullyQualifiedTypeName ../this.Context }}" /> from which the rule should be build</param>
-            /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+            /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
             /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-            public static void Build{{rule.RuleName}}({{ #NamedElement.WriteFullyQualifiedTypeName ../this.Context }} poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+            public static void Build{{rule.RuleName}}({{ #NamedElement.WriteFullyQualifiedTypeName ../this.Context }} poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
             {
                 {{RulesHelper.WriteRule rule ../this.Context ../this.AllRules}}
             }

--- a/SysML2.NET.CodeGenerator/Templates/Uml/core-textual-notation-shared-builder-template.hbs
+++ b/SysML2.NET.CodeGenerator/Templates/Uml/core-textual-notation-shared-builder-template.hbs
@@ -43,9 +43,9 @@ namespace SysML2.NET.TextualNotation
             /// <para>{{entry.Rule.RawRule}}</para>
             /// </summary>
             /// <param name="poco">The <see cref="{{ #NamedElement.WriteFullyQualifiedTypeName entry.TargetClass }}" /> from which the rule should be build</param>
-            /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+            /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
             /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-            public static void Build{{entry.Rule.RuleName}}({{ #NamedElement.WriteFullyQualifiedTypeName entry.TargetClass }} poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+            public static void Build{{entry.Rule.RuleName}}({{ #NamedElement.WriteFullyQualifiedTypeName entry.TargetClass }} poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
             {
                 {{RulesHelper.WriteRule entry.Rule entry.TargetClass ../this.AllRules}}
             }

--- a/SysML2.NET.Tests/TextualNotation/TextualNotationBuilderTestFixture.cs
+++ b/SysML2.NET.Tests/TextualNotation/TextualNotationBuilderTestFixture.cs
@@ -107,6 +107,7 @@ namespace SysML2.NET.Tests.TextualNotation
                 Assert.That(textualNotation, Does.Contain("library"));
                 Assert.That(textualNotation, Does.Contain("package"));
                 Assert.That(textualNotation, Does.Contain("Quantities"));
+                Assert.That(textualNotation, Does.Contain("private import ScalarValues::NumericalValue"));
             });
         }
     }

--- a/SysML2.NET.Tests/TextualNotation/TextualNotationBuilderTestFixture.cs
+++ b/SysML2.NET.Tests/TextualNotation/TextualNotationBuilderTestFixture.cs
@@ -81,12 +81,12 @@ namespace SysML2.NET.Tests.TextualNotation
         [Test]
         public void Verify_that_textual_notation_is_produced_from_Quantities_root_namespace()
         {
-            using var cursorCache = new CursorCache();
+            using var writerContext = new TextualNotationWriterContext(this.rootNamespace);
             var stringBuilder = new StringBuilder();
 
             try
             {
-                NamespaceTextualNotationBuilder.BuildRootNamespace(this.rootNamespace, cursorCache, stringBuilder);
+                NamespaceTextualNotationBuilder.BuildRootNamespace(this.rootNamespace, writerContext, stringBuilder);
             }
             catch (System.NotSupportedException notSupportedException)
             {
@@ -108,6 +108,7 @@ namespace SysML2.NET.Tests.TextualNotation
                 Assert.That(textualNotation, Does.Contain("package"));
                 Assert.That(textualNotation, Does.Contain("Quantities"));
                 Assert.That(textualNotation, Does.Contain("private import ScalarValues::NumericalValue"));
+                Assert.That(textualNotation, Does.Contain("isBound: Boolean"));
             });
         }
     }

--- a/SysML2.NET.Tests/TextualNotation/TextualNotationBuilderTestFixture.cs
+++ b/SysML2.NET.Tests/TextualNotation/TextualNotationBuilderTestFixture.cs
@@ -22,6 +22,7 @@ namespace SysML2.NET.Tests.TextualNotation
 {
     using System;
     using System.IO;
+    using System.Linq;
     using System.Text;
 
     using Microsoft.Extensions.Logging;
@@ -76,7 +77,7 @@ namespace SysML2.NET.Tests.TextualNotation
                 Assert.That(this.rootNamespace.Id, Is.EqualTo(Guid.Parse("88e753b3-e75d-525f-b9ad-d5e9095b98ec")));
             });
         }
-
+        
         [Test]
         public void Verify_that_textual_notation_is_produced_from_Quantities_root_namespace()
         {

--- a/SysML2.NET/TextualNotation/AllocationUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AllocationUsageTextualNotationBuilder.cs
@@ -36,7 +36,7 @@ namespace SysML2.NET.TextualNotation
         /// Builds the Textual Notation string for the rule AllocationUsageDeclaration
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Allocations.IAllocationUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         /// <remarks>
         /// AllocationUsageDeclaration : AllocationUsage =
@@ -45,9 +45,9 @@ namespace SysML2.NET.TextualNotation
         ///
         /// Auto-gen delegates entirely to this method.
         /// </remarks>
-        private static void BuildAllocationUsageDeclarationHandCoded(IAllocationUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildAllocationUsageDeclarationHandCoded(IAllocationUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             var hasDeclaration = !string.IsNullOrWhiteSpace(poco.DeclaredShortName)
                                  || !string.IsNullOrWhiteSpace(poco.DeclaredName)
@@ -58,19 +58,19 @@ namespace SysML2.NET.TextualNotation
             {
                 // Alt 1: 'allocation' UsageDeclaration ('allocate' ConnectorPart)?
                 stringBuilder.Append("allocation ");
-                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
 
                 if (poco.OwnedRelationship.OfType<IEndFeatureMembership>().Any())
                 {
                     stringBuilder.Append("allocate ");
-                    ConnectionUsageTextualNotationBuilder.BuildConnectorPart(poco, cursorCache, stringBuilder);
+                    ConnectionUsageTextualNotationBuilder.BuildConnectorPart(poco, writerContext, stringBuilder);
                 }
             }
             else
             {
                 // Alt 2: 'allocate' ConnectorPart
                 stringBuilder.Append("allocate ");
-                ConnectionUsageTextualNotationBuilder.BuildConnectorPart(poco, cursorCache, stringBuilder);
+                ConnectionUsageTextualNotationBuilder.BuildConnectorPart(poco, writerContext, stringBuilder);
             }
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AcceptActionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AcceptActionUsageTextualNotationBuilder.cs
@@ -39,13 +39,13 @@ namespace SysML2.NET.TextualNotation
         /// <para>AcceptNode:AcceptActionUsage=OccurrenceUsagePrefixAcceptNodeDeclarationActionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildAcceptNode(SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildAcceptNode(SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
-            BuildAcceptNodeDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildActionBody(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
+            BuildAcceptNodeDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildActionBody(poco, writerContext, stringBuilder);
 
         }
 
@@ -54,17 +54,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>AcceptNodeDeclaration:AcceptActionUsage=ActionNodeUsageDeclaration?'accept'AcceptParameterPart</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildAcceptNodeDeclaration(SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildAcceptNodeDeclaration(SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
             {
-                ActionUsageTextualNotationBuilder.BuildActionNodeUsageDeclaration(poco, cursorCache, stringBuilder);
+                ActionUsageTextualNotationBuilder.BuildActionNodeUsageDeclaration(poco, writerContext, stringBuilder);
             }
             stringBuilder.Append("accept ");
-            BuildAcceptParameterPart(poco, cursorCache, stringBuilder);
+            BuildAcceptParameterPart(poco, writerContext, stringBuilder);
 
         }
 
@@ -73,18 +73,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>AcceptParameterPart:AcceptActionUsage=ownedRelationship+=PayloadParameterMember('via'ownedRelationship+=NodeParameterMember)?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildAcceptParameterPart(SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildAcceptParameterPart(SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildPayloadParameterMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildPayloadParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -99,11 +99,11 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                     {
-                        ParameterMembershipTextualNotationBuilder.BuildNodeParameterMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                        ParameterMembershipTextualNotationBuilder.BuildNodeParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
             }
 
 
@@ -114,12 +114,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>StateAcceptActionUsage:AcceptActionUsage=AcceptNodeDeclarationActionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildStateAcceptActionUsage(SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildStateAcceptActionUsage(SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildAcceptNodeDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildActionBody(poco, cursorCache, stringBuilder);
+            BuildAcceptNodeDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildActionBody(poco, writerContext, stringBuilder);
 
         }
 
@@ -128,11 +128,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>TriggerAction:AcceptActionUsage=AcceptParameterPart</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTriggerAction(SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTriggerAction(SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildAcceptParameterPart(poco, cursorCache, stringBuilder);
+            BuildAcceptParameterPart(poco, writerContext, stringBuilder);
 
         }
 
@@ -141,20 +141,20 @@ namespace SysML2.NET.TextualNotation
         /// <para>TransitionAcceptActionUsage:AcceptActionUsage=AcceptNodeDeclaration('{'ActionBodyItem*'}')?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTransitionAcceptActionUsage(SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTransitionAcceptActionUsage(SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildAcceptNodeDeclaration(poco, cursorCache, stringBuilder);
+            BuildAcceptNodeDeclaration(poco, writerContext, stringBuilder);
 
             if (poco.OwnedRelationship.Count != 0 || poco.importedMembership.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsVariation || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.isReference || poco.IsIndividual || poco.PortionKind.HasValue || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
-                var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 while (ownedRelationshipCursor.Current != null)
                 {
-                    TypeTextualNotationBuilder.BuildActionBodyItem(poco, cursorCache, stringBuilder);
+                    TypeTextualNotationBuilder.BuildActionBodyItem(poco, writerContext, stringBuilder);
                 }
 
                 stringBuilder.AppendLine("}");

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ActionDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ActionDefinitionTextualNotationBuilder.cs
@@ -39,15 +39,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>ActionDefinition=OccurrenceDefinitionPrefix'action''def'DefinitionDeclarationActionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IActionDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildActionDefinition(SysML2.NET.Core.POCO.Systems.Actions.IActionDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildActionDefinition(SysML2.NET.Core.POCO.Systems.Actions.IActionDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, cursorCache, stringBuilder);
+            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("action ");
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildActionBody(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildActionBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ActionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ActionUsageTextualNotationBuilder.cs
@@ -39,15 +39,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>ActionUsageDeclaration:ActionUsage=UsageDeclarationValuePart?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildActionUsageDeclaration(SysML2.NET.Core.POCO.Systems.Actions.IActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildActionUsageDeclaration(SysML2.NET.Core.POCO.Systems.Actions.IActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
 
             if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
-                FeatureTextualNotationBuilder.BuildValuePart(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }
 
         }
@@ -57,35 +57,35 @@ namespace SysML2.NET.TextualNotation
         /// <para>ActionNode:ActionUsage=ControlNode|SendNode|AcceptNode|AssignmentNode|TerminateNode|IfNode|WhileLoopNode|ForLoopNode</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildActionNode(SysML2.NET.Core.POCO.Systems.Actions.IActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildActionNode(SysML2.NET.Core.POCO.Systems.Actions.IActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Systems.Actions.IWhileLoopActionUsage pocoWhileLoopActionUsage:
-                    WhileLoopActionUsageTextualNotationBuilder.BuildWhileLoopNode(pocoWhileLoopActionUsage, cursorCache, stringBuilder);
+                    WhileLoopActionUsageTextualNotationBuilder.BuildWhileLoopNode(pocoWhileLoopActionUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Actions.IForLoopActionUsage pocoForLoopActionUsage:
-                    ForLoopActionUsageTextualNotationBuilder.BuildForLoopNode(pocoForLoopActionUsage, cursorCache, stringBuilder);
+                    ForLoopActionUsageTextualNotationBuilder.BuildForLoopNode(pocoForLoopActionUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Actions.IControlNode pocoControlNode:
-                    ControlNodeTextualNotationBuilder.BuildControlNode(pocoControlNode, cursorCache, stringBuilder);
+                    ControlNodeTextualNotationBuilder.BuildControlNode(pocoControlNode, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Actions.ISendActionUsage pocoSendActionUsage:
-                    SendActionUsageTextualNotationBuilder.BuildSendNode(pocoSendActionUsage, cursorCache, stringBuilder);
+                    SendActionUsageTextualNotationBuilder.BuildSendNode(pocoSendActionUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage pocoAcceptActionUsage:
-                    AcceptActionUsageTextualNotationBuilder.BuildAcceptNode(pocoAcceptActionUsage, cursorCache, stringBuilder);
+                    AcceptActionUsageTextualNotationBuilder.BuildAcceptNode(pocoAcceptActionUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Actions.IAssignmentActionUsage pocoAssignmentActionUsage:
-                    AssignmentActionUsageTextualNotationBuilder.BuildAssignmentNode(pocoAssignmentActionUsage, cursorCache, stringBuilder);
+                    AssignmentActionUsageTextualNotationBuilder.BuildAssignmentNode(pocoAssignmentActionUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Actions.ITerminateActionUsage pocoTerminateActionUsage:
-                    TerminateActionUsageTextualNotationBuilder.BuildTerminateNode(pocoTerminateActionUsage, cursorCache, stringBuilder);
+                    TerminateActionUsageTextualNotationBuilder.BuildTerminateNode(pocoTerminateActionUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Actions.IIfActionUsage pocoIfActionUsage:
-                    IfActionUsageTextualNotationBuilder.BuildIfNode(pocoIfActionUsage, cursorCache, stringBuilder);
+                    IfActionUsageTextualNotationBuilder.BuildIfNode(pocoIfActionUsage, writerContext, stringBuilder);
                     break;
             }
 
@@ -96,15 +96,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>ActionNodeUsageDeclaration:ActionUsage='action'UsageDeclaration?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildActionNodeUsageDeclaration(SysML2.NET.Core.POCO.Systems.Actions.IActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildActionNodeUsageDeclaration(SysML2.NET.Core.POCO.Systems.Actions.IActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             stringBuilder.Append("action ");
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
             {
-                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
             }
 
         }
@@ -114,15 +114,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>ActionNodePrefix:ActionUsage=OccurrenceUsagePrefixActionNodeUsageDeclaration?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildActionNodePrefix(SysML2.NET.Core.POCO.Systems.Actions.IActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildActionNodePrefix(SysML2.NET.Core.POCO.Systems.Actions.IActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
             {
-                BuildActionNodeUsageDeclaration(poco, cursorCache, stringBuilder);
+                BuildActionNodeUsageDeclaration(poco, writerContext, stringBuilder);
             }
 
         }
@@ -132,15 +132,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>AssignmentNodeDeclaration:ActionUsage=(ActionNodeUsageDeclaration)?'assign'ownedRelationship+=AssignmentTargetMemberownedRelationship+=FeatureChainMember':='ownedRelationship+=NodeParameterMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildAssignmentNodeDeclaration(SysML2.NET.Core.POCO.Systems.Actions.IActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildAssignmentNodeDeclaration(SysML2.NET.Core.POCO.Systems.Actions.IActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
             {
-                BuildActionNodeUsageDeclaration(poco, cursorCache, stringBuilder);
+                BuildActionNodeUsageDeclaration(poco, writerContext, stringBuilder);
                 stringBuilder.Append(' ');
             }
 
@@ -151,7 +151,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildAssignmentTargetMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildAssignmentTargetMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -162,7 +162,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership elementAsMembership)
                 {
-                    MembershipTextualNotationBuilder.BuildFeatureChainMember(elementAsMembership, cursorCache, stringBuilder);
+                    MembershipTextualNotationBuilder.BuildFeatureChainMember(elementAsMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -174,7 +174,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildNodeParameterMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildNodeParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -187,9 +187,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>ActionBodyParameter:ActionUsage=('action'UsageDeclaration?)?'{'ActionBodyItem*'}'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildActionBodyParameter(SysML2.NET.Core.POCO.Systems.Actions.IActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildActionBodyParameter(SysML2.NET.Core.POCO.Systems.Actions.IActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
@@ -198,16 +198,16 @@ namespace SysML2.NET.TextualNotation
 
                 if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
                 {
-                    UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
+                    UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
                 }
             }
 
             stringBuilder.Append(' ');
             stringBuilder.AppendLine("{");
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             while (ownedRelationshipCursor.Current != null)
             {
-                TypeTextualNotationBuilder.BuildActionBodyItem(poco, cursorCache, stringBuilder);
+                TypeTextualNotationBuilder.BuildActionBodyItem(poco, writerContext, stringBuilder);
             }
 
             stringBuilder.AppendLine("}");
@@ -219,26 +219,26 @@ namespace SysML2.NET.TextualNotation
         /// <para>StateActionUsage:ActionUsage=EmptyActionUsage';'|StatePerformActionUsage|StateAcceptActionUsage|StateSendActionUsage|StateAssignmentActionUsage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildStateActionUsage(SysML2.NET.Core.POCO.Systems.Actions.IActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildStateActionUsage(SysML2.NET.Core.POCO.Systems.Actions.IActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Systems.Actions.IPerformActionUsage pocoPerformActionUsage:
-                    PerformActionUsageTextualNotationBuilder.BuildStatePerformActionUsage(pocoPerformActionUsage, cursorCache, stringBuilder);
+                    PerformActionUsageTextualNotationBuilder.BuildStatePerformActionUsage(pocoPerformActionUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage pocoAcceptActionUsage:
-                    AcceptActionUsageTextualNotationBuilder.BuildStateAcceptActionUsage(pocoAcceptActionUsage, cursorCache, stringBuilder);
+                    AcceptActionUsageTextualNotationBuilder.BuildStateAcceptActionUsage(pocoAcceptActionUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Actions.ISendActionUsage pocoSendActionUsage:
-                    SendActionUsageTextualNotationBuilder.BuildStateSendActionUsage(pocoSendActionUsage, cursorCache, stringBuilder);
+                    SendActionUsageTextualNotationBuilder.BuildStateSendActionUsage(pocoSendActionUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Actions.IAssignmentActionUsage pocoAssignmentActionUsage:
-                    AssignmentActionUsageTextualNotationBuilder.BuildStateAssignmentActionUsage(pocoAssignmentActionUsage, cursorCache, stringBuilder);
+                    AssignmentActionUsageTextualNotationBuilder.BuildStateAssignmentActionUsage(pocoAssignmentActionUsage, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildEmptyActionUsage(poco, cursorCache, stringBuilder);
+                    BuildEmptyActionUsage(poco, writerContext, stringBuilder);
                     stringBuilder.AppendLine(";");
                     break;
             }
@@ -250,9 +250,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>EmptyActionUsage:ActionUsage={}</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildEmptyActionUsage(SysML2.NET.Core.POCO.Systems.Actions.IActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildEmptyActionUsage(SysML2.NET.Core.POCO.Systems.Actions.IActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
         }
@@ -262,26 +262,26 @@ namespace SysML2.NET.TextualNotation
         /// <para>EffectBehaviorUsage:ActionUsage=EmptyActionUsage|TransitionPerformActionUsage|TransitionAcceptActionUsage|TransitionSendActionUsage|TransitionAssignmentActionUsage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildEffectBehaviorUsage(SysML2.NET.Core.POCO.Systems.Actions.IActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildEffectBehaviorUsage(SysML2.NET.Core.POCO.Systems.Actions.IActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Systems.Actions.IPerformActionUsage pocoPerformActionUsage:
-                    PerformActionUsageTextualNotationBuilder.BuildTransitionPerformActionUsage(pocoPerformActionUsage, cursorCache, stringBuilder);
+                    PerformActionUsageTextualNotationBuilder.BuildTransitionPerformActionUsage(pocoPerformActionUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage pocoAcceptActionUsage:
-                    AcceptActionUsageTextualNotationBuilder.BuildTransitionAcceptActionUsage(pocoAcceptActionUsage, cursorCache, stringBuilder);
+                    AcceptActionUsageTextualNotationBuilder.BuildTransitionAcceptActionUsage(pocoAcceptActionUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Actions.ISendActionUsage pocoSendActionUsage:
-                    SendActionUsageTextualNotationBuilder.BuildTransitionSendActionUsage(pocoSendActionUsage, cursorCache, stringBuilder);
+                    SendActionUsageTextualNotationBuilder.BuildTransitionSendActionUsage(pocoSendActionUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Actions.IAssignmentActionUsage pocoAssignmentActionUsage:
-                    AssignmentActionUsageTextualNotationBuilder.BuildTransitionAssignmentActionUsage(pocoAssignmentActionUsage, cursorCache, stringBuilder);
+                    AssignmentActionUsageTextualNotationBuilder.BuildTransitionAssignmentActionUsage(pocoAssignmentActionUsage, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildEmptyActionUsage(poco, cursorCache, stringBuilder);
+                    BuildEmptyActionUsage(poco, writerContext, stringBuilder);
                     break;
             }
 
@@ -292,14 +292,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>ActionUsage=OccurrenceUsagePrefix'action'ActionUsageDeclarationActionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildActionUsage(SysML2.NET.Core.POCO.Systems.Actions.IActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildActionUsage(SysML2.NET.Core.POCO.Systems.Actions.IActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("action ");
-            BuildActionUsageDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildActionBody(poco, cursorCache, stringBuilder);
+            BuildActionUsageDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildActionBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ActorMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ActorMembershipTextualNotationBuilder.cs
@@ -39,19 +39,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>ActorMember:ActorMembership=MemberPrefixownedRelatedElement+=ActorUsage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.IActorMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildActorMember(SysML2.NET.Core.POCO.Systems.Requirements.IActorMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildActorMember(SysML2.NET.Core.POCO.Systems.Requirements.IActorMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Parts.IPartUsage elementAsPartUsage)
                 {
-                    PartUsageTextualNotationBuilder.BuildActorUsage(elementAsPartUsage, cursorCache, stringBuilder);
+                    PartUsageTextualNotationBuilder.BuildActorUsage(elementAsPartUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AllocationDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AllocationDefinitionTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>AllocationDefinition=OccurrenceDefinitionPrefix'allocation''def'Definition</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Allocations.IAllocationDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildAllocationDefinition(SysML2.NET.Core.POCO.Systems.Allocations.IAllocationDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildAllocationDefinition(SysML2.NET.Core.POCO.Systems.Allocations.IAllocationDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, cursorCache, stringBuilder);
+            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("allocation ");
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinition(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinition(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AllocationUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AllocationUsageTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>AllocationUsageDeclaration:AllocationUsage='allocation'UsageDeclaration('allocate'ConnectorPart)?|'allocate'ConnectorPart</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Allocations.IAllocationUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildAllocationUsageDeclaration(SysML2.NET.Core.POCO.Systems.Allocations.IAllocationUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildAllocationUsageDeclaration(SysML2.NET.Core.POCO.Systems.Allocations.IAllocationUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildAllocationUsageDeclarationHandCoded(poco, cursorCache, stringBuilder);
+            BuildAllocationUsageDeclarationHandCoded(poco, writerContext, stringBuilder);
         }
 
         /// <summary>
@@ -51,13 +51,13 @@ namespace SysML2.NET.TextualNotation
         /// <para>AllocationUsage=OccurrenceUsagePrefixAllocationUsageDeclarationUsageBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Allocations.IAllocationUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildAllocationUsage(SysML2.NET.Core.POCO.Systems.Allocations.IAllocationUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildAllocationUsage(SysML2.NET.Core.POCO.Systems.Allocations.IAllocationUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
-            BuildAllocationUsageDeclaration(poco, cursorCache, stringBuilder);
-            UsageTextualNotationBuilder.BuildUsageBody(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
+            BuildAllocationUsageDeclaration(poco, writerContext, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsageBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AnalysisCaseDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AnalysisCaseDefinitionTextualNotationBuilder.cs
@@ -39,15 +39,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>AnalysisCaseDefinition=OccurrenceDefinitionPrefix'analysis''def'DefinitionDeclarationCaseBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.AnalysisCases.IAnalysisCaseDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildAnalysisCaseDefinition(SysML2.NET.Core.POCO.Systems.AnalysisCases.IAnalysisCaseDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildAnalysisCaseDefinition(SysML2.NET.Core.POCO.Systems.AnalysisCases.IAnalysisCaseDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, cursorCache, stringBuilder);
+            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("analysis ");
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildCaseBody(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildCaseBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AnalysisCaseUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AnalysisCaseUsageTextualNotationBuilder.cs
@@ -39,20 +39,20 @@ namespace SysML2.NET.TextualNotation
         /// <para>AnalysisCaseUsage=OccurrenceUsagePrefix'analysis'ConstraintUsageDeclarationCaseBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.AnalysisCases.IAnalysisCaseUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildAnalysisCaseUsage(SysML2.NET.Core.POCO.Systems.AnalysisCases.IAnalysisCaseUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildAnalysisCaseUsage(SysML2.NET.Core.POCO.Systems.AnalysisCases.IAnalysisCaseUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("analysis ");
-            UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
 
             if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
-                FeatureTextualNotationBuilder.BuildValuePart(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }
 
-            TypeTextualNotationBuilder.BuildCaseBody(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildCaseBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AnnotatingElementTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AnnotatingElementTextualNotationBuilder.cs
@@ -39,23 +39,23 @@ namespace SysML2.NET.TextualNotation
         /// <para>AnnotatingElement=Comment|Documentation|TextualRepresentation|MetadataFeature</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Annotations.IAnnotatingElement" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildAnnotatingElement(SysML2.NET.Core.POCO.Root.Annotations.IAnnotatingElement poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildAnnotatingElement(SysML2.NET.Core.POCO.Root.Annotations.IAnnotatingElement poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Kernel.Metadata.IMetadataFeature pocoMetadataFeature:
-                    MetadataFeatureTextualNotationBuilder.BuildMetadataFeature(pocoMetadataFeature, cursorCache, stringBuilder);
+                    MetadataFeatureTextualNotationBuilder.BuildMetadataFeature(pocoMetadataFeature, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Root.Annotations.IDocumentation pocoDocumentation:
-                    DocumentationTextualNotationBuilder.BuildDocumentation(pocoDocumentation, cursorCache, stringBuilder);
+                    DocumentationTextualNotationBuilder.BuildDocumentation(pocoDocumentation, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Root.Annotations.IComment pocoComment:
-                    CommentTextualNotationBuilder.BuildComment(pocoComment, cursorCache, stringBuilder);
+                    CommentTextualNotationBuilder.BuildComment(pocoComment, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Root.Annotations.ITextualRepresentation pocoTextualRepresentation:
-                    TextualRepresentationTextualNotationBuilder.BuildTextualRepresentation(pocoTextualRepresentation, cursorCache, stringBuilder);
+                    TextualRepresentationTextualNotationBuilder.BuildTextualRepresentation(pocoTextualRepresentation, writerContext, stringBuilder);
                     break;
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AnnotationTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AnnotationTextualNotationBuilder.cs
@@ -39,18 +39,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedAnnotation:Annotation=ownedRelatedElement+=AnnotatingElement</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Annotations.IAnnotation" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedAnnotation(SysML2.NET.Core.POCO.Root.Annotations.IAnnotation poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedAnnotation(SysML2.NET.Core.POCO.Root.Annotations.IAnnotation poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Root.Annotations.IAnnotatingElement elementAsAnnotatingElement)
                 {
-                    AnnotatingElementTextualNotationBuilder.BuildAnnotatingElement(elementAsAnnotatingElement, cursorCache, stringBuilder);
+                    AnnotatingElementTextualNotationBuilder.BuildAnnotatingElement(elementAsAnnotatingElement, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -63,9 +63,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>PrefixMetadataAnnotation:Annotation='#'annotatingElement=PrefixMetadataUsage{ownedRelatedElement+=annotatingElement}</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Annotations.IAnnotation" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPrefixMetadataAnnotation(SysML2.NET.Core.POCO.Root.Annotations.IAnnotation poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPrefixMetadataAnnotation(SysML2.NET.Core.POCO.Root.Annotations.IAnnotation poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             stringBuilder.Append("#");
 
@@ -74,7 +74,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (poco.annotatingElement is SysML2.NET.Core.POCO.Systems.Metadata.IMetadataUsage elementAsMetadataUsage)
                 {
-                    MetadataUsageTextualNotationBuilder.BuildPrefixMetadataUsage(elementAsMetadataUsage, cursorCache, stringBuilder);
+                    MetadataUsageTextualNotationBuilder.BuildPrefixMetadataUsage(elementAsMetadataUsage, writerContext, stringBuilder);
                 }
             }
             // NonParsing Assignment Element : ownedRelatedElement += annotatingElement => Does not have to be process
@@ -86,14 +86,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>Annotation=annotatedElement=[QualifiedName]</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Annotations.IAnnotation" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildAnnotation(SysML2.NET.Core.POCO.Root.Annotations.IAnnotation poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildAnnotation(SysML2.NET.Core.POCO.Root.Annotations.IAnnotation poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.AnnotatedElement != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.AnnotatedElement);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.AnnotatedElement, writerContext);
                 stringBuilder.Append(' ');
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AnnotationTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AnnotationTextualNotationBuilder.cs
@@ -93,7 +93,7 @@ namespace SysML2.NET.TextualNotation
 
             if (poco.AnnotatedElement != null)
             {
-                stringBuilder.Append(poco.AnnotatedElement.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.AnnotatedElement);
                 stringBuilder.Append(' ');
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AssertConstraintUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AssertConstraintUsageTextualNotationBuilder.cs
@@ -39,12 +39,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>AssertConstraintUsage=OccurrenceUsagePrefix'assert'(isNegated?='not')?(ownedRelationship+=OwnedReferenceSubsettingFeatureSpecializationPart?|'constraint'ConstraintUsageDeclaration)CalculationBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Constraints.IAssertConstraintUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildAssertConstraintUsage(SysML2.NET.Core.POCO.Systems.Constraints.IAssertConstraintUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildAssertConstraintUsage(SysML2.NET.Core.POCO.Systems.Constraints.IAssertConstraintUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("assert ");
 
             if (poco.IsNegated)
@@ -61,7 +61,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting elementAsReferenceSubsetting)
                     {
-                        ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, cursorCache, stringBuilder);
+                        ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -69,17 +69,17 @@ namespace SysML2.NET.TextualNotation
 
                 if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
                 {
-                    FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, cursorCache, stringBuilder);
+                    FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, writerContext, stringBuilder);
                 }
             }
             else
             {
                 stringBuilder.Append("constraint ");
-                ConstraintUsageTextualNotationBuilder.BuildConstraintUsageDeclaration(poco, cursorCache, stringBuilder);
+                ConstraintUsageTextualNotationBuilder.BuildConstraintUsageDeclaration(poco, writerContext, stringBuilder);
             }
 
             stringBuilder.Append(' ');
-            TypeTextualNotationBuilder.BuildCalculationBody(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildCalculationBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AssignmentActionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AssignmentActionUsageTextualNotationBuilder.cs
@@ -39,13 +39,13 @@ namespace SysML2.NET.TextualNotation
         /// <para>AssignmentNode:AssignmentActionUsage=OccurrenceUsagePrefixAssignmentNodeDeclarationActionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IAssignmentActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildAssignmentNode(SysML2.NET.Core.POCO.Systems.Actions.IAssignmentActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildAssignmentNode(SysML2.NET.Core.POCO.Systems.Actions.IAssignmentActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
-            ActionUsageTextualNotationBuilder.BuildAssignmentNodeDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildActionBody(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
+            ActionUsageTextualNotationBuilder.BuildAssignmentNodeDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildActionBody(poco, writerContext, stringBuilder);
 
         }
 
@@ -54,12 +54,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>StateAssignmentActionUsage:AssignmentActionUsage=AssignmentNodeDeclarationActionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IAssignmentActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildStateAssignmentActionUsage(SysML2.NET.Core.POCO.Systems.Actions.IAssignmentActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildStateAssignmentActionUsage(SysML2.NET.Core.POCO.Systems.Actions.IAssignmentActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            ActionUsageTextualNotationBuilder.BuildAssignmentNodeDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildActionBody(poco, cursorCache, stringBuilder);
+            ActionUsageTextualNotationBuilder.BuildAssignmentNodeDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildActionBody(poco, writerContext, stringBuilder);
 
         }
 
@@ -68,20 +68,20 @@ namespace SysML2.NET.TextualNotation
         /// <para>TransitionAssignmentActionUsage:AssignmentActionUsage=AssignmentNodeDeclaration('{'ActionBodyItem*'}')?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IAssignmentActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTransitionAssignmentActionUsage(SysML2.NET.Core.POCO.Systems.Actions.IAssignmentActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTransitionAssignmentActionUsage(SysML2.NET.Core.POCO.Systems.Actions.IAssignmentActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            ActionUsageTextualNotationBuilder.BuildAssignmentNodeDeclaration(poco, cursorCache, stringBuilder);
+            ActionUsageTextualNotationBuilder.BuildAssignmentNodeDeclaration(poco, writerContext, stringBuilder);
 
             if (poco.OwnedRelationship.Count != 0 || poco.importedMembership.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsVariation || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.isReference || poco.IsIndividual || poco.PortionKind.HasValue || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
-                var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 while (ownedRelationshipCursor.Current != null)
                 {
-                    TypeTextualNotationBuilder.BuildActionBodyItem(poco, cursorCache, stringBuilder);
+                    TypeTextualNotationBuilder.BuildActionBodyItem(poco, writerContext, stringBuilder);
                 }
 
                 stringBuilder.AppendLine("}");

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AssociationStructureTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AssociationStructureTextualNotationBuilder.cs
@@ -39,15 +39,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>AssociationStructure=TypePrefix'assoc''struct'ClassifierDeclarationTypeBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Associations.IAssociationStructure" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildAssociationStructure(SysML2.NET.Core.POCO.Kernel.Associations.IAssociationStructure poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildAssociationStructure(SysML2.NET.Core.POCO.Kernel.Associations.IAssociationStructure poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            TypeTextualNotationBuilder.BuildTypePrefix(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("assoc ");
             stringBuilder.Append("struct ");
-            ClassifierTextualNotationBuilder.BuildClassifierDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildTypeBody(poco, cursorCache, stringBuilder);
+            ClassifierTextualNotationBuilder.BuildClassifierDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypeBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AssociationTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AssociationTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>Association=TypePrefix'assoc'ClassifierDeclarationTypeBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Associations.IAssociation" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildAssociation(SysML2.NET.Core.POCO.Kernel.Associations.IAssociation poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildAssociation(SysML2.NET.Core.POCO.Kernel.Associations.IAssociation poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            TypeTextualNotationBuilder.BuildTypePrefix(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("assoc ");
-            ClassifierTextualNotationBuilder.BuildClassifierDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildTypeBody(poco, cursorCache, stringBuilder);
+            ClassifierTextualNotationBuilder.BuildClassifierDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypeBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AttributeDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AttributeDefinitionTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>AttributeDefinition:AttributeDefinition=DefinitionPrefix'attribute''def'Definition</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Attributes.IAttributeDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildAttributeDefinition(SysML2.NET.Core.POCO.Systems.Attributes.IAttributeDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildAttributeDefinition(SysML2.NET.Core.POCO.Systems.Attributes.IAttributeDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            DefinitionTextualNotationBuilder.BuildDefinitionPrefix(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinitionPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("attribute ");
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinition(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinition(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AttributeUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/AttributeUsageTextualNotationBuilder.cs
@@ -39,13 +39,13 @@ namespace SysML2.NET.TextualNotation
         /// <para>AttributeUsage:AttributeUsage=UsagePrefix'attribute'Usage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Attributes.IAttributeUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildAttributeUsage(SysML2.NET.Core.POCO.Systems.Attributes.IAttributeUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildAttributeUsage(SysML2.NET.Core.POCO.Systems.Attributes.IAttributeUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            UsageTextualNotationBuilder.BuildUsagePrefix(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("attribute ");
-            UsageTextualNotationBuilder.BuildUsage(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsage(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/BehaviorTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/BehaviorTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>Behavior=TypePrefix'behavior'ClassifierDeclarationTypeBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Behaviors.IBehavior" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildBehavior(SysML2.NET.Core.POCO.Kernel.Behaviors.IBehavior poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildBehavior(SysML2.NET.Core.POCO.Kernel.Behaviors.IBehavior poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            TypeTextualNotationBuilder.BuildTypePrefix(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("behavior ");
-            ClassifierTextualNotationBuilder.BuildClassifierDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildTypeBody(poco, cursorCache, stringBuilder);
+            ClassifierTextualNotationBuilder.BuildClassifierDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypeBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/BindingConnectorAsUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/BindingConnectorAsUsageTextualNotationBuilder.cs
@@ -39,17 +39,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>BindingConnectorAsUsage=UsagePrefix('binding'UsageDeclaration)?'bind'ownedRelationship+=ConnectorEndMember'='ownedRelationship+=ConnectorEndMemberUsageBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Connections.IBindingConnectorAsUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildBindingConnectorAsUsage(SysML2.NET.Core.POCO.Systems.Connections.IBindingConnectorAsUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildBindingConnectorAsUsage(SysML2.NET.Core.POCO.Systems.Connections.IBindingConnectorAsUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-            UsageTextualNotationBuilder.BuildUsagePrefix(poco, cursorCache, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            UsageTextualNotationBuilder.BuildUsagePrefix(poco, writerContext, stringBuilder);
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.OwnedRelatedElement.Count != 0 || poco.IsOrdered)
             {
                 stringBuilder.Append("binding ");
-                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
                 stringBuilder.Append(' ');
             }
 
@@ -60,7 +60,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
-                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -72,12 +72,12 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
-                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
 
-            UsageTextualNotationBuilder.BuildUsageBody(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsageBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/BindingConnectorTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/BindingConnectorTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>BindingConnectorDeclaration:BindingConnector=FeatureDeclaration('of'ownedRelationship+=ConnectorEndMember'='ownedRelationship+=ConnectorEndMember)?|(isSufficient?='all')?('of'?ownedRelationship+=ConnectorEndMember'='ownedRelationship+=ConnectorEndMember)?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Connectors.IBindingConnector" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildBindingConnectorDeclaration(SysML2.NET.Core.POCO.Kernel.Connectors.IBindingConnector poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildBindingConnectorDeclaration(SysML2.NET.Core.POCO.Kernel.Connectors.IBindingConnector poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildBindingConnectorDeclarationHandCoded(poco, cursorCache, stringBuilder);
+            BuildBindingConnectorDeclarationHandCoded(poco, writerContext, stringBuilder);
         }
 
         /// <summary>
@@ -51,14 +51,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>BindingConnector=FeaturePrefix'binding'BindingConnectorDeclarationTypeBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Connectors.IBindingConnector" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildBindingConnector(SysML2.NET.Core.POCO.Kernel.Connectors.IBindingConnector poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildBindingConnector(SysML2.NET.Core.POCO.Kernel.Connectors.IBindingConnector poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            SharedTextualNotationBuilder.BuildFeaturePrefix(poco, cursorCache, stringBuilder);
+            SharedTextualNotationBuilder.BuildFeaturePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("binding ");
-            BuildBindingConnectorDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildTypeBody(poco, cursorCache, stringBuilder);
+            BuildBindingConnectorDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypeBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/BooleanExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/BooleanExpressionTextualNotationBuilder.cs
@@ -39,19 +39,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>BooleanExpression=FeaturePrefix'bool'FeatureDeclarationValuePart?FunctionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.IBooleanExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildBooleanExpression(SysML2.NET.Core.POCO.Kernel.Functions.IBooleanExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildBooleanExpression(SysML2.NET.Core.POCO.Kernel.Functions.IBooleanExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            SharedTextualNotationBuilder.BuildFeaturePrefix(poco, cursorCache, stringBuilder);
+            SharedTextualNotationBuilder.BuildFeaturePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("bool ");
-            FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, cursorCache, stringBuilder);
+            FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, writerContext, stringBuilder);
 
             if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
-                FeatureTextualNotationBuilder.BuildValuePart(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }
-            TypeTextualNotationBuilder.BuildFunctionBody(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildFunctionBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/CalculationDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/CalculationDefinitionTextualNotationBuilder.cs
@@ -39,15 +39,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>CalculationDefinition=OccurrenceDefinitionPrefix'calc''def'DefinitionDeclarationCalculationBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Calculations.ICalculationDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildCalculationDefinition(SysML2.NET.Core.POCO.Systems.Calculations.ICalculationDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildCalculationDefinition(SysML2.NET.Core.POCO.Systems.Calculations.ICalculationDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, cursorCache, stringBuilder);
+            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("calc ");
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildCalculationBody(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildCalculationBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/CalculationUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/CalculationUsageTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>CalculationUsage:CalculationUsage=OccurrenceUsagePrefix'calc'ActionUsageDeclarationCalculationBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Calculations.ICalculationUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildCalculationUsage(SysML2.NET.Core.POCO.Systems.Calculations.ICalculationUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildCalculationUsage(SysML2.NET.Core.POCO.Systems.Calculations.ICalculationUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("calc ");
-            ActionUsageTextualNotationBuilder.BuildActionUsageDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildCalculationBody(poco, cursorCache, stringBuilder);
+            ActionUsageTextualNotationBuilder.BuildActionUsageDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildCalculationBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/CaseDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/CaseDefinitionTextualNotationBuilder.cs
@@ -39,15 +39,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>CaseDefinition=OccurrenceDefinitionPrefix'case''def'DefinitionDeclarationCaseBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Cases.ICaseDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildCaseDefinition(SysML2.NET.Core.POCO.Systems.Cases.ICaseDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildCaseDefinition(SysML2.NET.Core.POCO.Systems.Cases.ICaseDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, cursorCache, stringBuilder);
+            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("case ");
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildCaseBody(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildCaseBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/CaseUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/CaseUsageTextualNotationBuilder.cs
@@ -39,20 +39,20 @@ namespace SysML2.NET.TextualNotation
         /// <para>CaseUsage=OccurrenceUsagePrefix'case'ConstraintUsageDeclarationCaseBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Cases.ICaseUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildCaseUsage(SysML2.NET.Core.POCO.Systems.Cases.ICaseUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildCaseUsage(SysML2.NET.Core.POCO.Systems.Cases.ICaseUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("case ");
-            UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
 
             if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
-                FeatureTextualNotationBuilder.BuildValuePart(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }
 
-            TypeTextualNotationBuilder.BuildCaseBody(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildCaseBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ClassTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ClassTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>Class=TypePrefix'class'ClassifierDeclarationTypeBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Classes.IClass" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildClass(SysML2.NET.Core.POCO.Kernel.Classes.IClass poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildClass(SysML2.NET.Core.POCO.Kernel.Classes.IClass poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            TypeTextualNotationBuilder.BuildTypePrefix(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("class ");
-            ClassifierTextualNotationBuilder.BuildClassifierDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildTypeBody(poco, cursorCache, stringBuilder);
+            ClassifierTextualNotationBuilder.BuildClassifierDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypeBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ClassifierTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ClassifierTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>SubclassificationPart:Classifier=SPECIALIZESownedRelationship+=OwnedSubclassification(','ownedRelationship+=OwnedSubclassification)*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Classifiers.IClassifier" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSubclassificationPart(SysML2.NET.Core.POCO.Core.Classifiers.IClassifier poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSubclassificationPart(SysML2.NET.Core.POCO.Core.Classifiers.IClassifier poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append(" :> ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -51,7 +51,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Classifiers.ISubclassification elementAsSubclassification)
                 {
-                    SubclassificationTextualNotationBuilder.BuildOwnedSubclassification(elementAsSubclassification, cursorCache, stringBuilder);
+                    SubclassificationTextualNotationBuilder.BuildOwnedSubclassification(elementAsSubclassification, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -66,7 +66,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Classifiers.ISubclassification elementAsSubclassification)
                     {
-                        SubclassificationTextualNotationBuilder.BuildOwnedSubclassification(elementAsSubclassification, cursorCache, stringBuilder);
+                        SubclassificationTextualNotationBuilder.BuildOwnedSubclassification(elementAsSubclassification, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -80,11 +80,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>ClassifierDeclaration:Classifier=(isSufficient?='all')?Identification(ownedRelationship+=OwnedMultiplicity)?(SuperclassingPart|ConjugationPart)?TypeRelationshipPart*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Classifiers.IClassifier" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildClassifierDeclaration(SysML2.NET.Core.POCO.Core.Classifiers.IClassifier poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildClassifierDeclaration(SysML2.NET.Core.POCO.Core.Classifiers.IClassifier poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (poco.IsSufficient)
             {
@@ -92,7 +92,7 @@ namespace SysML2.NET.TextualNotation
                 stringBuilder.Append(' ');
             }
 
-            ElementTextualNotationBuilder.BuildIdentification(poco, cursorCache, stringBuilder);
+            ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
 
             if (ownedRelationshipCursor.Current != null)
             {
@@ -102,18 +102,18 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                     {
-                        OwningMembershipTextualNotationBuilder.BuildOwnedMultiplicity(elementAsOwningMembership, cursorCache, stringBuilder);
+                        OwningMembershipTextualNotationBuilder.BuildOwnedMultiplicity(elementAsOwningMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
                 stringBuilder.Append(' ');
             }
 
-            BuildClassifierDeclarationHandCoded(poco, cursorCache, stringBuilder);
+            BuildClassifierDeclarationHandCoded(poco, writerContext, stringBuilder);
             while (ownedRelationshipCursor.Current != null)
             {
-                TypeTextualNotationBuilder.BuildTypeRelationshipPart(poco, cursorCache, stringBuilder);
+                TypeTextualNotationBuilder.BuildTypeRelationshipPart(poco, writerContext, stringBuilder);
             }
 
 
@@ -124,11 +124,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>SuperclassingPart:Classifier=SPECIALIZESownedRelationship+=OwnedSubclassification(','ownedRelationship+=OwnedSubclassification)*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Classifiers.IClassifier" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSuperclassingPart(SysML2.NET.Core.POCO.Core.Classifiers.IClassifier poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSuperclassingPart(SysML2.NET.Core.POCO.Core.Classifiers.IClassifier poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append(" :> ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -136,7 +136,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Classifiers.ISubclassification elementAsSubclassification)
                 {
-                    SubclassificationTextualNotationBuilder.BuildOwnedSubclassification(elementAsSubclassification, cursorCache, stringBuilder);
+                    SubclassificationTextualNotationBuilder.BuildOwnedSubclassification(elementAsSubclassification, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -151,7 +151,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Classifiers.ISubclassification elementAsSubclassification)
                     {
-                        SubclassificationTextualNotationBuilder.BuildOwnedSubclassification(elementAsSubclassification, cursorCache, stringBuilder);
+                        SubclassificationTextualNotationBuilder.BuildOwnedSubclassification(elementAsSubclassification, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -165,14 +165,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>Classifier=TypePrefix'classifier'ClassifierDeclarationTypeBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Classifiers.IClassifier" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildClassifier(SysML2.NET.Core.POCO.Core.Classifiers.IClassifier poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildClassifier(SysML2.NET.Core.POCO.Core.Classifiers.IClassifier poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            TypeTextualNotationBuilder.BuildTypePrefix(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("classifier ");
-            BuildClassifierDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildTypeBody(poco, cursorCache, stringBuilder);
+            BuildClassifierDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypeBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/CollectExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/CollectExpressionTextualNotationBuilder.cs
@@ -39,18 +39,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>CollectExpression=ownedRelationship+=PrimaryArgumentMember'.'ownedRelationship+=BodyArgumentMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.ICollectExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildCollectExpression(SysML2.NET.Core.POCO.Kernel.Expressions.ICollectExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildCollectExpression(SysML2.NET.Core.POCO.Kernel.Expressions.ICollectExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildPrimaryArgumentMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildPrimaryArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -62,7 +62,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildBodyArgumentMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildBodyArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/CommentTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/CommentTextualNotationBuilder.cs
@@ -39,16 +39,16 @@ namespace SysML2.NET.TextualNotation
         /// <para>Comment=('comment'Identification('about'ownedRelationship+=Annotation(','ownedRelationship+=Annotation)*)?)?('locale'locale=STRING_VALUE)?body=REGULAR_COMMENT</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Annotations.IComment" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildComment(SysML2.NET.Core.POCO.Root.Annotations.IComment poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildComment(SysML2.NET.Core.POCO.Root.Annotations.IComment poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName))
             {
                 stringBuilder.Append("comment ");
-                ElementTextualNotationBuilder.BuildIdentification(poco, cursorCache, stringBuilder);
+                ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
 
                 if (ownedRelationshipCursor.Current != null)
                 {
@@ -59,11 +59,11 @@ namespace SysML2.NET.TextualNotation
 
                         if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Annotations.IAnnotation elementAsAnnotation)
                         {
-                            AnnotationTextualNotationBuilder.BuildAnnotation(elementAsAnnotation, cursorCache, stringBuilder);
+                            AnnotationTextualNotationBuilder.BuildAnnotation(elementAsAnnotation, writerContext, stringBuilder);
+                            ownedRelationshipCursor.Move();
+
                         }
                     }
-                    ownedRelationshipCursor.Move();
-
 
                     while (ownedRelationshipCursor.Current != null && ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Annotations.IAnnotation)
                     {
@@ -74,7 +74,7 @@ namespace SysML2.NET.TextualNotation
 
                             if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Annotations.IAnnotation elementAsAnnotation)
                             {
-                                AnnotationTextualNotationBuilder.BuildAnnotation(elementAsAnnotation, cursorCache, stringBuilder);
+                                AnnotationTextualNotationBuilder.BuildAnnotation(elementAsAnnotation, writerContext, stringBuilder);
                             }
                         }
                         ownedRelationshipCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConcernDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConcernDefinitionTextualNotationBuilder.cs
@@ -39,15 +39,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>ConcernDefinition=OccurrenceDefinitionPrefix'concern''def'DefinitionDeclarationRequirementBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.IConcernDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildConcernDefinition(SysML2.NET.Core.POCO.Systems.Requirements.IConcernDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildConcernDefinition(SysML2.NET.Core.POCO.Systems.Requirements.IConcernDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, cursorCache, stringBuilder);
+            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("concern ");
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildRequirementBody(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildRequirementBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConcernUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConcernUsageTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>FramedConcernUsage:ConcernUsage=ownedRelationship+=OwnedReferenceSubsettingFeatureSpecializationPart?CalculationBody|(UsageExtensionKeyword*'concern'|UsageExtensionKeyword+)CalculationUsageDeclarationCalculationBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.IConcernUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFramedConcernUsage(SysML2.NET.Core.POCO.Systems.Requirements.IConcernUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFramedConcernUsage(SysML2.NET.Core.POCO.Systems.Requirements.IConcernUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildFramedConcernUsageHandCoded(poco, cursorCache, stringBuilder);
+            BuildFramedConcernUsageHandCoded(poco, writerContext, stringBuilder);
         }
 
         /// <summary>
@@ -51,14 +51,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>ConcernUsage=OccurrenceUsagePrefix'concern'ConstraintUsageDeclarationRequirementBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.IConcernUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildConcernUsage(SysML2.NET.Core.POCO.Systems.Requirements.IConcernUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildConcernUsage(SysML2.NET.Core.POCO.Systems.Requirements.IConcernUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("concern ");
-            ConstraintUsageTextualNotationBuilder.BuildConstraintUsageDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildRequirementBody(poco, cursorCache, stringBuilder);
+            ConstraintUsageTextualNotationBuilder.BuildConstraintUsageDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildRequirementBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConjugatedPortDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConjugatedPortDefinitionTextualNotationBuilder.cs
@@ -39,18 +39,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>ConjugatedPortDefinition=ownedRelationship+=PortConjugation</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Ports.IConjugatedPortDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildConjugatedPortDefinition(SysML2.NET.Core.POCO.Systems.Ports.IConjugatedPortDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildConjugatedPortDefinition(SysML2.NET.Core.POCO.Systems.Ports.IConjugatedPortDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.Ports.IPortConjugation elementAsPortConjugation)
                 {
-                    PortConjugationTextualNotationBuilder.BuildPortConjugation(elementAsPortConjugation, cursorCache, stringBuilder);
+                    PortConjugationTextualNotationBuilder.BuildPortConjugation(elementAsPortConjugation, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConjugatedPortTypingTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConjugatedPortTypingTextualNotationBuilder.cs
@@ -39,12 +39,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>ConjugatedPortTyping:ConjugatedPortTyping='~'originalPortDefinition=~[QualifiedName]</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Ports.IConjugatedPortTyping" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildConjugatedPortTyping(SysML2.NET.Core.POCO.Systems.Ports.IConjugatedPortTyping poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildConjugatedPortTyping(SysML2.NET.Core.POCO.Systems.Ports.IConjugatedPortTyping poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             stringBuilder.Append("~");
-            BuildOriginalPortDefinition(poco, cursorCache, stringBuilder);
+            BuildOriginalPortDefinition(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConjugationTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConjugationTextualNotationBuilder.cs
@@ -39,17 +39,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedConjugation:Conjugation=originalType=[QualifiedName]|originalType=FeatureChain{ownedRelatedElement+=originalType}</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IConjugation" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedConjugation(SysML2.NET.Core.POCO.Core.Types.IConjugation poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedConjugation(SysML2.NET.Core.POCO.Core.Types.IConjugation poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             if (poco.OwnedRelatedElement.Contains(poco.OriginalType) && poco.OriginalType is SysML2.NET.Core.POCO.Core.Features.IFeature chainedOriginalTypeAsFeature)
             {
-                FeatureTextualNotationBuilder.BuildFeatureChain(chainedOriginalTypeAsFeature, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildFeatureChain(chainedOriginalTypeAsFeature, writerContext, stringBuilder);
             }
             else if (poco.OriginalType != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.OriginalType);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.OriginalType, writerContext);
                 stringBuilder.Append(' ');
             }
 
@@ -60,26 +60,26 @@ namespace SysML2.NET.TextualNotation
         /// <para>Conjugation=('conjugation'Identification)?'conjugate'(conjugatedType=[QualifiedName]|conjugatedType=FeatureChain{ownedRelatedElement+=conjugatedType})CONJUGATES(originalType=[QualifiedName]|originalType=FeatureChain{ownedRelatedElement+=originalType})RelationshipBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IConjugation" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildConjugation(SysML2.NET.Core.POCO.Core.Types.IConjugation poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildConjugation(SysML2.NET.Core.POCO.Core.Types.IConjugation poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName))
             {
                 stringBuilder.Append("conjugation ");
-                ElementTextualNotationBuilder.BuildIdentification(poco, cursorCache, stringBuilder);
+                ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
                 stringBuilder.Append(' ');
             }
 
             stringBuilder.Append("conjugate ");
             if (poco.OwnedRelatedElement.Contains(poco.ConjugatedType) && poco.ConjugatedType is SysML2.NET.Core.POCO.Core.Features.IFeature chainedConjugatedTypeAsFeature)
             {
-                FeatureTextualNotationBuilder.BuildFeatureChain(chainedConjugatedTypeAsFeature, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildFeatureChain(chainedConjugatedTypeAsFeature, writerContext, stringBuilder);
             }
             else if (poco.ConjugatedType != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.ConjugatedType);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.ConjugatedType, writerContext);
                 stringBuilder.Append(' ');
             }
 
@@ -87,16 +87,16 @@ namespace SysML2.NET.TextualNotation
             stringBuilder.Append(" ~");
             if (poco.OwnedRelatedElement.Contains(poco.OriginalType) && poco.OriginalType is SysML2.NET.Core.POCO.Core.Features.IFeature chainedOriginalTypeAsFeature)
             {
-                FeatureTextualNotationBuilder.BuildFeatureChain(chainedOriginalTypeAsFeature, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildFeatureChain(chainedOriginalTypeAsFeature, writerContext, stringBuilder);
             }
             else if (poco.OriginalType != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.OriginalType);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.OriginalType, writerContext);
                 stringBuilder.Append(' ');
             }
 
             stringBuilder.Append(' ');
-            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, cursorCache, stringBuilder);
+            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConjugationTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConjugationTextualNotationBuilder.cs
@@ -49,7 +49,7 @@ namespace SysML2.NET.TextualNotation
             }
             else if (poco.OriginalType != null)
             {
-                stringBuilder.Append(poco.OriginalType.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.OriginalType);
                 stringBuilder.Append(' ');
             }
 
@@ -79,7 +79,7 @@ namespace SysML2.NET.TextualNotation
             }
             else if (poco.ConjugatedType != null)
             {
-                stringBuilder.Append(poco.ConjugatedType.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.ConjugatedType);
                 stringBuilder.Append(' ');
             }
 
@@ -91,7 +91,7 @@ namespace SysML2.NET.TextualNotation
             }
             else if (poco.OriginalType != null)
             {
-                stringBuilder.Append(poco.OriginalType.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.OriginalType);
                 stringBuilder.Append(' ');
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConnectionDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConnectionDefinitionTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>ConnectionDefinition=OccurrenceDefinitionPrefix'connection''def'Definition</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Connections.IConnectionDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildConnectionDefinition(SysML2.NET.Core.POCO.Systems.Connections.IConnectionDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildConnectionDefinition(SysML2.NET.Core.POCO.Systems.Connections.IConnectionDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, cursorCache, stringBuilder);
+            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("connection ");
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinition(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinition(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConnectionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConnectionUsageTextualNotationBuilder.cs
@@ -39,17 +39,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>ConnectorPart:ConnectionUsage=BinaryConnectorPart|NaryConnectorPart</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Connections.IConnectionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildConnectorPart(SysML2.NET.Core.POCO.Systems.Connections.IConnectionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildConnectorPart(SysML2.NET.Core.POCO.Systems.Connections.IConnectionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Systems.Connections.IConnectionUsage pocoConnectionUsageBinaryConnectorPart when pocoConnectionUsageBinaryConnectorPart.IsValidForBinaryConnectorPart():
-                    BuildBinaryConnectorPart(pocoConnectionUsageBinaryConnectorPart, cursorCache, stringBuilder);
+                    BuildBinaryConnectorPart(pocoConnectionUsageBinaryConnectorPart, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildNaryConnectorPart(poco, cursorCache, stringBuilder);
+                    BuildNaryConnectorPart(poco, writerContext, stringBuilder);
                     break;
             }
 
@@ -60,18 +60,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>BinaryConnectorPart:ConnectionUsage=ownedRelationship+=ConnectorEndMember'to'ownedRelationship+=ConnectorEndMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Connections.IConnectionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildBinaryConnectorPart(SysML2.NET.Core.POCO.Systems.Connections.IConnectionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildBinaryConnectorPart(SysML2.NET.Core.POCO.Systems.Connections.IConnectionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
-                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -83,7 +83,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
-                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -96,11 +96,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>NaryConnectorPart:ConnectionUsage='('ownedRelationship+=ConnectorEndMember','ownedRelationship+=ConnectorEndMember(','ownedRelationship+=ConnectorEndMember)*')'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Connections.IConnectionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNaryConnectorPart(SysML2.NET.Core.POCO.Systems.Connections.IConnectionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNaryConnectorPart(SysML2.NET.Core.POCO.Systems.Connections.IConnectionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append("(");
 
             if (ownedRelationshipCursor.Current != null)
@@ -108,7 +108,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
-                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -120,7 +120,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
-                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -135,7 +135,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                     {
-                        EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, cursorCache, stringBuilder);
+                        EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -150,14 +150,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>ConnectionUsage=OccurrenceUsagePrefix('connection'UsageDeclarationValuePart?('connect'ConnectorPart)?|'connect'ConnectorPart)UsageBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Connections.IConnectionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildConnectionUsage(SysML2.NET.Core.POCO.Systems.Connections.IConnectionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildConnectionUsage(SysML2.NET.Core.POCO.Systems.Connections.IConnectionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
-            BuildConnectionUsageHandCoded(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
+            BuildConnectionUsageHandCoded(poco, writerContext, stringBuilder);
             stringBuilder.Append(' ');
-            UsageTextualNotationBuilder.BuildUsageBody(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsageBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConnectionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConnectionUsageTextualNotationBuilder.cs
@@ -45,7 +45,7 @@ namespace SysML2.NET.TextualNotation
         {
             switch (poco)
             {
-                case SysML2.NET.Core.POCO.Systems.Connections.IConnectionUsage pocoConnectionUsageBinaryConnectorPart when pocoConnectionUsageBinaryConnectorPart.IsValidForBinaryConnectorPart():
+                case SysML2.NET.Core.POCO.Systems.Connections.IConnectionUsage pocoConnectionUsageBinaryConnectorPart when pocoConnectionUsageBinaryConnectorPart.IsValidForBinaryConnectorPart(writerContext):
                     BuildBinaryConnectorPart(pocoConnectionUsageBinaryConnectorPart, writerContext, stringBuilder);
                     break;
                 default:

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConnectorTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConnectorTextualNotationBuilder.cs
@@ -39,17 +39,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>ConnectorDeclaration:Connector=BinaryConnectorDeclaration|NaryConnectorDeclaration</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Connectors.IConnector" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildConnectorDeclaration(SysML2.NET.Core.POCO.Kernel.Connectors.IConnector poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildConnectorDeclaration(SysML2.NET.Core.POCO.Kernel.Connectors.IConnector poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Kernel.Connectors.IConnector pocoConnectorBinaryConnectorDeclaration when pocoConnectorBinaryConnectorDeclaration.IsValidForBinaryConnectorDeclaration():
-                    BuildBinaryConnectorDeclaration(pocoConnectorBinaryConnectorDeclaration, cursorCache, stringBuilder);
+                    BuildBinaryConnectorDeclaration(pocoConnectorBinaryConnectorDeclaration, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildNaryConnectorDeclaration(poco, cursorCache, stringBuilder);
+                    BuildNaryConnectorDeclaration(poco, writerContext, stringBuilder);
                     break;
             }
 
@@ -60,19 +60,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>BinaryConnectorDeclaration:Connector=(FeatureDeclaration?'from'|isSufficient?='all''from'?)?ownedRelationship+=ConnectorEndMember'to'ownedRelationship+=ConnectorEndMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Connectors.IConnector" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildBinaryConnectorDeclaration(SysML2.NET.Core.POCO.Kernel.Connectors.IConnector poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildBinaryConnectorDeclaration(SysML2.NET.Core.POCO.Kernel.Connectors.IConnector poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-            BuildBinaryConnectorDeclarationHandCoded(poco, cursorCache, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            BuildBinaryConnectorDeclarationHandCoded(poco, writerContext, stringBuilder);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
-                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -84,7 +84,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
-                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -97,15 +97,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>NaryConnectorDeclaration:Connector=FeatureDeclaration?'('ownedRelationship+=ConnectorEndMember','ownedRelationship+=ConnectorEndMember(','ownedRelationship+=ConnectorEndMember)*')'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Connectors.IConnector" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNaryConnectorDeclaration(SysML2.NET.Core.POCO.Kernel.Connectors.IConnector poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNaryConnectorDeclaration(SysML2.NET.Core.POCO.Kernel.Connectors.IConnector poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (poco.IsSufficient || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
-                FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, writerContext, stringBuilder);
             }
             stringBuilder.Append("(");
 
@@ -114,7 +114,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
-                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -126,7 +126,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
-                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -141,7 +141,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                     {
-                        EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, cursorCache, stringBuilder);
+                        EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -156,15 +156,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>Connector=FeaturePrefix'connector'(FeatureDeclaration?ValuePart?|ConnectorDeclaration)TypeBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Connectors.IConnector" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildConnector(SysML2.NET.Core.POCO.Kernel.Connectors.IConnector poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildConnector(SysML2.NET.Core.POCO.Kernel.Connectors.IConnector poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            SharedTextualNotationBuilder.BuildFeaturePrefix(poco, cursorCache, stringBuilder);
+            SharedTextualNotationBuilder.BuildFeaturePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("connector ");
-            BuildConnectorHandCoded(poco, cursorCache, stringBuilder);
+            BuildConnectorHandCoded(poco, writerContext, stringBuilder);
             stringBuilder.Append(' ');
-            TypeTextualNotationBuilder.BuildTypeBody(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypeBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConnectorTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConnectorTextualNotationBuilder.cs
@@ -45,7 +45,7 @@ namespace SysML2.NET.TextualNotation
         {
             switch (poco)
             {
-                case SysML2.NET.Core.POCO.Kernel.Connectors.IConnector pocoConnectorBinaryConnectorDeclaration when pocoConnectorBinaryConnectorDeclaration.IsValidForBinaryConnectorDeclaration():
+                case SysML2.NET.Core.POCO.Kernel.Connectors.IConnector pocoConnectorBinaryConnectorDeclaration when pocoConnectorBinaryConnectorDeclaration.IsValidForBinaryConnectorDeclaration(writerContext):
                     BuildBinaryConnectorDeclaration(pocoConnectorBinaryConnectorDeclaration, writerContext, stringBuilder);
                     break;
                 default:

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConstraintDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConstraintDefinitionTextualNotationBuilder.cs
@@ -39,15 +39,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>ConstraintDefinition=OccurrenceDefinitionPrefix'constraint''def'DefinitionDeclarationCalculationBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Constraints.IConstraintDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildConstraintDefinition(SysML2.NET.Core.POCO.Systems.Constraints.IConstraintDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildConstraintDefinition(SysML2.NET.Core.POCO.Systems.Constraints.IConstraintDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, cursorCache, stringBuilder);
+            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("constraint ");
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildCalculationBody(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildCalculationBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConstraintUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConstraintUsageTextualNotationBuilder.cs
@@ -39,15 +39,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>ConstraintUsageDeclaration:ConstraintUsage=UsageDeclarationValuePart?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Constraints.IConstraintUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildConstraintUsageDeclaration(SysML2.NET.Core.POCO.Systems.Constraints.IConstraintUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildConstraintUsageDeclaration(SysML2.NET.Core.POCO.Systems.Constraints.IConstraintUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
 
             if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
-                FeatureTextualNotationBuilder.BuildValuePart(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }
 
         }
@@ -57,11 +57,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>RequirementConstraintUsage:ConstraintUsage=ownedRelationship+=OwnedReferenceSubsettingFeatureSpecializationPart?RequirementBody|(UsageExtensionKeyword*'constraint'|UsageExtensionKeyword+)ConstraintUsageDeclarationCalculationBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Constraints.IConstraintUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildRequirementConstraintUsage(SysML2.NET.Core.POCO.Systems.Constraints.IConstraintUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildRequirementConstraintUsage(SysML2.NET.Core.POCO.Systems.Constraints.IConstraintUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildRequirementConstraintUsageHandCoded(poco, cursorCache, stringBuilder);
+            BuildRequirementConstraintUsageHandCoded(poco, writerContext, stringBuilder);
         }
 
         /// <summary>
@@ -69,14 +69,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>ConstraintUsage=OccurrenceUsagePrefix'constraint'ConstraintUsageDeclarationCalculationBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Constraints.IConstraintUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildConstraintUsage(SysML2.NET.Core.POCO.Systems.Constraints.IConstraintUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildConstraintUsage(SysML2.NET.Core.POCO.Systems.Constraints.IConstraintUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("constraint ");
-            BuildConstraintUsageDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildCalculationBody(poco, cursorCache, stringBuilder);
+            BuildConstraintUsageDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildCalculationBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConstructorExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ConstructorExpressionTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>ConstructorExpression='new'ownedRelationship+=InstantiatedTypeMemberownedRelationship+=ConstructorResultMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.IConstructorExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildConstructorExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IConstructorExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildConstructorExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IConstructorExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append("new ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -51,7 +51,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership elementAsMembership)
                 {
-                    MembershipTextualNotationBuilder.BuildInstantiatedTypeMember(elementAsMembership, cursorCache, stringBuilder);
+                    MembershipTextualNotationBuilder.BuildInstantiatedTypeMember(elementAsMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -62,7 +62,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
                 {
-                    ReturnParameterMembershipTextualNotationBuilder.BuildConstructorResultMember(elementAsReturnParameterMembership, cursorCache, stringBuilder);
+                    ReturnParameterMembershipTextualNotationBuilder.BuildConstructorResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ControlNodeTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ControlNodeTextualNotationBuilder.cs
@@ -39,23 +39,23 @@ namespace SysML2.NET.TextualNotation
         /// <para>ControlNode=MergeNode|DecisionNode|JoinNode|ForkNode</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IControlNode" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildControlNode(SysML2.NET.Core.POCO.Systems.Actions.IControlNode poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildControlNode(SysML2.NET.Core.POCO.Systems.Actions.IControlNode poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Systems.Actions.IMergeNode pocoMergeNode:
-                    MergeNodeTextualNotationBuilder.BuildMergeNode(pocoMergeNode, cursorCache, stringBuilder);
+                    MergeNodeTextualNotationBuilder.BuildMergeNode(pocoMergeNode, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Actions.IDecisionNode pocoDecisionNode:
-                    DecisionNodeTextualNotationBuilder.BuildDecisionNode(pocoDecisionNode, cursorCache, stringBuilder);
+                    DecisionNodeTextualNotationBuilder.BuildDecisionNode(pocoDecisionNode, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Actions.IJoinNode pocoJoinNode:
-                    JoinNodeTextualNotationBuilder.BuildJoinNode(pocoJoinNode, cursorCache, stringBuilder);
+                    JoinNodeTextualNotationBuilder.BuildJoinNode(pocoJoinNode, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Actions.IForkNode pocoForkNode:
-                    ForkNodeTextualNotationBuilder.BuildForkNode(pocoForkNode, cursorCache, stringBuilder);
+                    ForkNodeTextualNotationBuilder.BuildForkNode(pocoForkNode, writerContext, stringBuilder);
                     break;
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/CrossSubsettingTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/CrossSubsettingTextualNotationBuilder.cs
@@ -49,7 +49,7 @@ namespace SysML2.NET.TextualNotation
             }
             else if (poco.CrossedFeature != null)
             {
-                stringBuilder.Append(poco.CrossedFeature.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.CrossedFeature);
                 stringBuilder.Append(' ');
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/CrossSubsettingTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/CrossSubsettingTextualNotationBuilder.cs
@@ -39,17 +39,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedCrossSubsetting:CrossSubsetting=crossedFeature=[QualifiedName]|crossedFeature=OwnedFeatureChain{ownedRelatedElement+=crossedFeature}</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedCrossSubsetting(SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedCrossSubsetting(SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             if (poco.OwnedRelatedElement.Contains(poco.CrossedFeature) && poco.CrossedFeature is SysML2.NET.Core.POCO.Core.Features.IFeature chainedCrossedFeatureAsFeature)
             {
-                FeatureTextualNotationBuilder.BuildOwnedFeatureChain(chainedCrossedFeatureAsFeature, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildOwnedFeatureChain(chainedCrossedFeatureAsFeature, writerContext, stringBuilder);
             }
             else if (poco.CrossedFeature != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.CrossedFeature);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.CrossedFeature, writerContext);
                 stringBuilder.Append(' ');
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/DataTypeTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/DataTypeTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>DataType=TypePrefix'datatype'ClassifierDeclarationTypeBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.DataTypes.IDataType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildDataType(SysML2.NET.Core.POCO.Kernel.DataTypes.IDataType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildDataType(SysML2.NET.Core.POCO.Kernel.DataTypes.IDataType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            TypeTextualNotationBuilder.BuildTypePrefix(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("datatype ");
-            ClassifierTextualNotationBuilder.BuildClassifierDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildTypeBody(poco, cursorCache, stringBuilder);
+            ClassifierTextualNotationBuilder.BuildClassifierDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypeBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/DecisionNodeTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/DecisionNodeTextualNotationBuilder.cs
@@ -39,17 +39,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>DecisionNode=ControlNodePrefixisComposite?='decide'UsageDeclarationActionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IDecisionNode" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildDecisionNode(SysML2.NET.Core.POCO.Systems.Actions.IDecisionNode poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildDecisionNode(SysML2.NET.Core.POCO.Systems.Actions.IDecisionNode poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildControlNodePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildControlNodePrefix(poco, writerContext, stringBuilder);
             if (poco.IsComposite)
             {
                 stringBuilder.Append(" decide ");
             }
-            UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildActionBody(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildActionBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/DefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/DefinitionTextualNotationBuilder.cs
@@ -39,18 +39,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>DefinitionExtensionKeyword:Definition=ownedRelationship+=PrefixMetadataMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildDefinitionExtensionKeyword(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildDefinitionExtensionKeyword(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                 {
-                    OwningMembershipTextualNotationBuilder.BuildPrefixMetadataMember(elementAsOwningMembership, cursorCache, stringBuilder);
+                    OwningMembershipTextualNotationBuilder.BuildPrefixMetadataMember(elementAsOwningMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -63,19 +63,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>DefinitionPrefix:Definition=BasicDefinitionPrefix?DefinitionExtensionKeyword*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildDefinitionPrefix(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildDefinitionPrefix(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.IsAbstract || poco.IsVariation)
             {
-                SharedTextualNotationBuilder.BuildBasicDefinitionPrefix(poco, cursorCache, stringBuilder);
+                SharedTextualNotationBuilder.BuildBasicDefinitionPrefix(poco, writerContext, stringBuilder);
             }
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership owningMembershipGuard && owningMembershipGuard.OwnedRelatedElement.OfType<SysML2.NET.Core.POCO.Systems.Metadata.IMetadataUsage>().Any())
             {
-                BuildDefinitionExtensionKeyword(poco, cursorCache, stringBuilder);
+                BuildDefinitionExtensionKeyword(poco, writerContext, stringBuilder);
             }
 
 
@@ -86,15 +86,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>DefinitionDeclaration:Definition=IdentificationSubclassificationPart?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildDefinitionDeclaration(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildDefinitionDeclaration(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            ElementTextualNotationBuilder.BuildIdentification(poco, cursorCache, stringBuilder);
+            ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
 
             if (poco.OwnedRelationship.Count != 0)
             {
-                ClassifierTextualNotationBuilder.BuildSubclassificationPart(poco, cursorCache, stringBuilder);
+                ClassifierTextualNotationBuilder.BuildSubclassificationPart(poco, writerContext, stringBuilder);
             }
 
         }
@@ -104,23 +104,23 @@ namespace SysML2.NET.TextualNotation
         /// <para>ExtendedDefinition:Definition=BasicDefinitionPrefix?DefinitionExtensionKeyword+'def'Definition</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildExtendedDefinition(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildExtendedDefinition(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.IsAbstract || poco.IsVariation)
             {
-                SharedTextualNotationBuilder.BuildBasicDefinitionPrefix(poco, cursorCache, stringBuilder);
+                SharedTextualNotationBuilder.BuildBasicDefinitionPrefix(poco, writerContext, stringBuilder);
             }
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership)
             {
-                BuildDefinitionExtensionKeyword(poco, cursorCache, stringBuilder);
+                BuildDefinitionExtensionKeyword(poco, writerContext, stringBuilder);
             }
 
             stringBuilder.Append("def ");
-            BuildDefinition(poco, cursorCache, stringBuilder);
+            BuildDefinition(poco, writerContext, stringBuilder);
 
         }
 
@@ -129,12 +129,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>Definition=DefinitionDeclarationDefinitionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildDefinition(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildDefinition(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildDefinitionDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildDefinitionBody(poco, cursorCache, stringBuilder);
+            BuildDefinitionDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildDefinitionBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/DependencyTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/DependencyTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>Dependency=(ownedRelationship+=PrefixMetadataAnnotation)*'dependency'DependencyDeclarationRelationshipBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Dependencies.IDependency" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildDependency(SysML2.NET.Core.POCO.Root.Dependencies.IDependency poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildDependency(SysML2.NET.Core.POCO.Root.Dependencies.IDependency poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             while (ownedRelationshipCursor.Current != null && ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Annotations.IAnnotation)
             {
@@ -53,15 +53,15 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Annotations.IAnnotation elementAsAnnotation)
                     {
-                        AnnotationTextualNotationBuilder.BuildPrefixMetadataAnnotation(elementAsAnnotation, cursorCache, stringBuilder);
+                        AnnotationTextualNotationBuilder.BuildPrefixMetadataAnnotation(elementAsAnnotation, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
 
             }
             stringBuilder.Append("dependency ");
-            SharedTextualNotationBuilder.BuildDependencyDeclaration(poco, cursorCache, stringBuilder);
-            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, cursorCache, stringBuilder);
+            SharedTextualNotationBuilder.BuildDependencyDeclaration(poco, writerContext, stringBuilder);
+            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/DifferencingTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/DifferencingTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>Differencing=differencingType=[QualifiedName]|ownedRelatedElement+=OwnedFeatureChain</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IDifferencing" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildDifferencing(SysML2.NET.Core.POCO.Core.Types.IDifferencing poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildDifferencing(SysML2.NET.Core.POCO.Core.Types.IDifferencing poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
             if (poco.DifferencingType != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.DifferencingType);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.DifferencingType, writerContext);
                 stringBuilder.Append(' ');
             }
             else
@@ -57,7 +57,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                     {
-                        FeatureTextualNotationBuilder.BuildOwnedFeatureChain(elementAsFeature, cursorCache, stringBuilder);
+                        FeatureTextualNotationBuilder.BuildOwnedFeatureChain(elementAsFeature, writerContext, stringBuilder);
                     }
                 }
             }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/DifferencingTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/DifferencingTextualNotationBuilder.cs
@@ -46,7 +46,7 @@ namespace SysML2.NET.TextualNotation
             var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
             if (poco.DifferencingType != null)
             {
-                stringBuilder.Append(poco.DifferencingType.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.DifferencingType);
                 stringBuilder.Append(' ');
             }
             else

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/DisjoiningTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/DisjoiningTextualNotationBuilder.cs
@@ -49,7 +49,7 @@ namespace SysML2.NET.TextualNotation
             }
             else if (poco.DisjoiningType != null)
             {
-                stringBuilder.Append(poco.DisjoiningType.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.DisjoiningType);
                 stringBuilder.Append(' ');
             }
 
@@ -79,7 +79,7 @@ namespace SysML2.NET.TextualNotation
             }
             else if (poco.TypeDisjoined != null)
             {
-                stringBuilder.Append(poco.TypeDisjoined.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.TypeDisjoined);
                 stringBuilder.Append(' ');
             }
 
@@ -91,7 +91,7 @@ namespace SysML2.NET.TextualNotation
             }
             else if (poco.DisjoiningType != null)
             {
-                stringBuilder.Append(poco.DisjoiningType.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.DisjoiningType);
                 stringBuilder.Append(' ');
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/DisjoiningTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/DisjoiningTextualNotationBuilder.cs
@@ -39,17 +39,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedDisjoining:Disjoining=disjoiningType=[QualifiedName]|disjoiningType=FeatureChain{ownedRelatedElement+=disjoiningType}</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IDisjoining" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedDisjoining(SysML2.NET.Core.POCO.Core.Types.IDisjoining poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedDisjoining(SysML2.NET.Core.POCO.Core.Types.IDisjoining poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             if (poco.OwnedRelatedElement.Contains(poco.DisjoiningType) && poco.DisjoiningType is SysML2.NET.Core.POCO.Core.Features.IFeature chainedDisjoiningTypeAsFeature)
             {
-                FeatureTextualNotationBuilder.BuildFeatureChain(chainedDisjoiningTypeAsFeature, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildFeatureChain(chainedDisjoiningTypeAsFeature, writerContext, stringBuilder);
             }
             else if (poco.DisjoiningType != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.DisjoiningType);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.DisjoiningType, writerContext);
                 stringBuilder.Append(' ');
             }
 
@@ -60,26 +60,26 @@ namespace SysML2.NET.TextualNotation
         /// <para>Disjoining=('disjoining'Identification)?'disjoint'(typeDisjoined=[QualifiedName]|typeDisjoined=FeatureChain{ownedRelatedElement+=typeDisjoined})'from'(disjoiningType=[QualifiedName]|disjoiningType=FeatureChain{ownedRelatedElement+=disjoiningType})RelationshipBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IDisjoining" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildDisjoining(SysML2.NET.Core.POCO.Core.Types.IDisjoining poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildDisjoining(SysML2.NET.Core.POCO.Core.Types.IDisjoining poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName))
             {
                 stringBuilder.Append("disjoining ");
-                ElementTextualNotationBuilder.BuildIdentification(poco, cursorCache, stringBuilder);
+                ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
                 stringBuilder.Append(' ');
             }
 
             stringBuilder.Append("disjoint ");
             if (poco.OwnedRelatedElement.Contains(poco.TypeDisjoined) && poco.TypeDisjoined is SysML2.NET.Core.POCO.Core.Features.IFeature chainedTypeDisjoinedAsFeature)
             {
-                FeatureTextualNotationBuilder.BuildFeatureChain(chainedTypeDisjoinedAsFeature, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildFeatureChain(chainedTypeDisjoinedAsFeature, writerContext, stringBuilder);
             }
             else if (poco.TypeDisjoined != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.TypeDisjoined);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.TypeDisjoined, writerContext);
                 stringBuilder.Append(' ');
             }
 
@@ -87,16 +87,16 @@ namespace SysML2.NET.TextualNotation
             stringBuilder.Append("from ");
             if (poco.OwnedRelatedElement.Contains(poco.DisjoiningType) && poco.DisjoiningType is SysML2.NET.Core.POCO.Core.Features.IFeature chainedDisjoiningTypeAsFeature)
             {
-                FeatureTextualNotationBuilder.BuildFeatureChain(chainedDisjoiningTypeAsFeature, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildFeatureChain(chainedDisjoiningTypeAsFeature, writerContext, stringBuilder);
             }
             else if (poco.DisjoiningType != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.DisjoiningType);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.DisjoiningType, writerContext);
                 stringBuilder.Append(' ');
             }
 
             stringBuilder.Append(' ');
-            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, cursorCache, stringBuilder);
+            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/DocumentationTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/DocumentationTextualNotationBuilder.cs
@@ -39,12 +39,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>Documentation='doc'Identification('locale'locale=STRING_VALUE)?body=REGULAR_COMMENT</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Annotations.IDocumentation" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildDocumentation(SysML2.NET.Core.POCO.Root.Annotations.IDocumentation poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildDocumentation(SysML2.NET.Core.POCO.Root.Annotations.IDocumentation poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             stringBuilder.Append("doc ");
-            ElementTextualNotationBuilder.BuildIdentification(poco, cursorCache, stringBuilder);
+            ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
 
             if (!string.IsNullOrWhiteSpace(poco.Locale))
             {

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ElementFilterMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ElementFilterMembershipTextualNotationBuilder.cs
@@ -39,12 +39,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>ElementFilterMember:ElementFilterMembership=MemberPrefix'filter'ownedRelatedElement+=OwnedExpression';'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Packages.IElementFilterMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildElementFilterMember(SysML2.NET.Core.POCO.Kernel.Packages.IElementFilterMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildElementFilterMember(SysML2.NET.Core.POCO.Kernel.Packages.IElementFilterMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("filter ");
 
             if (ownedRelatedElementCursor.Current != null)
@@ -52,7 +52,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IExpression elementAsExpression)
                 {
-                    ExpressionTextualNotationBuilder.BuildOwnedExpression(elementAsExpression, cursorCache, stringBuilder);
+                    ExpressionTextualNotationBuilder.BuildOwnedExpression(elementAsExpression, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -66,11 +66,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>FilterPackageMember:ElementFilterMembership='['ownedRelatedElement+=OwnedExpression']'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Packages.IElementFilterMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFilterPackageMember(SysML2.NET.Core.POCO.Kernel.Packages.IElementFilterMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFilterPackageMember(SysML2.NET.Core.POCO.Kernel.Packages.IElementFilterMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
             stringBuilder.Append("[");
 
             if (ownedRelatedElementCursor.Current != null)
@@ -78,7 +78,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IExpression elementAsExpression)
                 {
-                    ExpressionTextualNotationBuilder.BuildOwnedExpression(elementAsExpression, cursorCache, stringBuilder);
+                    ExpressionTextualNotationBuilder.BuildOwnedExpression(elementAsExpression, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ElementTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ElementTextualNotationBuilder.cs
@@ -39,9 +39,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>Identification:Element=('&lt;'declaredShortName=NAME'&gt;')?(declaredName=NAME)?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Elements.IElement" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildIdentification(SysML2.NET.Core.POCO.Root.Elements.IElement poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildIdentification(SysML2.NET.Core.POCO.Root.Elements.IElement poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName))
@@ -66,98 +66,98 @@ namespace SysML2.NET.TextualNotation
         /// <para>DefinitionElement:Element=Package|LibraryPackage|AnnotatingElement|Dependency|AttributeDefinition|EnumerationDefinition|OccurrenceDefinition|IndividualDefinition|ItemDefinition|PartDefinition|ConnectionDefinition|FlowDefinition|InterfaceDefinition|PortDefinition|ActionDefinition|CalculationDefinition|StateDefinition|ConstraintDefinition|RequirementDefinition|ConcernDefinition|CaseDefinition|AnalysisCaseDefinition|VerificationCaseDefinition|UseCaseDefinition|ViewDefinition|ViewpointDefinition|RenderingDefinition|MetadataDefinition|ExtendedDefinition</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Elements.IElement" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildDefinitionElement(SysML2.NET.Core.POCO.Root.Elements.IElement poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildDefinitionElement(SysML2.NET.Core.POCO.Root.Elements.IElement poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceDefinition pocoInterfaceDefinition:
-                    InterfaceDefinitionTextualNotationBuilder.BuildInterfaceDefinition(pocoInterfaceDefinition, cursorCache, stringBuilder);
+                    InterfaceDefinitionTextualNotationBuilder.BuildInterfaceDefinition(pocoInterfaceDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Connections.IConnectionDefinition pocoConnectionDefinition:
-                    ConnectionDefinitionTextualNotationBuilder.BuildConnectionDefinition(pocoConnectionDefinition, cursorCache, stringBuilder);
+                    ConnectionDefinitionTextualNotationBuilder.BuildConnectionDefinition(pocoConnectionDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Flows.IFlowDefinition pocoFlowDefinition:
-                    FlowDefinitionTextualNotationBuilder.BuildFlowDefinition(pocoFlowDefinition, cursorCache, stringBuilder);
+                    FlowDefinitionTextualNotationBuilder.BuildFlowDefinition(pocoFlowDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Requirements.IConcernDefinition pocoConcernDefinition:
-                    ConcernDefinitionTextualNotationBuilder.BuildConcernDefinition(pocoConcernDefinition, cursorCache, stringBuilder);
+                    ConcernDefinitionTextualNotationBuilder.BuildConcernDefinition(pocoConcernDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.AnalysisCases.IAnalysisCaseDefinition pocoAnalysisCaseDefinition:
-                    AnalysisCaseDefinitionTextualNotationBuilder.BuildAnalysisCaseDefinition(pocoAnalysisCaseDefinition, cursorCache, stringBuilder);
+                    AnalysisCaseDefinitionTextualNotationBuilder.BuildAnalysisCaseDefinition(pocoAnalysisCaseDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.VerificationCases.IVerificationCaseDefinition pocoVerificationCaseDefinition:
-                    VerificationCaseDefinitionTextualNotationBuilder.BuildVerificationCaseDefinition(pocoVerificationCaseDefinition, cursorCache, stringBuilder);
+                    VerificationCaseDefinitionTextualNotationBuilder.BuildVerificationCaseDefinition(pocoVerificationCaseDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.UseCases.IUseCaseDefinition pocoUseCaseDefinition:
-                    UseCaseDefinitionTextualNotationBuilder.BuildUseCaseDefinition(pocoUseCaseDefinition, cursorCache, stringBuilder);
+                    UseCaseDefinitionTextualNotationBuilder.BuildUseCaseDefinition(pocoUseCaseDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Views.IViewpointDefinition pocoViewpointDefinition:
-                    ViewpointDefinitionTextualNotationBuilder.BuildViewpointDefinition(pocoViewpointDefinition, cursorCache, stringBuilder);
+                    ViewpointDefinitionTextualNotationBuilder.BuildViewpointDefinition(pocoViewpointDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Requirements.IRequirementDefinition pocoRequirementDefinition:
-                    RequirementDefinitionTextualNotationBuilder.BuildRequirementDefinition(pocoRequirementDefinition, cursorCache, stringBuilder);
+                    RequirementDefinitionTextualNotationBuilder.BuildRequirementDefinition(pocoRequirementDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Cases.ICaseDefinition pocoCaseDefinition:
-                    CaseDefinitionTextualNotationBuilder.BuildCaseDefinition(pocoCaseDefinition, cursorCache, stringBuilder);
+                    CaseDefinitionTextualNotationBuilder.BuildCaseDefinition(pocoCaseDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Views.IRenderingDefinition pocoRenderingDefinition:
-                    RenderingDefinitionTextualNotationBuilder.BuildRenderingDefinition(pocoRenderingDefinition, cursorCache, stringBuilder);
+                    RenderingDefinitionTextualNotationBuilder.BuildRenderingDefinition(pocoRenderingDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Views.IViewDefinition pocoViewDefinition:
-                    ViewDefinitionTextualNotationBuilder.BuildViewDefinition(pocoViewDefinition, cursorCache, stringBuilder);
+                    ViewDefinitionTextualNotationBuilder.BuildViewDefinition(pocoViewDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Metadata.IMetadataDefinition pocoMetadataDefinition:
-                    MetadataDefinitionTextualNotationBuilder.BuildMetadataDefinition(pocoMetadataDefinition, cursorCache, stringBuilder);
+                    MetadataDefinitionTextualNotationBuilder.BuildMetadataDefinition(pocoMetadataDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Calculations.ICalculationDefinition pocoCalculationDefinition:
-                    CalculationDefinitionTextualNotationBuilder.BuildCalculationDefinition(pocoCalculationDefinition, cursorCache, stringBuilder);
+                    CalculationDefinitionTextualNotationBuilder.BuildCalculationDefinition(pocoCalculationDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Constraints.IConstraintDefinition pocoConstraintDefinition:
-                    ConstraintDefinitionTextualNotationBuilder.BuildConstraintDefinition(pocoConstraintDefinition, cursorCache, stringBuilder);
+                    ConstraintDefinitionTextualNotationBuilder.BuildConstraintDefinition(pocoConstraintDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Parts.IPartDefinition pocoPartDefinition:
-                    PartDefinitionTextualNotationBuilder.BuildPartDefinition(pocoPartDefinition, cursorCache, stringBuilder);
+                    PartDefinitionTextualNotationBuilder.BuildPartDefinition(pocoPartDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.States.IStateDefinition pocoStateDefinition:
-                    StateDefinitionTextualNotationBuilder.BuildStateDefinition(pocoStateDefinition, cursorCache, stringBuilder);
+                    StateDefinitionTextualNotationBuilder.BuildStateDefinition(pocoStateDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Items.IItemDefinition pocoItemDefinition:
-                    ItemDefinitionTextualNotationBuilder.BuildItemDefinition(pocoItemDefinition, cursorCache, stringBuilder);
+                    ItemDefinitionTextualNotationBuilder.BuildItemDefinition(pocoItemDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Ports.IPortDefinition pocoPortDefinition:
-                    PortDefinitionTextualNotationBuilder.BuildPortDefinition(pocoPortDefinition, cursorCache, stringBuilder);
+                    PortDefinitionTextualNotationBuilder.BuildPortDefinition(pocoPortDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Actions.IActionDefinition pocoActionDefinition:
-                    ActionDefinitionTextualNotationBuilder.BuildActionDefinition(pocoActionDefinition, cursorCache, stringBuilder);
+                    ActionDefinitionTextualNotationBuilder.BuildActionDefinition(pocoActionDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Enumerations.IEnumerationDefinition pocoEnumerationDefinition:
-                    EnumerationDefinitionTextualNotationBuilder.BuildEnumerationDefinition(pocoEnumerationDefinition, cursorCache, stringBuilder);
+                    EnumerationDefinitionTextualNotationBuilder.BuildEnumerationDefinition(pocoEnumerationDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Attributes.IAttributeDefinition pocoAttributeDefinition:
-                    AttributeDefinitionTextualNotationBuilder.BuildAttributeDefinition(pocoAttributeDefinition, cursorCache, stringBuilder);
+                    AttributeDefinitionTextualNotationBuilder.BuildAttributeDefinition(pocoAttributeDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceDefinition pocoOccurrenceDefinitionOccurrenceDefinition when pocoOccurrenceDefinitionOccurrenceDefinition.IsValidForOccurrenceDefinition():
-                    OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinition(pocoOccurrenceDefinitionOccurrenceDefinition, cursorCache, stringBuilder);
+                    OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinition(pocoOccurrenceDefinitionOccurrenceDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceDefinition pocoOccurrenceDefinition:
-                    OccurrenceDefinitionTextualNotationBuilder.BuildIndividualDefinition(pocoOccurrenceDefinition, cursorCache, stringBuilder);
+                    OccurrenceDefinitionTextualNotationBuilder.BuildIndividualDefinition(pocoOccurrenceDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IDefinition pocoDefinition:
-                    DefinitionTextualNotationBuilder.BuildExtendedDefinition(pocoDefinition, cursorCache, stringBuilder);
+                    DefinitionTextualNotationBuilder.BuildExtendedDefinition(pocoDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Packages.ILibraryPackage pocoLibraryPackage:
-                    LibraryPackageTextualNotationBuilder.BuildLibraryPackage(pocoLibraryPackage, cursorCache, stringBuilder);
+                    LibraryPackageTextualNotationBuilder.BuildLibraryPackage(pocoLibraryPackage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Root.Dependencies.IDependency pocoDependency:
-                    DependencyTextualNotationBuilder.BuildDependency(pocoDependency, cursorCache, stringBuilder);
+                    DependencyTextualNotationBuilder.BuildDependency(pocoDependency, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Packages.IPackage pocoPackage:
-                    PackageTextualNotationBuilder.BuildPackage(pocoPackage, cursorCache, stringBuilder);
+                    PackageTextualNotationBuilder.BuildPackage(pocoPackage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Root.Annotations.IAnnotatingElement pocoAnnotatingElement:
-                    AnnotatingElementTextualNotationBuilder.BuildAnnotatingElement(pocoAnnotatingElement, cursorCache, stringBuilder);
+                    AnnotatingElementTextualNotationBuilder.BuildAnnotatingElement(pocoAnnotatingElement, writerContext, stringBuilder);
                     break;
             }
 
@@ -168,17 +168,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedRelatedElement:Element=NonFeatureElement|FeatureElement</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Elements.IElement" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedRelatedElement(SysML2.NET.Core.POCO.Root.Elements.IElement poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedRelatedElement(SysML2.NET.Core.POCO.Root.Elements.IElement poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeature:
-                    FeatureTextualNotationBuilder.BuildFeatureElement(pocoFeature, cursorCache, stringBuilder);
+                    FeatureTextualNotationBuilder.BuildFeatureElement(pocoFeature, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildNonFeatureElement(poco, cursorCache, stringBuilder);
+                    BuildNonFeatureElement(poco, writerContext, stringBuilder);
                     break;
             }
 
@@ -189,17 +189,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>MemberElement:Element=AnnotatingElement|NonFeatureElement</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Elements.IElement" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMemberElement(SysML2.NET.Core.POCO.Root.Elements.IElement poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMemberElement(SysML2.NET.Core.POCO.Root.Elements.IElement poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Root.Annotations.IAnnotatingElement pocoAnnotatingElement:
-                    AnnotatingElementTextualNotationBuilder.BuildAnnotatingElement(pocoAnnotatingElement, cursorCache, stringBuilder);
+                    AnnotatingElementTextualNotationBuilder.BuildAnnotatingElement(pocoAnnotatingElement, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildNonFeatureElement(poco, cursorCache, stringBuilder);
+                    BuildNonFeatureElement(poco, writerContext, stringBuilder);
                     break;
             }
 
@@ -210,89 +210,89 @@ namespace SysML2.NET.TextualNotation
         /// <para>NonFeatureElement:Element=Dependency|Namespace|Type|Classifier|DataType|Class|Structure|Metaclass|Association|AssociationStructure|Interaction|Behavior|Function|Predicate|Multiplicity|Package|LibraryPackage|Specialization|Conjugation|Subclassification|Disjoining|FeatureInverting|FeatureTyping|Subsetting|Redefinition|TypeFeaturing</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Elements.IElement" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNonFeatureElement(SysML2.NET.Core.POCO.Root.Elements.IElement poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNonFeatureElement(SysML2.NET.Core.POCO.Root.Elements.IElement poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Kernel.Associations.IAssociationStructure pocoAssociationStructure:
-                    AssociationStructureTextualNotationBuilder.BuildAssociationStructure(pocoAssociationStructure, cursorCache, stringBuilder);
+                    AssociationStructureTextualNotationBuilder.BuildAssociationStructure(pocoAssociationStructure, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Interactions.IInteraction pocoInteraction:
-                    InteractionTextualNotationBuilder.BuildInteraction(pocoInteraction, cursorCache, stringBuilder);
+                    InteractionTextualNotationBuilder.BuildInteraction(pocoInteraction, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Functions.IPredicate pocoPredicate:
-                    PredicateTextualNotationBuilder.BuildPredicate(pocoPredicate, cursorCache, stringBuilder);
+                    PredicateTextualNotationBuilder.BuildPredicate(pocoPredicate, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Metadata.IMetaclass pocoMetaclass:
-                    MetaclassTextualNotationBuilder.BuildMetaclass(pocoMetaclass, cursorCache, stringBuilder);
+                    MetaclassTextualNotationBuilder.BuildMetaclass(pocoMetaclass, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Functions.IFunction pocoFunction:
-                    FunctionTextualNotationBuilder.BuildFunction(pocoFunction, cursorCache, stringBuilder);
+                    FunctionTextualNotationBuilder.BuildFunction(pocoFunction, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Structures.IStructure pocoStructure:
-                    StructureTextualNotationBuilder.BuildStructure(pocoStructure, cursorCache, stringBuilder);
+                    StructureTextualNotationBuilder.BuildStructure(pocoStructure, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Associations.IAssociation pocoAssociation:
-                    AssociationTextualNotationBuilder.BuildAssociation(pocoAssociation, cursorCache, stringBuilder);
+                    AssociationTextualNotationBuilder.BuildAssociation(pocoAssociation, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Behaviors.IBehavior pocoBehavior:
-                    BehaviorTextualNotationBuilder.BuildBehavior(pocoBehavior, cursorCache, stringBuilder);
+                    BehaviorTextualNotationBuilder.BuildBehavior(pocoBehavior, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.DataTypes.IDataType pocoDataType:
-                    DataTypeTextualNotationBuilder.BuildDataType(pocoDataType, cursorCache, stringBuilder);
+                    DataTypeTextualNotationBuilder.BuildDataType(pocoDataType, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Classes.IClass pocoClass:
-                    ClassTextualNotationBuilder.BuildClass(pocoClass, cursorCache, stringBuilder);
+                    ClassTextualNotationBuilder.BuildClass(pocoClass, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Core.Types.IMultiplicity pocoMultiplicity:
-                    MultiplicityTextualNotationBuilder.BuildMultiplicity(pocoMultiplicity, cursorCache, stringBuilder);
+                    MultiplicityTextualNotationBuilder.BuildMultiplicity(pocoMultiplicity, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Core.Features.IRedefinition pocoRedefinition:
-                    RedefinitionTextualNotationBuilder.BuildRedefinition(pocoRedefinition, cursorCache, stringBuilder);
+                    RedefinitionTextualNotationBuilder.BuildRedefinition(pocoRedefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Core.Features.ISubsetting pocoSubsetting:
-                    SubsettingTextualNotationBuilder.BuildSubsetting(pocoSubsetting, cursorCache, stringBuilder);
+                    SubsettingTextualNotationBuilder.BuildSubsetting(pocoSubsetting, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Core.Features.IFeatureTyping pocoFeatureTyping:
-                    FeatureTypingTextualNotationBuilder.BuildFeatureTyping(pocoFeatureTyping, cursorCache, stringBuilder);
+                    FeatureTypingTextualNotationBuilder.BuildFeatureTyping(pocoFeatureTyping, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Core.Classifiers.IClassifier pocoClassifier:
-                    ClassifierTextualNotationBuilder.BuildClassifier(pocoClassifier, cursorCache, stringBuilder);
+                    ClassifierTextualNotationBuilder.BuildClassifier(pocoClassifier, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Packages.ILibraryPackage pocoLibraryPackage:
-                    LibraryPackageTextualNotationBuilder.BuildLibraryPackage(pocoLibraryPackage, cursorCache, stringBuilder);
+                    LibraryPackageTextualNotationBuilder.BuildLibraryPackage(pocoLibraryPackage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Core.Classifiers.ISubclassification pocoSubclassification:
-                    SubclassificationTextualNotationBuilder.BuildSubclassification(pocoSubclassification, cursorCache, stringBuilder);
+                    SubclassificationTextualNotationBuilder.BuildSubclassification(pocoSubclassification, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Core.Features.ITypeFeaturing pocoTypeFeaturing:
-                    TypeFeaturingTextualNotationBuilder.BuildTypeFeaturing(pocoTypeFeaturing, cursorCache, stringBuilder);
+                    TypeFeaturingTextualNotationBuilder.BuildTypeFeaturing(pocoTypeFeaturing, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Root.Dependencies.IDependency pocoDependency:
-                    DependencyTextualNotationBuilder.BuildDependency(pocoDependency, cursorCache, stringBuilder);
+                    DependencyTextualNotationBuilder.BuildDependency(pocoDependency, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Core.Types.IType pocoType:
-                    TypeTextualNotationBuilder.BuildType(pocoType, cursorCache, stringBuilder);
+                    TypeTextualNotationBuilder.BuildType(pocoType, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Packages.IPackage pocoPackage:
-                    PackageTextualNotationBuilder.BuildPackage(pocoPackage, cursorCache, stringBuilder);
+                    PackageTextualNotationBuilder.BuildPackage(pocoPackage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Core.Types.ISpecialization pocoSpecialization:
-                    SpecializationTextualNotationBuilder.BuildSpecialization(pocoSpecialization, cursorCache, stringBuilder);
+                    SpecializationTextualNotationBuilder.BuildSpecialization(pocoSpecialization, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Core.Types.IConjugation pocoConjugation:
-                    ConjugationTextualNotationBuilder.BuildConjugation(pocoConjugation, cursorCache, stringBuilder);
+                    ConjugationTextualNotationBuilder.BuildConjugation(pocoConjugation, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Core.Types.IDisjoining pocoDisjoining:
-                    DisjoiningTextualNotationBuilder.BuildDisjoining(pocoDisjoining, cursorCache, stringBuilder);
+                    DisjoiningTextualNotationBuilder.BuildDisjoining(pocoDisjoining, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Core.Features.IFeatureInverting pocoFeatureInverting:
-                    FeatureInvertingTextualNotationBuilder.BuildFeatureInverting(pocoFeatureInverting, cursorCache, stringBuilder);
+                    FeatureInvertingTextualNotationBuilder.BuildFeatureInverting(pocoFeatureInverting, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Root.Namespaces.INamespace pocoNamespace:
-                    NamespaceTextualNotationBuilder.BuildNamespace(pocoNamespace, cursorCache, stringBuilder);
+                    NamespaceTextualNotationBuilder.BuildNamespace(pocoNamespace, writerContext, stringBuilder);
                     break;
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ElementTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ElementTextualNotationBuilder.cs
@@ -138,7 +138,7 @@ namespace SysML2.NET.TextualNotation
                 case SysML2.NET.Core.POCO.Systems.Attributes.IAttributeDefinition pocoAttributeDefinition:
                     AttributeDefinitionTextualNotationBuilder.BuildAttributeDefinition(pocoAttributeDefinition, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceDefinition pocoOccurrenceDefinitionOccurrenceDefinition when pocoOccurrenceDefinitionOccurrenceDefinition.IsValidForOccurrenceDefinition():
+                case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceDefinition pocoOccurrenceDefinitionOccurrenceDefinition when pocoOccurrenceDefinitionOccurrenceDefinition.IsValidForOccurrenceDefinition(writerContext):
                     OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinition(pocoOccurrenceDefinitionOccurrenceDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceDefinition pocoOccurrenceDefinition:

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/EndFeatureMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/EndFeatureMembershipTextualNotationBuilder.cs
@@ -39,18 +39,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>SourceEndMember:EndFeatureMembership=ownedRelatedElement+=SourceEnd</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSourceEndMember(SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSourceEndMember(SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
-                    ReferenceUsageTextualNotationBuilder.BuildSourceEnd(elementAsReferenceUsage, cursorCache, stringBuilder);
+                    ReferenceUsageTextualNotationBuilder.BuildSourceEnd(elementAsReferenceUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -63,18 +63,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>ConnectorEndMember:EndFeatureMembership=ownedRelatedElement+=ConnectorEnd</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildConnectorEndMember(SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildConnectorEndMember(SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
-                    ReferenceUsageTextualNotationBuilder.BuildConnectorEnd(elementAsReferenceUsage, cursorCache, stringBuilder);
+                    ReferenceUsageTextualNotationBuilder.BuildConnectorEnd(elementAsReferenceUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -87,18 +87,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>InterfaceEndMember:EndFeatureMembership=ownedRelatedElement+=InterfaceEnd</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildInterfaceEndMember(SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildInterfaceEndMember(SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Ports.IPortUsage elementAsPortUsage)
                 {
-                    PortUsageTextualNotationBuilder.BuildInterfaceEnd(elementAsPortUsage, cursorCache, stringBuilder);
+                    PortUsageTextualNotationBuilder.BuildInterfaceEnd(elementAsPortUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -111,18 +111,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>FlowEndMember:EndFeatureMembership=ownedRelatedElement+=FlowEnd</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFlowEndMember(SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFlowEndMember(SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Interactions.IFlowEnd elementAsFlowEnd)
                 {
-                    FlowEndTextualNotationBuilder.BuildFlowEnd(elementAsFlowEnd, cursorCache, stringBuilder);
+                    FlowEndTextualNotationBuilder.BuildFlowEnd(elementAsFlowEnd, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -135,18 +135,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>EmptyEndMember:EndFeatureMembership=ownedRelatedElement+=EmptyFeature</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildEmptyEndMember(SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildEmptyEndMember(SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
-                    ReferenceUsageTextualNotationBuilder.BuildEmptyFeature(elementAsReferenceUsage, cursorCache, stringBuilder);
+                    ReferenceUsageTextualNotationBuilder.BuildEmptyFeature(elementAsReferenceUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/EnumerationDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/EnumerationDefinitionTextualNotationBuilder.cs
@@ -39,17 +39,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>EnumerationBody:EnumerationDefinition=';'|'{'(ownedRelationship+=AnnotatingMember|ownedRelationship+=EnumerationUsageMember)*'}'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Enumerations.IEnumerationDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildEnumerationBody(SysML2.NET.Core.POCO.Systems.Enumerations.IEnumerationDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildEnumerationBody(SysML2.NET.Core.POCO.Systems.Enumerations.IEnumerationDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            if (cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
+            if (writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
             {
                 stringBuilder.AppendLine(";");
             }
             else
             {
-                var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
                 while (ownedRelationshipCursor.Current != null)
@@ -57,10 +57,10 @@ namespace SysML2.NET.TextualNotation
                     switch (ownedRelationshipCursor.Current)
                     {
                         case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IVariantMembership variantMembership:
-                            VariantMembershipTextualNotationBuilder.BuildEnumerationUsageMember(variantMembership, cursorCache, stringBuilder);
+                            VariantMembershipTextualNotationBuilder.BuildEnumerationUsageMember(variantMembership, writerContext, stringBuilder);
                             break;
                         case SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership owningMembership:
-                            OwningMembershipTextualNotationBuilder.BuildAnnotatingMember(owningMembership, cursorCache, stringBuilder);
+                            OwningMembershipTextualNotationBuilder.BuildAnnotatingMember(owningMembership, writerContext, stringBuilder);
                             break;
                     }
                     ownedRelationshipCursor.Move();
@@ -76,20 +76,20 @@ namespace SysML2.NET.TextualNotation
         /// <para>EnumerationDefinition=DefinitionExtensionKeyword*'enum''def'DefinitionDeclarationEnumerationBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Enumerations.IEnumerationDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildEnumerationDefinition(SysML2.NET.Core.POCO.Systems.Enumerations.IEnumerationDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildEnumerationDefinition(SysML2.NET.Core.POCO.Systems.Enumerations.IEnumerationDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership)
             {
-                DefinitionTextualNotationBuilder.BuildDefinitionExtensionKeyword(poco, cursorCache, stringBuilder);
+                DefinitionTextualNotationBuilder.BuildDefinitionExtensionKeyword(poco, writerContext, stringBuilder);
             }
 
             stringBuilder.Append("enum ");
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, cursorCache, stringBuilder);
-            BuildEnumerationBody(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, writerContext, stringBuilder);
+            BuildEnumerationBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/EnumerationUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/EnumerationUsageTextualNotationBuilder.cs
@@ -39,12 +39,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>EnumeratedValue:EnumerationUsage='enum'?Usage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Enumerations.IEnumerationUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildEnumeratedValue(SysML2.NET.Core.POCO.Systems.Enumerations.IEnumerationUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildEnumeratedValue(SysML2.NET.Core.POCO.Systems.Enumerations.IEnumerationUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             stringBuilder.Append("enum ");
-            UsageTextualNotationBuilder.BuildUsage(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsage(poco, writerContext, stringBuilder);
 
         }
 
@@ -53,13 +53,13 @@ namespace SysML2.NET.TextualNotation
         /// <para>EnumerationUsage:EnumerationUsage=UsagePrefix'enum'Usage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Enumerations.IEnumerationUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildEnumerationUsage(SysML2.NET.Core.POCO.Systems.Enumerations.IEnumerationUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildEnumerationUsage(SysML2.NET.Core.POCO.Systems.Enumerations.IEnumerationUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            UsageTextualNotationBuilder.BuildUsagePrefix(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("enum ");
-            UsageTextualNotationBuilder.BuildUsage(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsage(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/EventOccurrenceUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/EventOccurrenceUsageTextualNotationBuilder.cs
@@ -39,18 +39,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>MessageEvent:EventOccurrenceUsage=ownedRelationship+=OwnedReferenceSubsetting</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Occurrences.IEventOccurrenceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMessageEvent(SysML2.NET.Core.POCO.Systems.Occurrences.IEventOccurrenceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMessageEvent(SysML2.NET.Core.POCO.Systems.Occurrences.IEventOccurrenceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting elementAsReferenceSubsetting)
                 {
-                    ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, cursorCache, stringBuilder);
+                    ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -63,12 +63,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>EventOccurrenceUsage=OccurrenceUsagePrefix'event'(ownedRelationship+=OwnedReferenceSubsettingFeatureSpecializationPart?|'occurrence'UsageDeclaration?)UsageCompletion</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Occurrences.IEventOccurrenceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildEventOccurrenceUsage(SysML2.NET.Core.POCO.Systems.Occurrences.IEventOccurrenceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildEventOccurrenceUsage(SysML2.NET.Core.POCO.Systems.Occurrences.IEventOccurrenceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("event ");
             if (poco.OwnedRelationship.OfType<SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting>().Any())
             {
@@ -78,7 +78,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting elementAsReferenceSubsetting)
                     {
-                        ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, cursorCache, stringBuilder);
+                        ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -86,7 +86,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
                 {
-                    FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, cursorCache, stringBuilder);
+                    FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, writerContext, stringBuilder);
                 }
             }
             else
@@ -95,12 +95,12 @@ namespace SysML2.NET.TextualNotation
 
                 if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
                 {
-                    UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
+                    UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
                 }
             }
 
             stringBuilder.Append(' ');
-            UsageTextualNotationBuilder.BuildUsageCompletion(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsageCompletion(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ExhibitStateUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ExhibitStateUsageTextualNotationBuilder.cs
@@ -39,12 +39,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>ExhibitStateUsage=OccurrenceUsagePrefix'exhibit'(ownedRelationship+=OwnedReferenceSubsettingFeatureSpecializationPart?|'state'UsageDeclaration)ValuePart?StateUsageBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.IExhibitStateUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildExhibitStateUsage(SysML2.NET.Core.POCO.Systems.States.IExhibitStateUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildExhibitStateUsage(SysML2.NET.Core.POCO.Systems.States.IExhibitStateUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("exhibit ");
             if (poco.OwnedRelationship.OfType<SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting>().Any())
             {
@@ -54,7 +54,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting elementAsReferenceSubsetting)
                     {
-                        ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, cursorCache, stringBuilder);
+                        ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -62,22 +62,22 @@ namespace SysML2.NET.TextualNotation
 
                 if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
                 {
-                    FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, cursorCache, stringBuilder);
+                    FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, writerContext, stringBuilder);
                 }
             }
             else
             {
                 stringBuilder.Append("state ");
-                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
             }
 
             stringBuilder.Append(' ');
 
             if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
-                FeatureTextualNotationBuilder.BuildValuePart(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }
-            StateUsageTextualNotationBuilder.BuildStateUsageBody(poco, cursorCache, stringBuilder);
+            StateUsageTextualNotationBuilder.BuildStateUsageBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ExposeTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ExposeTextualNotationBuilder.cs
@@ -39,23 +39,23 @@ namespace SysML2.NET.TextualNotation
         /// <para>Expose='expose'(MembershipExpose|NamespaceExpose)RelationshipBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.IExpose" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildExpose(SysML2.NET.Core.POCO.Systems.Views.IExpose poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildExpose(SysML2.NET.Core.POCO.Systems.Views.IExpose poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             stringBuilder.Append("expose ");
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Systems.Views.IMembershipExpose pocoMembershipExpose:
-                    MembershipExposeTextualNotationBuilder.BuildMembershipExpose(pocoMembershipExpose, cursorCache, stringBuilder);
+                    MembershipExposeTextualNotationBuilder.BuildMembershipExpose(pocoMembershipExpose, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Views.INamespaceExpose pocoNamespaceExpose:
-                    NamespaceExposeTextualNotationBuilder.BuildNamespaceExpose(pocoNamespaceExpose, cursorCache, stringBuilder);
+                    NamespaceExposeTextualNotationBuilder.BuildNamespaceExpose(pocoNamespaceExpose, writerContext, stringBuilder);
                     break;
             }
 
             stringBuilder.Append(' ');
-            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, cursorCache, stringBuilder);
+            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ExpressionTextualNotationBuilder.cs
@@ -39,35 +39,35 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedExpression:Expression=ConditionalExpression|ConditionalBinaryOperatorExpression|BinaryOperatorExpression|UnaryOperatorExpression|ClassificationExpression|MetaclassificationExpression|ExtentExpression|PrimaryExpression</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.IExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedExpression(SysML2.NET.Core.POCO.Kernel.Functions.IExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedExpression(SysML2.NET.Core.POCO.Kernel.Functions.IExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpressionConditionalExpression when pocoOperatorExpressionConditionalExpression.IsValidForConditionalExpression():
-                    OperatorExpressionTextualNotationBuilder.BuildConditionalExpression(pocoOperatorExpressionConditionalExpression, cursorCache, stringBuilder);
+                    OperatorExpressionTextualNotationBuilder.BuildConditionalExpression(pocoOperatorExpressionConditionalExpression, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpressionConditionalBinaryOperatorExpression when pocoOperatorExpressionConditionalBinaryOperatorExpression.IsValidForConditionalBinaryOperatorExpression():
-                    OperatorExpressionTextualNotationBuilder.BuildConditionalBinaryOperatorExpression(pocoOperatorExpressionConditionalBinaryOperatorExpression, cursorCache, stringBuilder);
+                    OperatorExpressionTextualNotationBuilder.BuildConditionalBinaryOperatorExpression(pocoOperatorExpressionConditionalBinaryOperatorExpression, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpressionBinaryOperatorExpression when pocoOperatorExpressionBinaryOperatorExpression.IsValidForBinaryOperatorExpression():
-                    OperatorExpressionTextualNotationBuilder.BuildBinaryOperatorExpression(pocoOperatorExpressionBinaryOperatorExpression, cursorCache, stringBuilder);
+                    OperatorExpressionTextualNotationBuilder.BuildBinaryOperatorExpression(pocoOperatorExpressionBinaryOperatorExpression, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpressionUnaryOperatorExpression when pocoOperatorExpressionUnaryOperatorExpression.IsValidForUnaryOperatorExpression():
-                    OperatorExpressionTextualNotationBuilder.BuildUnaryOperatorExpression(pocoOperatorExpressionUnaryOperatorExpression, cursorCache, stringBuilder);
+                    OperatorExpressionTextualNotationBuilder.BuildUnaryOperatorExpression(pocoOperatorExpressionUnaryOperatorExpression, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpressionClassificationExpression when pocoOperatorExpressionClassificationExpression.IsValidForClassificationExpression():
-                    OperatorExpressionTextualNotationBuilder.BuildClassificationExpression(pocoOperatorExpressionClassificationExpression, cursorCache, stringBuilder);
+                    OperatorExpressionTextualNotationBuilder.BuildClassificationExpression(pocoOperatorExpressionClassificationExpression, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpressionMetaclassificationExpression when pocoOperatorExpressionMetaclassificationExpression.IsValidForMetaclassificationExpression():
-                    OperatorExpressionTextualNotationBuilder.BuildMetaclassificationExpression(pocoOperatorExpressionMetaclassificationExpression, cursorCache, stringBuilder);
+                    OperatorExpressionTextualNotationBuilder.BuildMetaclassificationExpression(pocoOperatorExpressionMetaclassificationExpression, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpression:
-                    OperatorExpressionTextualNotationBuilder.BuildExtentExpression(pocoOperatorExpression, cursorCache, stringBuilder);
+                    OperatorExpressionTextualNotationBuilder.BuildExtentExpression(pocoOperatorExpression, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildPrimaryExpression(poco, cursorCache, stringBuilder);
+                    BuildPrimaryExpression(poco, writerContext, stringBuilder);
                     break;
             }
 
@@ -78,17 +78,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>PrimaryExpression:Expression=FeatureChainExpression|NonFeatureChainPrimaryExpression</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.IExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPrimaryExpression(SysML2.NET.Core.POCO.Kernel.Functions.IExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPrimaryExpression(SysML2.NET.Core.POCO.Kernel.Functions.IExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureChainExpression pocoFeatureChainExpression:
-                    FeatureChainExpressionTextualNotationBuilder.BuildFeatureChainExpression(pocoFeatureChainExpression, cursorCache, stringBuilder);
+                    FeatureChainExpressionTextualNotationBuilder.BuildFeatureChainExpression(pocoFeatureChainExpression, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildNonFeatureChainPrimaryExpression(poco, cursorCache, stringBuilder);
+                    BuildNonFeatureChainPrimaryExpression(poco, writerContext, stringBuilder);
                     break;
             }
 
@@ -99,32 +99,32 @@ namespace SysML2.NET.TextualNotation
         /// <para>NonFeatureChainPrimaryExpression:Expression=BracketExpression|IndexExpression|SequenceExpression|SelectExpression|CollectExpression|FunctionOperationExpression|BaseExpression</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.IExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNonFeatureChainPrimaryExpression(SysML2.NET.Core.POCO.Kernel.Functions.IExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNonFeatureChainPrimaryExpression(SysML2.NET.Core.POCO.Kernel.Functions.IExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Kernel.Expressions.IIndexExpression pocoIndexExpression:
-                    IndexExpressionTextualNotationBuilder.BuildIndexExpression(pocoIndexExpression, cursorCache, stringBuilder);
+                    IndexExpressionTextualNotationBuilder.BuildIndexExpression(pocoIndexExpression, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Expressions.ISelectExpression pocoSelectExpression:
-                    SelectExpressionTextualNotationBuilder.BuildSelectExpression(pocoSelectExpression, cursorCache, stringBuilder);
+                    SelectExpressionTextualNotationBuilder.BuildSelectExpression(pocoSelectExpression, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Expressions.ICollectExpression pocoCollectExpression:
-                    CollectExpressionTextualNotationBuilder.BuildCollectExpression(pocoCollectExpression, cursorCache, stringBuilder);
+                    CollectExpressionTextualNotationBuilder.BuildCollectExpression(pocoCollectExpression, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpression:
-                    OperatorExpressionTextualNotationBuilder.BuildBracketExpression(pocoOperatorExpression, cursorCache, stringBuilder);
+                    OperatorExpressionTextualNotationBuilder.BuildBracketExpression(pocoOperatorExpression, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Expressions.IInvocationExpression pocoInvocationExpression:
-                    InvocationExpressionTextualNotationBuilder.BuildFunctionOperationExpression(pocoInvocationExpression, cursorCache, stringBuilder);
+                    InvocationExpressionTextualNotationBuilder.BuildFunctionOperationExpression(pocoInvocationExpression, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Functions.IExpression pocoExpressionSequenceExpression when pocoExpressionSequenceExpression.IsValidForSequenceExpression():
-                    BuildSequenceExpression(pocoExpressionSequenceExpression, cursorCache, stringBuilder);
+                    BuildSequenceExpression(pocoExpressionSequenceExpression, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildBaseExpression(poco, cursorCache, stringBuilder);
+                    BuildBaseExpression(poco, writerContext, stringBuilder);
                     break;
             }
 
@@ -135,12 +135,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>SequenceExpression:Expression='('SequenceExpressionList')'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.IExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSequenceExpression(SysML2.NET.Core.POCO.Kernel.Functions.IExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSequenceExpression(SysML2.NET.Core.POCO.Kernel.Functions.IExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             stringBuilder.Append("(");
-            BuildSequenceExpressionList(poco, cursorCache, stringBuilder);
+            BuildSequenceExpressionList(poco, writerContext, stringBuilder);
             stringBuilder.Append(") ");
 
         }
@@ -150,11 +150,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>SequenceExpressionList:Expression=OwnedExpression','?|SequenceOperatorExpression</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.IExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSequenceExpressionList(SysML2.NET.Core.POCO.Kernel.Functions.IExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSequenceExpressionList(SysML2.NET.Core.POCO.Kernel.Functions.IExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildSequenceExpressionListHandCoded(poco, cursorCache, stringBuilder);
+            BuildSequenceExpressionListHandCoded(poco, writerContext, stringBuilder);
         }
 
         /// <summary>
@@ -162,18 +162,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>FunctionReference:Expression=ownedRelationship+=ReferenceTyping</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.IExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFunctionReference(SysML2.NET.Core.POCO.Kernel.Functions.IExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFunctionReference(SysML2.NET.Core.POCO.Kernel.Functions.IExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping elementAsFeatureTyping)
                 {
-                    FeatureTypingTextualNotationBuilder.BuildReferenceTyping(elementAsFeatureTyping, cursorCache, stringBuilder);
+                    FeatureTypingTextualNotationBuilder.BuildReferenceTyping(elementAsFeatureTyping, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -186,32 +186,32 @@ namespace SysML2.NET.TextualNotation
         /// <para>BaseExpression:Expression=NullExpression|LiteralExpression|FeatureReferenceExpression|MetadataAccessExpression|InvocationExpression|ConstructorExpression|BodyExpression</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.IExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildBaseExpression(SysML2.NET.Core.POCO.Kernel.Functions.IExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildBaseExpression(SysML2.NET.Core.POCO.Kernel.Functions.IExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Kernel.Expressions.IInvocationExpression pocoInvocationExpression:
-                    InvocationExpressionTextualNotationBuilder.BuildInvocationExpression(pocoInvocationExpression, cursorCache, stringBuilder);
+                    InvocationExpressionTextualNotationBuilder.BuildInvocationExpression(pocoInvocationExpression, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Expressions.IConstructorExpression pocoConstructorExpression:
-                    ConstructorExpressionTextualNotationBuilder.BuildConstructorExpression(pocoConstructorExpression, cursorCache, stringBuilder);
+                    ConstructorExpressionTextualNotationBuilder.BuildConstructorExpression(pocoConstructorExpression, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Expressions.INullExpression pocoNullExpression:
-                    NullExpressionTextualNotationBuilder.BuildNullExpression(pocoNullExpression, cursorCache, stringBuilder);
+                    NullExpressionTextualNotationBuilder.BuildNullExpression(pocoNullExpression, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Expressions.ILiteralExpression pocoLiteralExpression:
-                    LiteralExpressionTextualNotationBuilder.BuildLiteralExpression(pocoLiteralExpression, cursorCache, stringBuilder);
+                    LiteralExpressionTextualNotationBuilder.BuildLiteralExpression(pocoLiteralExpression, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression pocoFeatureReferenceExpressionFeatureReferenceExpression when pocoFeatureReferenceExpressionFeatureReferenceExpression.IsValidForFeatureReferenceExpression():
-                    FeatureReferenceExpressionTextualNotationBuilder.BuildFeatureReferenceExpression(pocoFeatureReferenceExpressionFeatureReferenceExpression, cursorCache, stringBuilder);
+                    FeatureReferenceExpressionTextualNotationBuilder.BuildFeatureReferenceExpression(pocoFeatureReferenceExpressionFeatureReferenceExpression, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression pocoFeatureReferenceExpression:
-                    FeatureReferenceExpressionTextualNotationBuilder.BuildBodyExpression(pocoFeatureReferenceExpression, cursorCache, stringBuilder);
+                    FeatureReferenceExpressionTextualNotationBuilder.BuildBodyExpression(pocoFeatureReferenceExpression, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Expressions.IMetadataAccessExpression pocoMetadataAccessExpression:
-                    MetadataAccessExpressionTextualNotationBuilder.BuildMetadataAccessExpression(pocoMetadataAccessExpression, cursorCache, stringBuilder);
+                    MetadataAccessExpressionTextualNotationBuilder.BuildMetadataAccessExpression(pocoMetadataAccessExpression, writerContext, stringBuilder);
                     break;
             }
 
@@ -222,13 +222,13 @@ namespace SysML2.NET.TextualNotation
         /// <para>ExpressionBody:Expression='{'FunctionBodyPart'}'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.IExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildExpressionBody(SysML2.NET.Core.POCO.Kernel.Functions.IExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildExpressionBody(SysML2.NET.Core.POCO.Kernel.Functions.IExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             stringBuilder.Append(' ');
             stringBuilder.AppendLine("{");
-            TypeTextualNotationBuilder.BuildFunctionBodyPart(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildFunctionBodyPart(poco, writerContext, stringBuilder);
             stringBuilder.AppendLine("}");
 
         }
@@ -238,19 +238,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>Expression=FeaturePrefix'expr'FeatureDeclarationValuePart?FunctionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.IExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildExpression(SysML2.NET.Core.POCO.Kernel.Functions.IExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildExpression(SysML2.NET.Core.POCO.Kernel.Functions.IExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            SharedTextualNotationBuilder.BuildFeaturePrefix(poco, cursorCache, stringBuilder);
+            SharedTextualNotationBuilder.BuildFeaturePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("expr ");
-            FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, cursorCache, stringBuilder);
+            FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, writerContext, stringBuilder);
 
             if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
-                FeatureTextualNotationBuilder.BuildValuePart(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }
-            TypeTextualNotationBuilder.BuildFunctionBody(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildFunctionBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ExpressionTextualNotationBuilder.cs
@@ -45,22 +45,22 @@ namespace SysML2.NET.TextualNotation
         {
             switch (poco)
             {
-                case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpressionConditionalExpression when pocoOperatorExpressionConditionalExpression.IsValidForConditionalExpression():
+                case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpressionConditionalExpression when pocoOperatorExpressionConditionalExpression.IsValidForConditionalExpression(writerContext):
                     OperatorExpressionTextualNotationBuilder.BuildConditionalExpression(pocoOperatorExpressionConditionalExpression, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpressionConditionalBinaryOperatorExpression when pocoOperatorExpressionConditionalBinaryOperatorExpression.IsValidForConditionalBinaryOperatorExpression():
+                case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpressionConditionalBinaryOperatorExpression when pocoOperatorExpressionConditionalBinaryOperatorExpression.IsValidForConditionalBinaryOperatorExpression(writerContext):
                     OperatorExpressionTextualNotationBuilder.BuildConditionalBinaryOperatorExpression(pocoOperatorExpressionConditionalBinaryOperatorExpression, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpressionBinaryOperatorExpression when pocoOperatorExpressionBinaryOperatorExpression.IsValidForBinaryOperatorExpression():
+                case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpressionBinaryOperatorExpression when pocoOperatorExpressionBinaryOperatorExpression.IsValidForBinaryOperatorExpression(writerContext):
                     OperatorExpressionTextualNotationBuilder.BuildBinaryOperatorExpression(pocoOperatorExpressionBinaryOperatorExpression, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpressionUnaryOperatorExpression when pocoOperatorExpressionUnaryOperatorExpression.IsValidForUnaryOperatorExpression():
+                case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpressionUnaryOperatorExpression when pocoOperatorExpressionUnaryOperatorExpression.IsValidForUnaryOperatorExpression(writerContext):
                     OperatorExpressionTextualNotationBuilder.BuildUnaryOperatorExpression(pocoOperatorExpressionUnaryOperatorExpression, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpressionClassificationExpression when pocoOperatorExpressionClassificationExpression.IsValidForClassificationExpression():
+                case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpressionClassificationExpression when pocoOperatorExpressionClassificationExpression.IsValidForClassificationExpression(writerContext):
                     OperatorExpressionTextualNotationBuilder.BuildClassificationExpression(pocoOperatorExpressionClassificationExpression, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpressionMetaclassificationExpression when pocoOperatorExpressionMetaclassificationExpression.IsValidForMetaclassificationExpression():
+                case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpressionMetaclassificationExpression when pocoOperatorExpressionMetaclassificationExpression.IsValidForMetaclassificationExpression(writerContext):
                     OperatorExpressionTextualNotationBuilder.BuildMetaclassificationExpression(pocoOperatorExpressionMetaclassificationExpression, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpression:
@@ -120,7 +120,7 @@ namespace SysML2.NET.TextualNotation
                 case SysML2.NET.Core.POCO.Kernel.Expressions.IInvocationExpression pocoInvocationExpression:
                     InvocationExpressionTextualNotationBuilder.BuildFunctionOperationExpression(pocoInvocationExpression, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Kernel.Functions.IExpression pocoExpressionSequenceExpression when pocoExpressionSequenceExpression.IsValidForSequenceExpression():
+                case SysML2.NET.Core.POCO.Kernel.Functions.IExpression pocoExpressionSequenceExpression when pocoExpressionSequenceExpression.IsValidForSequenceExpression(writerContext):
                     BuildSequenceExpression(pocoExpressionSequenceExpression, writerContext, stringBuilder);
                     break;
                 default:
@@ -204,7 +204,7 @@ namespace SysML2.NET.TextualNotation
                 case SysML2.NET.Core.POCO.Kernel.Expressions.ILiteralExpression pocoLiteralExpression:
                     LiteralExpressionTextualNotationBuilder.BuildLiteralExpression(pocoLiteralExpression, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression pocoFeatureReferenceExpressionFeatureReferenceExpression when pocoFeatureReferenceExpressionFeatureReferenceExpression.IsValidForFeatureReferenceExpression():
+                case SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression pocoFeatureReferenceExpressionFeatureReferenceExpression when pocoFeatureReferenceExpressionFeatureReferenceExpression.IsValidForFeatureReferenceExpression(writerContext):
                     FeatureReferenceExpressionTextualNotationBuilder.BuildFeatureReferenceExpression(pocoFeatureReferenceExpressionFeatureReferenceExpression, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression pocoFeatureReferenceExpression:

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureChainExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureChainExpressionTextualNotationBuilder.cs
@@ -39,18 +39,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>FeatureChainExpression=ownedRelationship+=NonFeatureChainPrimaryArgumentMember'.'ownedRelationship+=FeatureChainMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureChainExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFeatureChainExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureChainExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFeatureChainExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureChainExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildNonFeatureChainPrimaryArgumentMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildNonFeatureChainPrimaryArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -62,7 +62,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership elementAsMembership)
                 {
-                    MembershipTextualNotationBuilder.BuildFeatureChainMember(elementAsMembership, cursorCache, stringBuilder);
+                    MembershipTextualNotationBuilder.BuildFeatureChainMember(elementAsMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureChainingTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureChainingTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedFeatureChaining:FeatureChaining=chainingFeature=[QualifiedName]</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeatureChaining" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedFeatureChaining(SysML2.NET.Core.POCO.Core.Features.IFeatureChaining poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedFeatureChaining(SysML2.NET.Core.POCO.Core.Features.IFeatureChaining poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.ChainingFeature != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.ChainingFeature);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.ChainingFeature, writerContext);
                 stringBuilder.Append(' ');
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureChainingTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureChainingTextualNotationBuilder.cs
@@ -46,7 +46,7 @@ namespace SysML2.NET.TextualNotation
 
             if (poco.ChainingFeature != null)
             {
-                stringBuilder.Append(poco.ChainingFeature.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.ChainingFeature);
                 stringBuilder.Append(' ');
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureDirectionKindTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureDirectionKindTextualNotationBuilder.cs
@@ -39,9 +39,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>FeatureDirection:FeatureDirectionKind='in'|'out'|'inout'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.Core.Types.FeatureDirectionKind" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFeatureDirection(SysML2.NET.Core.Core.Types.FeatureDirectionKind poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFeatureDirection(SysML2.NET.Core.Core.Types.FeatureDirectionKind poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
         }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureInvertingTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureInvertingTextualNotationBuilder.cs
@@ -49,7 +49,7 @@ namespace SysML2.NET.TextualNotation
             }
             else if (poco.InvertingFeature != null)
             {
-                stringBuilder.Append(poco.InvertingFeature.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.InvertingFeature);
                 stringBuilder.Append(' ');
             }
 
@@ -84,7 +84,7 @@ namespace SysML2.NET.TextualNotation
             }
             else if (poco.FeatureInverted != null)
             {
-                stringBuilder.Append(poco.FeatureInverted.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.FeatureInverted);
                 stringBuilder.Append(' ');
             }
 
@@ -96,7 +96,7 @@ namespace SysML2.NET.TextualNotation
             }
             else if (poco.InvertingFeature != null)
             {
-                stringBuilder.Append(poco.InvertingFeature.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.InvertingFeature);
                 stringBuilder.Append(' ');
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureInvertingTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureInvertingTextualNotationBuilder.cs
@@ -39,17 +39,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedFeatureInverting:FeatureInverting=invertingFeature=[QualifiedName]|invertingFeature=OwnedFeatureChain{ownedRelatedElement+=invertingFeature}</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeatureInverting" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedFeatureInverting(SysML2.NET.Core.POCO.Core.Features.IFeatureInverting poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedFeatureInverting(SysML2.NET.Core.POCO.Core.Features.IFeatureInverting poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             if (poco.OwnedRelatedElement.Contains(poco.InvertingFeature) && poco.InvertingFeature is SysML2.NET.Core.POCO.Core.Features.IFeature chainedInvertingFeatureAsFeature)
             {
-                FeatureTextualNotationBuilder.BuildOwnedFeatureChain(chainedInvertingFeatureAsFeature, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildOwnedFeatureChain(chainedInvertingFeatureAsFeature, writerContext, stringBuilder);
             }
             else if (poco.InvertingFeature != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.InvertingFeature);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.InvertingFeature, writerContext);
                 stringBuilder.Append(' ');
             }
 
@@ -60,11 +60,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>FeatureInverting=('inverting'Identification?)?'inverse'(featureInverted=[QualifiedName]|featureInverted=OwnedFeatureChain{ownedRelatedElement+=featureInverted})'of'(invertingFeature=[QualifiedName]|ownedRelatedElement+=OwnedFeatureChain{ownedRelatedElement+=invertingFeature})RelationshipBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeatureInverting" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFeatureInverting(SysML2.NET.Core.POCO.Core.Features.IFeatureInverting poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFeatureInverting(SysML2.NET.Core.POCO.Core.Features.IFeatureInverting poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName))
             {
@@ -72,7 +72,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName))
                 {
-                    ElementTextualNotationBuilder.BuildIdentification(poco, cursorCache, stringBuilder);
+                    ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
                 }
                 stringBuilder.Append(' ');
             }
@@ -80,11 +80,11 @@ namespace SysML2.NET.TextualNotation
             stringBuilder.Append("inverse ");
             if (poco.OwnedRelatedElement.Contains(poco.FeatureInverted) && poco.FeatureInverted is SysML2.NET.Core.POCO.Core.Features.IFeature chainedFeatureInvertedAsFeature)
             {
-                FeatureTextualNotationBuilder.BuildOwnedFeatureChain(chainedFeatureInvertedAsFeature, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildOwnedFeatureChain(chainedFeatureInvertedAsFeature, writerContext, stringBuilder);
             }
             else if (poco.FeatureInverted != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.FeatureInverted);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.FeatureInverted, writerContext);
                 stringBuilder.Append(' ');
             }
 
@@ -92,16 +92,16 @@ namespace SysML2.NET.TextualNotation
             stringBuilder.Append("of ");
             if (poco.OwnedRelatedElement.Contains(poco.InvertingFeature) && poco.InvertingFeature is SysML2.NET.Core.POCO.Core.Features.IFeature chainedInvertingFeatureAsFeature)
             {
-                FeatureTextualNotationBuilder.BuildOwnedFeatureChain(chainedInvertingFeatureAsFeature, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildOwnedFeatureChain(chainedInvertingFeatureAsFeature, writerContext, stringBuilder);
             }
             else if (poco.InvertingFeature != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.InvertingFeature);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.InvertingFeature, writerContext);
                 stringBuilder.Append(' ');
             }
 
             stringBuilder.Append(' ');
-            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, cursorCache, stringBuilder);
+            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureMembershipTextualNotationBuilder.cs
@@ -39,19 +39,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>NonOccurrenceUsageMember:FeatureMembership=MemberPrefixownedRelatedElement+=NonOccurrenceUsageElement</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNonOccurrenceUsageMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNonOccurrenceUsageMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage elementAsUsage)
                 {
-                    UsageTextualNotationBuilder.BuildNonOccurrenceUsageElement(elementAsUsage, cursorCache, stringBuilder);
+                    UsageTextualNotationBuilder.BuildNonOccurrenceUsageElement(elementAsUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -64,19 +64,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>OccurrenceUsageMember:FeatureMembership=MemberPrefixownedRelatedElement+=OccurrenceUsageElement</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOccurrenceUsageMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOccurrenceUsageMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage elementAsUsage)
                 {
-                    UsageTextualNotationBuilder.BuildOccurrenceUsageElement(elementAsUsage, cursorCache, stringBuilder);
+                    UsageTextualNotationBuilder.BuildOccurrenceUsageElement(elementAsUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -89,19 +89,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>StructureUsageMember:FeatureMembership=MemberPrefixownedRelatedElement+=StructureUsageElement</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildStructureUsageMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildStructureUsageMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage elementAsUsage)
                 {
-                    UsageTextualNotationBuilder.BuildStructureUsageElement(elementAsUsage, cursorCache, stringBuilder);
+                    UsageTextualNotationBuilder.BuildStructureUsageElement(elementAsUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -114,19 +114,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>BehaviorUsageMember:FeatureMembership=MemberPrefixownedRelatedElement+=BehaviorUsageElement</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildBehaviorUsageMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildBehaviorUsageMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage elementAsUsage)
                 {
-                    UsageTextualNotationBuilder.BuildBehaviorUsageElement(elementAsUsage, cursorCache, stringBuilder);
+                    UsageTextualNotationBuilder.BuildBehaviorUsageElement(elementAsUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -139,11 +139,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>SourceSuccessionMember:FeatureMembership='then'ownedRelatedElement+=SourceSuccession</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSourceSuccessionMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSourceSuccessionMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
             stringBuilder.Append("then ");
 
             if (ownedRelatedElementCursor.Current != null)
@@ -151,7 +151,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Connections.ISuccessionAsUsage elementAsSuccessionAsUsage)
                 {
-                    SuccessionAsUsageTextualNotationBuilder.BuildSourceSuccession(elementAsSuccessionAsUsage, cursorCache, stringBuilder);
+                    SuccessionAsUsageTextualNotationBuilder.BuildSourceSuccession(elementAsSuccessionAsUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -164,19 +164,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>InterfaceNonOccurrenceUsageMember:FeatureMembership=MemberPrefixownedRelatedElement+=InterfaceNonOccurrenceUsageElement</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildInterfaceNonOccurrenceUsageMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildInterfaceNonOccurrenceUsageMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage elementAsUsage)
                 {
-                    UsageTextualNotationBuilder.BuildInterfaceNonOccurrenceUsageElement(elementAsUsage, cursorCache, stringBuilder);
+                    UsageTextualNotationBuilder.BuildInterfaceNonOccurrenceUsageElement(elementAsUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -189,19 +189,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>InterfaceOccurrenceUsageMember:FeatureMembership=MemberPrefixownedRelatedElement+=InterfaceOccurrenceUsageElement</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildInterfaceOccurrenceUsageMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildInterfaceOccurrenceUsageMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage elementAsUsage)
                 {
-                    UsageTextualNotationBuilder.BuildInterfaceOccurrenceUsageElement(elementAsUsage, cursorCache, stringBuilder);
+                    UsageTextualNotationBuilder.BuildInterfaceOccurrenceUsageElement(elementAsUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -214,18 +214,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>FlowPayloadFeatureMember:FeatureMembership=ownedRelatedElement+=FlowPayloadFeature</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFlowPayloadFeatureMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFlowPayloadFeatureMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Interactions.IPayloadFeature elementAsPayloadFeature)
                 {
-                    PayloadFeatureTextualNotationBuilder.BuildFlowPayloadFeature(elementAsPayloadFeature, cursorCache, stringBuilder);
+                    PayloadFeatureTextualNotationBuilder.BuildFlowPayloadFeature(elementAsPayloadFeature, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -238,18 +238,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>FlowFeatureMember:FeatureMembership=ownedRelatedElement+=FlowFeature</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFlowFeatureMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFlowFeatureMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
-                    ReferenceUsageTextualNotationBuilder.BuildFlowFeature(elementAsReferenceUsage, cursorCache, stringBuilder);
+                    ReferenceUsageTextualNotationBuilder.BuildFlowFeature(elementAsReferenceUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -262,17 +262,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>ActionBehaviorMember:FeatureMembership=BehaviorUsageMember|ActionNodeMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildActionBehaviorMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildActionBehaviorMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Core.Types.IFeatureMembership pocoFeatureMembershipBehaviorUsageMember when pocoFeatureMembershipBehaviorUsageMember.IsValidForBehaviorUsageMember():
-                    BuildBehaviorUsageMember(pocoFeatureMembershipBehaviorUsageMember, cursorCache, stringBuilder);
+                    BuildBehaviorUsageMember(pocoFeatureMembershipBehaviorUsageMember, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildActionNodeMember(poco, cursorCache, stringBuilder);
+                    BuildActionNodeMember(poco, writerContext, stringBuilder);
                     break;
             }
 
@@ -283,14 +283,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>InitialNodeMember:FeatureMembership=MemberPrefix'first'memberFeature=[QualifiedName]RelationshipBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildInitialNodeMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildInitialNodeMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("first ");
-            BuildMemberFeature(poco, cursorCache, stringBuilder);
-            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, cursorCache, stringBuilder);
+            BuildMemberFeature(poco, writerContext, stringBuilder);
+            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, writerContext, stringBuilder);
 
         }
 
@@ -299,19 +299,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>ActionNodeMember:FeatureMembership=MemberPrefixownedRelatedElement+=ActionNode</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildActionNodeMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildActionNodeMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Actions.IActionUsage elementAsActionUsage)
                 {
-                    ActionUsageTextualNotationBuilder.BuildActionNode(elementAsActionUsage, cursorCache, stringBuilder);
+                    ActionUsageTextualNotationBuilder.BuildActionNode(elementAsActionUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -324,19 +324,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>ActionTargetSuccessionMember:FeatureMembership=MemberPrefixownedRelatedElement+=ActionTargetSuccession</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildActionTargetSuccessionMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildActionTargetSuccessionMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage elementAsUsage)
                 {
-                    UsageTextualNotationBuilder.BuildActionTargetSuccession(elementAsUsage, cursorCache, stringBuilder);
+                    UsageTextualNotationBuilder.BuildActionTargetSuccession(elementAsUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -349,19 +349,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>GuardedSuccessionMember:FeatureMembership=MemberPrefixownedRelatedElement+=GuardedSuccession</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildGuardedSuccessionMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildGuardedSuccessionMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.States.ITransitionUsage elementAsTransitionUsage)
                 {
-                    TransitionUsageTextualNotationBuilder.BuildGuardedSuccession(elementAsTransitionUsage, cursorCache, stringBuilder);
+                    TransitionUsageTextualNotationBuilder.BuildGuardedSuccession(elementAsTransitionUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -374,18 +374,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>ForVariableDeclarationMember:FeatureMembership=ownedRelatedElement+=UsageDeclaration</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildForVariableDeclarationMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildForVariableDeclarationMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage elementAsUsage)
                 {
-                    UsageTextualNotationBuilder.BuildUsageDeclaration(elementAsUsage, cursorCache, stringBuilder);
+                    UsageTextualNotationBuilder.BuildUsageDeclaration(elementAsUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -398,13 +398,13 @@ namespace SysML2.NET.TextualNotation
         /// <para>EntryTransitionMember:FeatureMembership=MemberPrefix(ownedRelatedElement+=GuardedTargetSuccession|'then'ownedRelatedElement+=TargetSuccession)';'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildEntryTransitionMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildEntryTransitionMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
-            BuildEntryTransitionMemberHandCoded(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
+            BuildEntryTransitionMemberHandCoded(poco, writerContext, stringBuilder);
             stringBuilder.AppendLine(";");
 
         }
@@ -414,19 +414,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>TransitionUsageMember:FeatureMembership=MemberPrefixownedRelatedElement+=TransitionUsage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTransitionUsageMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTransitionUsageMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.States.ITransitionUsage elementAsTransitionUsage)
                 {
-                    TransitionUsageTextualNotationBuilder.BuildTransitionUsage(elementAsTransitionUsage, cursorCache, stringBuilder);
+                    TransitionUsageTextualNotationBuilder.BuildTransitionUsage(elementAsTransitionUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -439,19 +439,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>TargetTransitionUsageMember:FeatureMembership=MemberPrefixownedRelatedElement+=TargetTransitionUsage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTargetTransitionUsageMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTargetTransitionUsageMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.States.ITransitionUsage elementAsTransitionUsage)
                 {
-                    TransitionUsageTextualNotationBuilder.BuildTargetTransitionUsage(elementAsTransitionUsage, cursorCache, stringBuilder);
+                    TransitionUsageTextualNotationBuilder.BuildTargetTransitionUsage(elementAsTransitionUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -464,9 +464,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>MetadataBodyUsageMember:FeatureMembership=ownedMemberFeature=MetadataBodyUsage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMetadataBodyUsageMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMetadataBodyUsageMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.ownedMemberFeature != null)
@@ -474,7 +474,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (poco.ownedMemberFeature is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
-                    ReferenceUsageTextualNotationBuilder.BuildMetadataBodyUsage(elementAsReferenceUsage, cursorCache, stringBuilder);
+                    ReferenceUsageTextualNotationBuilder.BuildMetadataBodyUsage(elementAsReferenceUsage, writerContext, stringBuilder);
                 }
             }
 
@@ -485,19 +485,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedFeatureMember:FeatureMembership=MemberPrefixownedRelatedElement+=FeatureElement</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedFeatureMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedFeatureMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                 {
-                    FeatureTextualNotationBuilder.BuildFeatureElement(elementAsFeature, cursorCache, stringBuilder);
+                    FeatureTextualNotationBuilder.BuildFeatureElement(elementAsFeature, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -510,18 +510,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedExpressionReferenceMember:FeatureMembership=ownedRelationship+=OwnedExpressionReference</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedExpressionReferenceMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedExpressionReferenceMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression elementAsFeatureReferenceExpression)
                 {
-                    FeatureReferenceExpressionTextualNotationBuilder.BuildOwnedExpressionReference(elementAsFeatureReferenceExpression, cursorCache, stringBuilder);
+                    FeatureReferenceExpressionTextualNotationBuilder.BuildOwnedExpressionReference(elementAsFeatureReferenceExpression, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -534,11 +534,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedExpressionMember:FeatureMembership=ownedFeatureMember=OwnedExpression</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedExpressionMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedExpressionMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildOwnedFeatureMember(poco, cursorCache, stringBuilder);
+            BuildOwnedFeatureMember(poco, writerContext, stringBuilder);
 
         }
 
@@ -547,9 +547,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>SequenceExpressionListMember:FeatureMembership=ownedMemberFeature=SequenceExpressionList</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSequenceExpressionListMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSequenceExpressionListMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.ownedMemberFeature != null)
@@ -557,7 +557,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (poco.ownedMemberFeature is SysML2.NET.Core.POCO.Kernel.Functions.IExpression elementAsExpression)
                 {
-                    ExpressionTextualNotationBuilder.BuildSequenceExpressionList(elementAsExpression, cursorCache, stringBuilder);
+                    ExpressionTextualNotationBuilder.BuildSequenceExpressionList(elementAsExpression, writerContext, stringBuilder);
                 }
             }
 
@@ -568,9 +568,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>FunctionReferenceMember:FeatureMembership=ownedMemberFeature=FunctionReference</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFunctionReferenceMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFunctionReferenceMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.ownedMemberFeature != null)
@@ -578,7 +578,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (poco.ownedMemberFeature is SysML2.NET.Core.POCO.Kernel.Functions.IExpression elementAsExpression)
                 {
-                    ExpressionTextualNotationBuilder.BuildFunctionReference(elementAsExpression, cursorCache, stringBuilder);
+                    ExpressionTextualNotationBuilder.BuildFunctionReference(elementAsExpression, writerContext, stringBuilder);
                 }
             }
 
@@ -589,14 +589,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>NamedArgumentMember:FeatureMembership=ownedMemberFeature=NamedArgument</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNamedArgumentMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNamedArgumentMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.ownedMemberFeature != null)
             {
-                FeatureTextualNotationBuilder.BuildNamedArgument(poco.ownedMemberFeature, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildNamedArgument(poco.ownedMemberFeature, writerContext, stringBuilder);
             }
 
         }
@@ -606,9 +606,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>ExpressionBodyMember:FeatureMembership=ownedMemberFeature=ExpressionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildExpressionBodyMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildExpressionBodyMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.ownedMemberFeature != null)
@@ -616,7 +616,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (poco.ownedMemberFeature is SysML2.NET.Core.POCO.Kernel.Functions.IExpression elementAsExpression)
                 {
-                    ExpressionTextualNotationBuilder.BuildExpressionBody(elementAsExpression, cursorCache, stringBuilder);
+                    ExpressionTextualNotationBuilder.BuildExpressionBody(elementAsExpression, writerContext, stringBuilder);
                 }
             }
 
@@ -627,18 +627,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>PayloadFeatureMember:FeatureMembership=ownedRelatedElement=PayloadFeature</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPayloadFeatureMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPayloadFeatureMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                 {
-                    FeatureTextualNotationBuilder.BuildPayloadFeature(elementAsFeature, cursorCache, stringBuilder);
+                    FeatureTextualNotationBuilder.BuildPayloadFeature(elementAsFeature, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -651,14 +651,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>MetadataBodyFeatureMember:FeatureMembership=ownedMemberFeature=MetadataBodyFeature</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMetadataBodyFeatureMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMetadataBodyFeatureMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.ownedMemberFeature != null)
             {
-                FeatureTextualNotationBuilder.BuildMetadataBodyFeature(poco.ownedMemberFeature, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildMetadataBodyFeature(poco.ownedMemberFeature, writerContext, stringBuilder);
             }
 
         }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureMembershipTextualNotationBuilder.cs
@@ -268,7 +268,7 @@ namespace SysML2.NET.TextualNotation
         {
             switch (poco)
             {
-                case SysML2.NET.Core.POCO.Core.Types.IFeatureMembership pocoFeatureMembershipBehaviorUsageMember when pocoFeatureMembershipBehaviorUsageMember.IsValidForBehaviorUsageMember():
+                case SysML2.NET.Core.POCO.Core.Types.IFeatureMembership pocoFeatureMembershipBehaviorUsageMember when pocoFeatureMembershipBehaviorUsageMember.IsValidForBehaviorUsageMember(writerContext):
                     BuildBehaviorUsageMember(pocoFeatureMembershipBehaviorUsageMember, writerContext, stringBuilder);
                     break;
                 default:

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureReferenceExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureReferenceExpressionTextualNotationBuilder.cs
@@ -39,18 +39,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>SatisfactionReferenceExpression:FeatureReferenceExpression=ownedRelationship+=FeatureChainMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSatisfactionReferenceExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSatisfactionReferenceExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership elementAsMembership)
                 {
-                    MembershipTextualNotationBuilder.BuildFeatureChainMember(elementAsMembership, cursorCache, stringBuilder);
+                    MembershipTextualNotationBuilder.BuildFeatureChainMember(elementAsMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -63,18 +63,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedExpressionReference:FeatureReferenceExpression=ownedRelationship+=OwnedExpressionMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedExpressionReference(SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedExpressionReference(SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
                 {
-                    FeatureMembershipTextualNotationBuilder.BuildOwnedExpressionMember(elementAsFeatureMembership, cursorCache, stringBuilder);
+                    FeatureMembershipTextualNotationBuilder.BuildOwnedExpressionMember(elementAsFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -87,18 +87,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>FunctionReferenceExpression:FeatureReferenceExpression=ownedRelationship+=FunctionReferenceMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFunctionReferenceExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFunctionReferenceExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
                 {
-                    FeatureMembershipTextualNotationBuilder.BuildFunctionReferenceMember(elementAsFeatureMembership, cursorCache, stringBuilder);
+                    FeatureMembershipTextualNotationBuilder.BuildFunctionReferenceMember(elementAsFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -111,18 +111,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>FeatureReferenceExpression:FeatureReferenceExpression=ownedRelationship+=FeatureReferenceMemberownedRelationship+=EmptyResultMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFeatureReferenceExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFeatureReferenceExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership elementAsMembership)
                 {
-                    MembershipTextualNotationBuilder.BuildFeatureReferenceMember(elementAsMembership, cursorCache, stringBuilder);
+                    MembershipTextualNotationBuilder.BuildFeatureReferenceMember(elementAsMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -133,7 +133,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
                 {
-                    ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, cursorCache, stringBuilder);
+                    ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -146,18 +146,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>BodyExpression:FeatureReferenceExpression=ownedRelationship+=ExpressionBodyMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildBodyExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildBodyExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
                 {
-                    FeatureMembershipTextualNotationBuilder.BuildExpressionBodyMember(elementAsFeatureMembership, cursorCache, stringBuilder);
+                    FeatureMembershipTextualNotationBuilder.BuildExpressionBodyMember(elementAsFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureTextualNotationBuilder.cs
@@ -996,7 +996,7 @@ namespace SysML2.NET.TextualNotation
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         public static void BuildFeatureReference(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
         {
-            stringBuilder.Append(poco.qualifiedName);
+            SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco);
             stringBuilder.Append(' ');
 
         }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureTextualNotationBuilder.cs
@@ -39,18 +39,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>ValuePart:Feature=ownedRelationship+=FeatureValue</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildValuePart(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildValuePart(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                 {
-                    FeatureValueTextualNotationBuilder.BuildFeatureValue(elementAsFeatureValue, cursorCache, stringBuilder);
+                    FeatureValueTextualNotationBuilder.BuildFeatureValue(elementAsFeatureValue, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -63,11 +63,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>FeatureSpecializationPart:Feature=FeatureSpecialization+MultiplicityPart?FeatureSpecialization*|MultiplicityPartFeatureSpecialization*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFeatureSpecializationPart(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFeatureSpecializationPart(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildFeatureSpecializationPartHandCoded(poco, cursorCache, stringBuilder);
+            BuildFeatureSpecializationPartHandCoded(poco, writerContext, stringBuilder);
         }
 
         /// <summary>
@@ -75,26 +75,26 @@ namespace SysML2.NET.TextualNotation
         /// <para>FeatureSpecialization:Feature=Typings|Subsettings|References|Crosses|Redefinitions</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFeatureSpecialization(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFeatureSpecialization(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeatureTypings when pocoFeatureTypings.IsValidForTypings():
-                    BuildTypings(pocoFeatureTypings, cursorCache, stringBuilder);
+                    BuildTypings(pocoFeatureTypings, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeatureSubsettings when pocoFeatureSubsettings.IsValidForSubsettings():
-                    BuildSubsettings(pocoFeatureSubsettings, cursorCache, stringBuilder);
+                    BuildSubsettings(pocoFeatureSubsettings, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeatureReferences when pocoFeatureReferences.IsValidForReferences():
-                    BuildReferences(pocoFeatureReferences, cursorCache, stringBuilder);
+                    BuildReferences(pocoFeatureReferences, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeatureCrosses when pocoFeatureCrosses.IsValidForCrosses():
-                    BuildCrosses(pocoFeatureCrosses, cursorCache, stringBuilder);
+                    BuildCrosses(pocoFeatureCrosses, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildRedefinitions(poco, cursorCache, stringBuilder);
+                    BuildRedefinitions(poco, writerContext, stringBuilder);
                     break;
             }
 
@@ -105,12 +105,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>Typings:Feature=TypedBy(','ownedRelationship+=FeatureTyping)*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTypings(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTypings(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-            BuildTypedBy(poco, cursorCache, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            BuildTypedBy(poco, writerContext, stringBuilder);
 
             while (ownedRelationshipCursor.Current != null && ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping)
             {
@@ -121,7 +121,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping elementAsFeatureTyping)
                     {
-                        FeatureTypingTextualNotationBuilder.BuildFeatureTyping(elementAsFeatureTyping, cursorCache, stringBuilder);
+                        FeatureTypingTextualNotationBuilder.BuildFeatureTyping(elementAsFeatureTyping, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -135,11 +135,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>TypedBy:Feature=DEFINED_BYownedRelationship+=FeatureTyping</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTypedBy(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTypedBy(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append(": ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -147,7 +147,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping elementAsFeatureTyping)
                 {
-                    FeatureTypingTextualNotationBuilder.BuildFeatureTyping(elementAsFeatureTyping, cursorCache, stringBuilder);
+                    FeatureTypingTextualNotationBuilder.BuildFeatureTyping(elementAsFeatureTyping, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -160,12 +160,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>Subsettings:Feature=Subsets(','ownedRelationship+=OwnedSubsetting)*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSubsettings(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSubsettings(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-            BuildSubsets(poco, cursorCache, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            BuildSubsets(poco, writerContext, stringBuilder);
 
             while (ownedRelationshipCursor.Current != null && ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting)
             {
@@ -176,7 +176,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting elementAsSubsetting)
                     {
-                        SubsettingTextualNotationBuilder.BuildOwnedSubsetting(elementAsSubsetting, cursorCache, stringBuilder);
+                        SubsettingTextualNotationBuilder.BuildOwnedSubsetting(elementAsSubsetting, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -190,11 +190,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>Subsets:Feature=SUBSETSownedRelationship+=OwnedSubsetting</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSubsets(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSubsets(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append(" :> ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -202,7 +202,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting elementAsSubsetting)
                 {
-                    SubsettingTextualNotationBuilder.BuildOwnedSubsetting(elementAsSubsetting, cursorCache, stringBuilder);
+                    SubsettingTextualNotationBuilder.BuildOwnedSubsetting(elementAsSubsetting, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -215,11 +215,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>References:Feature=REFERENCESownedRelationship+=OwnedReferenceSubsetting</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildReferences(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildReferences(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append(" ::> ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -227,7 +227,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting elementAsReferenceSubsetting)
                 {
-                    ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, cursorCache, stringBuilder);
+                    ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -240,11 +240,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>Crosses:Feature=CROSSESownedRelationship+=OwnedCrossSubsetting</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildCrosses(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildCrosses(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append(" => ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -252,7 +252,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting elementAsCrossSubsetting)
                 {
-                    CrossSubsettingTextualNotationBuilder.BuildOwnedCrossSubsetting(elementAsCrossSubsetting, cursorCache, stringBuilder);
+                    CrossSubsettingTextualNotationBuilder.BuildOwnedCrossSubsetting(elementAsCrossSubsetting, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -265,12 +265,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>Redefinitions:Feature=Redefines(','ownedRelationship+=OwnedRedefinition)*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildRedefinitions(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildRedefinitions(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-            BuildRedefines(poco, cursorCache, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            BuildRedefines(poco, writerContext, stringBuilder);
 
             while (ownedRelationshipCursor.Current != null && ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition)
             {
@@ -281,7 +281,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition elementAsRedefinition)
                     {
-                        RedefinitionTextualNotationBuilder.BuildOwnedRedefinition(elementAsRedefinition, cursorCache, stringBuilder);
+                        RedefinitionTextualNotationBuilder.BuildOwnedRedefinition(elementAsRedefinition, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -295,11 +295,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>Redefines:Feature=REDEFINESownedRelationship+=OwnedRedefinition</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildRedefines(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildRedefines(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append(" :>> ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -307,7 +307,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition elementAsRedefinition)
                 {
-                    RedefinitionTextualNotationBuilder.BuildOwnedRedefinition(elementAsRedefinition, cursorCache, stringBuilder);
+                    RedefinitionTextualNotationBuilder.BuildOwnedRedefinition(elementAsRedefinition, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -320,18 +320,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedFeatureChain:Feature=ownedRelationship+=OwnedFeatureChaining('.'ownedRelationship+=OwnedFeatureChaining)+</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedFeatureChain(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedFeatureChain(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureChaining elementAsFeatureChaining)
                 {
-                    FeatureChainingTextualNotationBuilder.BuildOwnedFeatureChaining(elementAsFeatureChaining, cursorCache, stringBuilder);
+                    FeatureChainingTextualNotationBuilder.BuildOwnedFeatureChaining(elementAsFeatureChaining, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -346,7 +346,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureChaining elementAsFeatureChaining)
                     {
-                        FeatureChainingTextualNotationBuilder.BuildOwnedFeatureChaining(elementAsFeatureChaining, cursorCache, stringBuilder);
+                        FeatureChainingTextualNotationBuilder.BuildOwnedFeatureChaining(elementAsFeatureChaining, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -360,11 +360,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>MultiplicityPart:Feature=ownedRelationship+=OwnedMultiplicity|(ownedRelationship+=OwnedMultiplicity)?(isOrdered?='ordered'({isUnique=false}'nonunique')?|{isUnique=false}'nonunique'(isOrdered?='ordered')?)</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMultiplicityPart(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMultiplicityPart(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildMultiplicityPartHandCoded(poco, cursorCache, stringBuilder);
+            BuildMultiplicityPartHandCoded(poco, writerContext, stringBuilder);
         }
 
         /// <summary>
@@ -372,18 +372,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedCrossMultiplicity:Feature=ownedRelationship+=OwnedMultiplicity</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedCrossMultiplicity(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedCrossMultiplicity(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                 {
-                    OwningMembershipTextualNotationBuilder.BuildOwnedMultiplicity(elementAsOwningMembership, cursorCache, stringBuilder);
+                    OwningMembershipTextualNotationBuilder.BuildOwnedMultiplicity(elementAsOwningMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -396,11 +396,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>PayloadFeature:Feature=Identification?PayloadFeatureSpecializationPartValuePart?|ownedRelationship+=OwnedFeatureTyping(ownedRelationship+=OwnedMultiplicity)?|ownedRelationship+=OwnedMultiplicityownedRelationship+=OwnedFeatureTyping</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPayloadFeature(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPayloadFeature(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildPayloadFeatureHandCoded(poco, cursorCache, stringBuilder);
+            BuildPayloadFeatureHandCoded(poco, writerContext, stringBuilder);
         }
 
         /// <summary>
@@ -408,11 +408,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>PayloadFeatureSpecializationPart:Feature=(FeatureSpecialization)+MultiplicityPart?FeatureSpecialization*|MultiplicityPartFeatureSpecialization+</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPayloadFeatureSpecializationPart(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPayloadFeatureSpecializationPart(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildPayloadFeatureSpecializationPartHandCoded(poco, cursorCache, stringBuilder);
+            BuildPayloadFeatureSpecializationPartHandCoded(poco, writerContext, stringBuilder);
         }
 
         /// <summary>
@@ -420,11 +420,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>FeatureChainPrefix:Feature=(ownedRelationship+=OwnedFeatureChaining'.')+ownedRelationship+=OwnedFeatureChaining'.'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFeatureChainPrefix(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFeatureChainPrefix(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             while (ownedRelationshipCursor.Current != null && ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureChaining)
             {
@@ -434,7 +434,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureChaining elementAsFeatureChaining)
                     {
-                        FeatureChainingTextualNotationBuilder.BuildOwnedFeatureChaining(elementAsFeatureChaining, cursorCache, stringBuilder);
+                        FeatureChainingTextualNotationBuilder.BuildOwnedFeatureChaining(elementAsFeatureChaining, writerContext, stringBuilder);
                     }
                 }
                 stringBuilder.Append(".");
@@ -448,7 +448,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureChaining elementAsFeatureChaining)
                 {
-                    FeatureChainingTextualNotationBuilder.BuildOwnedFeatureChaining(elementAsFeatureChaining, cursorCache, stringBuilder);
+                    FeatureChainingTextualNotationBuilder.BuildOwnedFeatureChaining(elementAsFeatureChaining, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -462,18 +462,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>TriggerValuePart:Feature=ownedRelationship+=TriggerFeatureValue</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTriggerValuePart(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTriggerValuePart(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                 {
-                    FeatureValueTextualNotationBuilder.BuildTriggerFeatureValue(elementAsFeatureValue, cursorCache, stringBuilder);
+                    FeatureValueTextualNotationBuilder.BuildTriggerFeatureValue(elementAsFeatureValue, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -486,18 +486,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>Argument:Feature=ownedRelationship+=ArgumentValue</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildArgument(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildArgument(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                 {
-                    FeatureValueTextualNotationBuilder.BuildArgumentValue(elementAsFeatureValue, cursorCache, stringBuilder);
+                    FeatureValueTextualNotationBuilder.BuildArgumentValue(elementAsFeatureValue, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -510,18 +510,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>ArgumentExpression:Feature=ownedRelationship+=ArgumentExpressionValue</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildArgumentExpression(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildArgumentExpression(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                 {
-                    FeatureValueTextualNotationBuilder.BuildArgumentExpressionValue(elementAsFeatureValue, cursorCache, stringBuilder);
+                    FeatureValueTextualNotationBuilder.BuildArgumentExpressionValue(elementAsFeatureValue, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -534,41 +534,41 @@ namespace SysML2.NET.TextualNotation
         /// <para>FeatureElement:Feature=Feature|Step|Expression|BooleanExpression|Invariant|Connector|BindingConnector|Succession|Flow|SuccessionFlow</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFeatureElement(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFeatureElement(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Kernel.Interactions.ISuccessionFlow pocoSuccessionFlow:
-                    SuccessionFlowTextualNotationBuilder.BuildSuccessionFlow(pocoSuccessionFlow, cursorCache, stringBuilder);
+                    SuccessionFlowTextualNotationBuilder.BuildSuccessionFlow(pocoSuccessionFlow, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Functions.IInvariant pocoInvariant:
-                    InvariantTextualNotationBuilder.BuildInvariant(pocoInvariant, cursorCache, stringBuilder);
+                    InvariantTextualNotationBuilder.BuildInvariant(pocoInvariant, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Interactions.IFlow pocoFlow:
-                    FlowTextualNotationBuilder.BuildFlow(pocoFlow, cursorCache, stringBuilder);
+                    FlowTextualNotationBuilder.BuildFlow(pocoFlow, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Functions.IBooleanExpression pocoBooleanExpression:
-                    BooleanExpressionTextualNotationBuilder.BuildBooleanExpression(pocoBooleanExpression, cursorCache, stringBuilder);
+                    BooleanExpressionTextualNotationBuilder.BuildBooleanExpression(pocoBooleanExpression, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Connectors.IBindingConnector pocoBindingConnector:
-                    BindingConnectorTextualNotationBuilder.BuildBindingConnector(pocoBindingConnector, cursorCache, stringBuilder);
+                    BindingConnectorTextualNotationBuilder.BuildBindingConnector(pocoBindingConnector, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Connectors.ISuccession pocoSuccession:
-                    SuccessionTextualNotationBuilder.BuildSuccession(pocoSuccession, cursorCache, stringBuilder);
+                    SuccessionTextualNotationBuilder.BuildSuccession(pocoSuccession, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Functions.IExpression pocoExpression:
-                    ExpressionTextualNotationBuilder.BuildExpression(pocoExpression, cursorCache, stringBuilder);
+                    ExpressionTextualNotationBuilder.BuildExpression(pocoExpression, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Connectors.IConnector pocoConnector:
-                    ConnectorTextualNotationBuilder.BuildConnector(pocoConnector, cursorCache, stringBuilder);
+                    ConnectorTextualNotationBuilder.BuildConnector(pocoConnector, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Behaviors.IStep pocoStep:
-                    StepTextualNotationBuilder.BuildStep(pocoStep, cursorCache, stringBuilder);
+                    StepTextualNotationBuilder.BuildStep(pocoStep, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildFeature(poco, cursorCache, stringBuilder);
+                    BuildFeature(poco, writerContext, stringBuilder);
                     break;
             }
 
@@ -579,9 +579,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>EndFeaturePrefix:Feature=(isConstant?='const'{isVariable=true})?isEnd?='end'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildEndFeaturePrefix(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildEndFeaturePrefix(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.IsConstant)
@@ -603,9 +603,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>BasicFeaturePrefix:Feature=(direction=FeatureDirection)?(isDerived?='derived')?(isAbstract?='abstract')?(isComposite?='composite'|isPortion?='portion')?(isVariable?='var'|isConstant?='const'{isVariable=true})?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildBasicFeaturePrefix(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildBasicFeaturePrefix(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.Direction.HasValue)
@@ -638,7 +638,7 @@ namespace SysML2.NET.TextualNotation
                 stringBuilder.Append(" portion ");
             }
 
-            BuildBasicFeaturePrefixHandCoded(poco, cursorCache, stringBuilder);
+            BuildBasicFeaturePrefixHandCoded(poco, writerContext, stringBuilder);
 
         }
 
@@ -647,9 +647,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>FeatureDeclaration:Feature=(isSufficient?='all')?(FeatureIdentification(FeatureSpecializationPart|ConjugationPart)?|FeatureSpecializationPart|ConjugationPart)FeatureRelationshipPart*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFeatureDeclaration(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFeatureDeclaration(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.IsSufficient)
@@ -658,7 +658,7 @@ namespace SysML2.NET.TextualNotation
                 stringBuilder.Append(' ');
             }
 
-            BuildFeatureDeclarationHandCoded(poco, cursorCache, stringBuilder);
+            BuildFeatureDeclarationHandCoded(poco, writerContext, stringBuilder);
             stringBuilder.Append(' ');
 
 
@@ -670,11 +670,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>FeatureIdentification:Feature='&lt;'declaredShortName=NAME'&gt;'(declaredName=NAME)?|declaredName=NAME</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFeatureIdentification(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFeatureIdentification(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildFeatureIdentificationHandCoded(poco, cursorCache, stringBuilder);
+            BuildFeatureIdentificationHandCoded(poco, writerContext, stringBuilder);
         }
 
         /// <summary>
@@ -682,23 +682,23 @@ namespace SysML2.NET.TextualNotation
         /// <para>FeatureRelationshipPart:Feature=TypeRelationshipPart|ChainingPart|InvertingPart|TypeFeaturingPart</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFeatureRelationshipPart(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFeatureRelationshipPart(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeatureChainingPart when pocoFeatureChainingPart.IsValidForChainingPart():
-                    BuildChainingPart(pocoFeatureChainingPart, cursorCache, stringBuilder);
+                    BuildChainingPart(pocoFeatureChainingPart, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeatureInvertingPart when pocoFeatureInvertingPart.IsValidForInvertingPart():
-                    BuildInvertingPart(pocoFeatureInvertingPart, cursorCache, stringBuilder);
+                    BuildInvertingPart(pocoFeatureInvertingPart, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Core.Types.IType pocoType:
-                    TypeTextualNotationBuilder.BuildTypeRelationshipPart(pocoType, cursorCache, stringBuilder);
+                    TypeTextualNotationBuilder.BuildTypeRelationshipPart(pocoType, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildTypeFeaturingPart(poco, cursorCache, stringBuilder);
+                    BuildTypeFeaturingPart(poco, writerContext, stringBuilder);
                     break;
             }
 
@@ -709,11 +709,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>ChainingPart:Feature='chains'(ownedRelationship+=OwnedFeatureChaining|FeatureChain)</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildChainingPart(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildChainingPart(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append("chains ");
             if (ownedRelationshipCursor.Current != null)
             {
@@ -723,13 +723,13 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureChaining elementAsFeatureChaining)
                     {
-                        FeatureChainingTextualNotationBuilder.BuildOwnedFeatureChaining(elementAsFeatureChaining, cursorCache, stringBuilder);
+                        FeatureChainingTextualNotationBuilder.BuildOwnedFeatureChaining(elementAsFeatureChaining, writerContext, stringBuilder);
                     }
                 }
             }
             else
             {
-                BuildFeatureChain(poco, cursorCache, stringBuilder);
+                BuildFeatureChain(poco, writerContext, stringBuilder);
             }
 
         }
@@ -739,11 +739,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>InvertingPart:Feature='inverse''of'ownedRelationship+=OwnedFeatureInverting</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildInvertingPart(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildInvertingPart(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append("inverse ");
             stringBuilder.Append("of ");
 
@@ -752,7 +752,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureInverting elementAsFeatureInverting)
                 {
-                    FeatureInvertingTextualNotationBuilder.BuildOwnedFeatureInverting(elementAsFeatureInverting, cursorCache, stringBuilder);
+                    FeatureInvertingTextualNotationBuilder.BuildOwnedFeatureInverting(elementAsFeatureInverting, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -765,12 +765,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>TypeFeaturingPart:Feature='featured''by'ownedRelationship+=OwnedTypeFeaturing(','ownedTypeFeaturing+=OwnedTypeFeaturing)*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTypeFeaturingPart(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTypeFeaturingPart(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-            var ownedTypeFeaturingCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedTypeFeaturing", poco.ownedTypeFeaturing);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedTypeFeaturingCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedTypeFeaturing", poco.ownedTypeFeaturing);
             stringBuilder.Append("featured ");
             stringBuilder.Append("by ");
 
@@ -779,7 +779,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ITypeFeaturing elementAsTypeFeaturing)
                 {
-                    TypeFeaturingTextualNotationBuilder.BuildOwnedTypeFeaturing(elementAsTypeFeaturing, cursorCache, stringBuilder);
+                    TypeFeaturingTextualNotationBuilder.BuildOwnedTypeFeaturing(elementAsTypeFeaturing, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -794,7 +794,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedTypeFeaturingCursor.Current is SysML2.NET.Core.POCO.Core.Features.ITypeFeaturing elementAsTypeFeaturing)
                     {
-                        TypeFeaturingTextualNotationBuilder.BuildOwnedTypeFeaturing(elementAsTypeFeaturing, cursorCache, stringBuilder);
+                        TypeFeaturingTextualNotationBuilder.BuildOwnedTypeFeaturing(elementAsTypeFeaturing, writerContext, stringBuilder);
                     }
                 }
                 ownedTypeFeaturingCursor.Move();
@@ -808,18 +808,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>FeatureChain:Feature=ownedRelationship+=OwnedFeatureChaining('.'ownedRelationship+=OwnedFeatureChaining)+</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFeatureChain(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFeatureChain(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureChaining elementAsFeatureChaining)
                 {
-                    FeatureChainingTextualNotationBuilder.BuildOwnedFeatureChaining(elementAsFeatureChaining, cursorCache, stringBuilder);
+                    FeatureChainingTextualNotationBuilder.BuildOwnedFeatureChaining(elementAsFeatureChaining, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -834,7 +834,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureChaining elementAsFeatureChaining)
                     {
-                        FeatureChainingTextualNotationBuilder.BuildOwnedFeatureChaining(elementAsFeatureChaining, cursorCache, stringBuilder);
+                        FeatureChainingTextualNotationBuilder.BuildOwnedFeatureChaining(elementAsFeatureChaining, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -848,18 +848,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>MetadataArgument:Feature=ownedRelationship+=MetadataValue</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMetadataArgument(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMetadataArgument(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                 {
-                    FeatureValueTextualNotationBuilder.BuildMetadataValue(elementAsFeatureValue, cursorCache, stringBuilder);
+                    FeatureValueTextualNotationBuilder.BuildMetadataValue(elementAsFeatureValue, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -872,18 +872,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>TypeReference:Feature=ownedRelationship+=ReferenceTyping</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTypeReference(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTypeReference(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping elementAsFeatureTyping)
                 {
-                    FeatureTypingTextualNotationBuilder.BuildReferenceTyping(elementAsFeatureTyping, cursorCache, stringBuilder);
+                    FeatureTypingTextualNotationBuilder.BuildReferenceTyping(elementAsFeatureTyping, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -896,18 +896,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>PrimaryArgument:Feature=ownedRelationship+=PrimaryArgumentValue</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPrimaryArgument(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPrimaryArgument(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                 {
-                    FeatureValueTextualNotationBuilder.BuildPrimaryArgumentValue(elementAsFeatureValue, cursorCache, stringBuilder);
+                    FeatureValueTextualNotationBuilder.BuildPrimaryArgumentValue(elementAsFeatureValue, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -920,18 +920,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>NonFeatureChainPrimaryArgument:Feature=ownedRelationship+=NonFeatureChainPrimaryArgumentValue</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNonFeatureChainPrimaryArgument(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNonFeatureChainPrimaryArgument(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                 {
-                    FeatureValueTextualNotationBuilder.BuildNonFeatureChainPrimaryArgumentValue(elementAsFeatureValue, cursorCache, stringBuilder);
+                    FeatureValueTextualNotationBuilder.BuildNonFeatureChainPrimaryArgumentValue(elementAsFeatureValue, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -944,18 +944,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>BodyArgument:Feature=ownedRelationship+=BodyArgumentValue</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildBodyArgument(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildBodyArgument(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                 {
-                    FeatureValueTextualNotationBuilder.BuildBodyArgumentValue(elementAsFeatureValue, cursorCache, stringBuilder);
+                    FeatureValueTextualNotationBuilder.BuildBodyArgumentValue(elementAsFeatureValue, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -968,18 +968,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>FunctionReferenceArgument:Feature=ownedRelationship+=FunctionReferenceArgumentValue</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFunctionReferenceArgument(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFunctionReferenceArgument(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                 {
-                    FeatureValueTextualNotationBuilder.BuildFunctionReferenceArgumentValue(elementAsFeatureValue, cursorCache, stringBuilder);
+                    FeatureValueTextualNotationBuilder.BuildFunctionReferenceArgumentValue(elementAsFeatureValue, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -992,11 +992,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>FeatureReference:Feature=[QualifiedName]</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFeatureReference(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFeatureReference(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco);
+            SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco, writerContext);
             stringBuilder.Append(' ');
 
         }
@@ -1006,11 +1006,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>ConstructorResult:Feature=ArgumentList</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildConstructorResult(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildConstructorResult(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildArgumentList(poco, cursorCache, stringBuilder);
+            BuildArgumentList(poco, writerContext, stringBuilder);
 
         }
 
@@ -1019,18 +1019,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>ArgumentList:Feature='('(PositionalArgumentList|NamedArgumentList)?')'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildArgumentList(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildArgumentList(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             stringBuilder.Append("(");
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeaturePositionalArgumentList when pocoFeaturePositionalArgumentList.IsValidForPositionalArgumentList():
-                    BuildPositionalArgumentList(pocoFeaturePositionalArgumentList, cursorCache, stringBuilder);
+                    BuildPositionalArgumentList(pocoFeaturePositionalArgumentList, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildNamedArgumentList(poco, cursorCache, stringBuilder);
+                    BuildNamedArgumentList(poco, writerContext, stringBuilder);
                     break;
             }
 
@@ -1043,18 +1043,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>PositionalArgumentList:Feature=e.ownedRelationship+=ArgumentMember(','e.ownedRelationship+=ArgumentMember)*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPositionalArgumentList(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPositionalArgumentList(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -1069,7 +1069,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                     {
-                        ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                        ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -1083,18 +1083,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>NamedArgumentList:Feature=ownedRelationship+=NamedArgumentMember(','ownedRelationship+=NamedArgumentMember)*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNamedArgumentList(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNamedArgumentList(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
                 {
-                    FeatureMembershipTextualNotationBuilder.BuildNamedArgumentMember(elementAsFeatureMembership, cursorCache, stringBuilder);
+                    FeatureMembershipTextualNotationBuilder.BuildNamedArgumentMember(elementAsFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -1109,7 +1109,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
                     {
-                        FeatureMembershipTextualNotationBuilder.BuildNamedArgumentMember(elementAsFeatureMembership, cursorCache, stringBuilder);
+                        FeatureMembershipTextualNotationBuilder.BuildNamedArgumentMember(elementAsFeatureMembership, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -1123,18 +1123,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>NamedArgument:Feature=ownedRelationship+=ParameterRedefinition'='ownedRelationship+=ArgumentValue</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNamedArgument(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNamedArgument(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition elementAsRedefinition)
                 {
-                    RedefinitionTextualNotationBuilder.BuildParameterRedefinition(elementAsRedefinition, cursorCache, stringBuilder);
+                    RedefinitionTextualNotationBuilder.BuildParameterRedefinition(elementAsRedefinition, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -1146,7 +1146,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                 {
-                    FeatureValueTextualNotationBuilder.BuildArgumentValue(elementAsFeatureValue, cursorCache, stringBuilder);
+                    FeatureValueTextualNotationBuilder.BuildArgumentValue(elementAsFeatureValue, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -1159,11 +1159,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>MetadataBodyFeature:Feature='feature'?(':&gt;&gt;'|'redefines')?ownedRelationship+=OwnedRedefinitionFeatureSpecializationPart?ValuePart?MetadataBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMetadataBodyFeature(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMetadataBodyFeature(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append("feature ");
             stringBuilder.Append(" :>> ");
 
@@ -1172,7 +1172,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition elementAsRedefinition)
                 {
-                    RedefinitionTextualNotationBuilder.BuildOwnedRedefinition(elementAsRedefinition, cursorCache, stringBuilder);
+                    RedefinitionTextualNotationBuilder.BuildOwnedRedefinition(elementAsRedefinition, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -1180,14 +1180,14 @@ namespace SysML2.NET.TextualNotation
 
             if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
             {
-                BuildFeatureSpecializationPart(poco, cursorCache, stringBuilder);
+                BuildFeatureSpecializationPart(poco, writerContext, stringBuilder);
             }
 
             if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
-                BuildValuePart(poco, cursorCache, stringBuilder);
+                BuildValuePart(poco, writerContext, stringBuilder);
             }
-            TypeTextualNotationBuilder.BuildMetadataBody(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildMetadataBody(poco, writerContext, stringBuilder);
 
         }
 
@@ -1196,19 +1196,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>Feature=(FeaturePrefix('feature'|ownedRelationship+=PrefixMetadataMember)FeatureDeclaration?|(EndFeaturePrefix|BasicFeaturePrefix)FeatureDeclaration)ValuePart?TypeBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFeature(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFeature(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-            BuildFeatureHandCoded(poco, cursorCache, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            BuildFeatureHandCoded(poco, writerContext, stringBuilder);
             stringBuilder.Append(' ');
 
             if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
-                BuildValuePart(poco, cursorCache, stringBuilder);
+                BuildValuePart(poco, writerContext, stringBuilder);
             }
-            TypeTextualNotationBuilder.BuildTypeBody(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypeBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureTextualNotationBuilder.cs
@@ -81,16 +81,16 @@ namespace SysML2.NET.TextualNotation
         {
             switch (poco)
             {
-                case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeatureTypings when pocoFeatureTypings.IsValidForTypings():
+                case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeatureTypings when pocoFeatureTypings.IsValidForTypings(writerContext):
                     BuildTypings(pocoFeatureTypings, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeatureSubsettings when pocoFeatureSubsettings.IsValidForSubsettings():
+                case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeatureSubsettings when pocoFeatureSubsettings.IsValidForSubsettings(writerContext):
                     BuildSubsettings(pocoFeatureSubsettings, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeatureReferences when pocoFeatureReferences.IsValidForReferences():
+                case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeatureReferences when pocoFeatureReferences.IsValidForReferences(writerContext):
                     BuildReferences(pocoFeatureReferences, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeatureCrosses when pocoFeatureCrosses.IsValidForCrosses():
+                case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeatureCrosses when pocoFeatureCrosses.IsValidForCrosses(writerContext):
                     BuildCrosses(pocoFeatureCrosses, writerContext, stringBuilder);
                     break;
                 default:
@@ -688,10 +688,10 @@ namespace SysML2.NET.TextualNotation
         {
             switch (poco)
             {
-                case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeatureChainingPart when pocoFeatureChainingPart.IsValidForChainingPart():
+                case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeatureChainingPart when pocoFeatureChainingPart.IsValidForChainingPart(writerContext):
                     BuildChainingPart(pocoFeatureChainingPart, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeatureInvertingPart when pocoFeatureInvertingPart.IsValidForInvertingPart():
+                case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeatureInvertingPart when pocoFeatureInvertingPart.IsValidForInvertingPart(writerContext):
                     BuildInvertingPart(pocoFeatureInvertingPart, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Core.Types.IType pocoType:
@@ -1026,7 +1026,7 @@ namespace SysML2.NET.TextualNotation
             stringBuilder.Append("(");
             switch (poco)
             {
-                case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeaturePositionalArgumentList when pocoFeaturePositionalArgumentList.IsValidForPositionalArgumentList():
+                case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeaturePositionalArgumentList when pocoFeaturePositionalArgumentList.IsValidForPositionalArgumentList(writerContext):
                     BuildPositionalArgumentList(pocoFeaturePositionalArgumentList, writerContext, stringBuilder);
                     break;
                 default:

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureTypingTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureTypingTextualNotationBuilder.cs
@@ -49,7 +49,7 @@ namespace SysML2.NET.TextualNotation
             }
             else if (poco.Type != null)
             {
-                stringBuilder.Append(poco.Type.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.Type);
                 stringBuilder.Append(' ');
             }
 
@@ -67,7 +67,7 @@ namespace SysML2.NET.TextualNotation
 
             if (poco.Type != null)
             {
-                stringBuilder.Append(poco.Type.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.Type);
                 stringBuilder.Append(' ');
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureTypingTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureTypingTextualNotationBuilder.cs
@@ -39,17 +39,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedFeatureTyping:FeatureTyping=type=[QualifiedName]|type=OwnedFeatureChain{ownedRelatedElement+=type}</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeatureTyping" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedFeatureTyping(SysML2.NET.Core.POCO.Core.Features.IFeatureTyping poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedFeatureTyping(SysML2.NET.Core.POCO.Core.Features.IFeatureTyping poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             if (poco.OwnedRelatedElement.Contains(poco.Type) && poco.Type is SysML2.NET.Core.POCO.Core.Features.IFeature chainedTypeAsFeature)
             {
-                FeatureTextualNotationBuilder.BuildOwnedFeatureChain(chainedTypeAsFeature, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildOwnedFeatureChain(chainedTypeAsFeature, writerContext, stringBuilder);
             }
             else if (poco.Type != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.Type);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.Type, writerContext);
                 stringBuilder.Append(' ');
             }
 
@@ -60,14 +60,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>ReferenceTyping:FeatureTyping=type=[QualifiedName]</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeatureTyping" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildReferenceTyping(SysML2.NET.Core.POCO.Core.Features.IFeatureTyping poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildReferenceTyping(SysML2.NET.Core.POCO.Core.Features.IFeatureTyping poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.Type != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.Type);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.Type, writerContext);
                 stringBuilder.Append(' ');
             }
 
@@ -78,17 +78,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>FeatureTyping=OwnedFeatureTyping|ConjugatedPortTyping</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeatureTyping" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFeatureTyping(SysML2.NET.Core.POCO.Core.Features.IFeatureTyping poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFeatureTyping(SysML2.NET.Core.POCO.Core.Features.IFeatureTyping poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Systems.Ports.IConjugatedPortTyping pocoConjugatedPortTyping:
-                    ConjugatedPortTypingTextualNotationBuilder.BuildConjugatedPortTyping(pocoConjugatedPortTyping, cursorCache, stringBuilder);
+                    ConjugatedPortTypingTextualNotationBuilder.BuildConjugatedPortTyping(pocoConjugatedPortTyping, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildOwnedFeatureTyping(poco, cursorCache, stringBuilder);
+                    BuildOwnedFeatureTyping(poco, writerContext, stringBuilder);
                     break;
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureValueTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FeatureValueTextualNotationBuilder.cs
@@ -39,18 +39,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>TriggerFeatureValue:FeatureValue=ownedRelatedElement+=TriggerExpression</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTriggerFeatureValue(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTriggerFeatureValue(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Actions.ITriggerInvocationExpression elementAsTriggerInvocationExpression)
                 {
-                    TriggerInvocationExpressionTextualNotationBuilder.BuildTriggerExpression(elementAsTriggerInvocationExpression, cursorCache, stringBuilder);
+                    TriggerInvocationExpressionTextualNotationBuilder.BuildTriggerExpression(elementAsTriggerInvocationExpression, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -63,14 +63,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>ArgumentValue:FeatureValue=value=OwnedExpression</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildArgumentValue(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildArgumentValue(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.value != null)
             {
-                ExpressionTextualNotationBuilder.BuildOwnedExpression(poco.value, cursorCache, stringBuilder);
+                ExpressionTextualNotationBuilder.BuildOwnedExpression(poco.value, writerContext, stringBuilder);
             }
 
         }
@@ -80,18 +80,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>ArgumentExpressionValue:FeatureValue=ownedRelatedElement+=OwnedExpressionReference</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildArgumentExpressionValue(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildArgumentExpressionValue(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression elementAsFeatureReferenceExpression)
                 {
-                    FeatureReferenceExpressionTextualNotationBuilder.BuildOwnedExpressionReference(elementAsFeatureReferenceExpression, cursorCache, stringBuilder);
+                    FeatureReferenceExpressionTextualNotationBuilder.BuildOwnedExpressionReference(elementAsFeatureReferenceExpression, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -104,18 +104,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>FeatureBinding:FeatureValue=ownedRelatedElement+=OwnedExpression</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFeatureBinding(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFeatureBinding(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IExpression elementAsExpression)
                 {
-                    ExpressionTextualNotationBuilder.BuildOwnedExpression(elementAsExpression, cursorCache, stringBuilder);
+                    ExpressionTextualNotationBuilder.BuildOwnedExpression(elementAsExpression, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -128,18 +128,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>AssignmentTargetBinding:FeatureValue=ownedRelatedElement+=NonFeatureChainPrimaryExpression</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildAssignmentTargetBinding(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildAssignmentTargetBinding(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IExpression elementAsExpression)
                 {
-                    ExpressionTextualNotationBuilder.BuildNonFeatureChainPrimaryExpression(elementAsExpression, cursorCache, stringBuilder);
+                    ExpressionTextualNotationBuilder.BuildNonFeatureChainPrimaryExpression(elementAsExpression, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -152,18 +152,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>SatisfactionFeatureValue:FeatureValue=ownedRelatedElement+=SatisfactionReferenceExpression</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSatisfactionFeatureValue(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSatisfactionFeatureValue(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression elementAsFeatureReferenceExpression)
                 {
-                    FeatureReferenceExpressionTextualNotationBuilder.BuildSatisfactionReferenceExpression(elementAsFeatureReferenceExpression, cursorCache, stringBuilder);
+                    FeatureReferenceExpressionTextualNotationBuilder.BuildSatisfactionReferenceExpression(elementAsFeatureReferenceExpression, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -176,9 +176,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>MetadataValue:FeatureValue=value=MetadataReference</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMetadataValue(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMetadataValue(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.value != null)
@@ -186,7 +186,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (poco.value is SysML2.NET.Core.POCO.Kernel.Expressions.IMetadataAccessExpression elementAsMetadataAccessExpression)
                 {
-                    MetadataAccessExpressionTextualNotationBuilder.BuildMetadataReference(elementAsMetadataAccessExpression, cursorCache, stringBuilder);
+                    MetadataAccessExpressionTextualNotationBuilder.BuildMetadataReference(elementAsMetadataAccessExpression, writerContext, stringBuilder);
                 }
             }
 
@@ -197,14 +197,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>PrimaryArgumentValue:FeatureValue=value=PrimaryExpression</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPrimaryArgumentValue(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPrimaryArgumentValue(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.value != null)
             {
-                ExpressionTextualNotationBuilder.BuildPrimaryExpression(poco.value, cursorCache, stringBuilder);
+                ExpressionTextualNotationBuilder.BuildPrimaryExpression(poco.value, writerContext, stringBuilder);
             }
 
         }
@@ -214,14 +214,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>NonFeatureChainPrimaryArgumentValue:FeatureValue=value=NonFeatureChainPrimaryExpression</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNonFeatureChainPrimaryArgumentValue(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNonFeatureChainPrimaryArgumentValue(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.value != null)
             {
-                ExpressionTextualNotationBuilder.BuildNonFeatureChainPrimaryExpression(poco.value, cursorCache, stringBuilder);
+                ExpressionTextualNotationBuilder.BuildNonFeatureChainPrimaryExpression(poco.value, writerContext, stringBuilder);
             }
 
         }
@@ -231,9 +231,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>BodyArgumentValue:FeatureValue=value=BodyExpression</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildBodyArgumentValue(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildBodyArgumentValue(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.value != null)
@@ -241,7 +241,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (poco.value is SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression elementAsFeatureReferenceExpression)
                 {
-                    FeatureReferenceExpressionTextualNotationBuilder.BuildBodyExpression(elementAsFeatureReferenceExpression, cursorCache, stringBuilder);
+                    FeatureReferenceExpressionTextualNotationBuilder.BuildBodyExpression(elementAsFeatureReferenceExpression, writerContext, stringBuilder);
                 }
             }
 
@@ -252,9 +252,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>FunctionReferenceArgumentValue:FeatureValue=value=FunctionReferenceExpression</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFunctionReferenceArgumentValue(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFunctionReferenceArgumentValue(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.value != null)
@@ -262,7 +262,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (poco.value is SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression elementAsFeatureReferenceExpression)
                 {
-                    FeatureReferenceExpressionTextualNotationBuilder.BuildFunctionReferenceExpression(elementAsFeatureReferenceExpression, cursorCache, stringBuilder);
+                    FeatureReferenceExpressionTextualNotationBuilder.BuildFunctionReferenceExpression(elementAsFeatureReferenceExpression, writerContext, stringBuilder);
                 }
             }
 
@@ -273,12 +273,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>FeatureValue=('='|isInitial?=':='|isDefault?='default'('='|isInitial?=':=')?)ownedRelatedElement+=OwnedExpression</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFeatureValue(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFeatureValue(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            BuildFeatureValueHandCoded(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            BuildFeatureValueHandCoded(poco, writerContext, stringBuilder);
             stringBuilder.Append(' ');
 
             if (ownedRelatedElementCursor.Current != null)
@@ -286,7 +286,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IExpression elementAsExpression)
                 {
-                    ExpressionTextualNotationBuilder.BuildOwnedExpression(elementAsExpression, cursorCache, stringBuilder);
+                    ExpressionTextualNotationBuilder.BuildOwnedExpression(elementAsExpression, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FlowDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FlowDefinitionTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>FlowDefinition=OccurrenceDefinitionPrefix'flow''def'Definition</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Flows.IFlowDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFlowDefinition(SysML2.NET.Core.POCO.Systems.Flows.IFlowDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFlowDefinition(SysML2.NET.Core.POCO.Systems.Flows.IFlowDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, cursorCache, stringBuilder);
+            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("flow ");
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinition(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinition(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FlowEndTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FlowEndTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>FlowEnd=(ownedRelationship+=FlowEndSubsetting)?ownedRelationship+=FlowFeatureMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Interactions.IFlowEnd" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFlowEnd(SysML2.NET.Core.POCO.Kernel.Interactions.IFlowEnd poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFlowEnd(SysML2.NET.Core.POCO.Kernel.Interactions.IFlowEnd poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
@@ -53,11 +53,11 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting elementAsReferenceSubsetting)
                     {
-                        ReferenceSubsettingTextualNotationBuilder.BuildFlowEndSubsetting(elementAsReferenceSubsetting, cursorCache, stringBuilder);
+                        ReferenceSubsettingTextualNotationBuilder.BuildFlowEndSubsetting(elementAsReferenceSubsetting, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
                 stringBuilder.Append(' ');
             }
 
@@ -67,7 +67,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
                 {
-                    FeatureMembershipTextualNotationBuilder.BuildFlowFeatureMember(elementAsFeatureMembership, cursorCache, stringBuilder);
+                    FeatureMembershipTextualNotationBuilder.BuildFlowFeatureMember(elementAsFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FlowTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FlowTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>Flow=FeaturePrefix'flow'FlowDeclarationTypeBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Interactions.IFlow" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFlow(SysML2.NET.Core.POCO.Kernel.Interactions.IFlow poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFlow(SysML2.NET.Core.POCO.Kernel.Interactions.IFlow poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            SharedTextualNotationBuilder.BuildFeaturePrefix(poco, cursorCache, stringBuilder);
+            SharedTextualNotationBuilder.BuildFeaturePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("flow ");
-            BuildFlowDeclarationHandCoded(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildTypeBody(poco, cursorCache, stringBuilder);
+            BuildFlowDeclarationHandCoded(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypeBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FlowUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FlowUsageTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>Message:FlowUsage=OccurrenceUsagePrefix'message'MessageDeclarationDefinitionBody{isAbstract=true}</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Flows.IFlowUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMessage(SysML2.NET.Core.POCO.Systems.Flows.IFlowUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMessage(SysML2.NET.Core.POCO.Systems.Flows.IFlowUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("message ");
-            BuildMessageDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildDefinitionBody(poco, cursorCache, stringBuilder);
+            BuildMessageDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildDefinitionBody(poco, writerContext, stringBuilder);
             // NonParsing Assignment Element : isAbstract = true => Does not have to be process
 
         }
@@ -56,11 +56,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>MessageDeclaration:FlowUsage=UsageDeclarationValuePart?('of'ownedRelationship+=FlowPayloadFeatureMember)?('from'ownedRelationship+=MessageEventMember'to'ownedRelationship+=MessageEventMember)?|ownedRelationship+=MessageEventMember'to'ownedRelationship+=MessageEventMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Flows.IFlowUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMessageDeclaration(SysML2.NET.Core.POCO.Systems.Flows.IFlowUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMessageDeclaration(SysML2.NET.Core.POCO.Systems.Flows.IFlowUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildMessageDeclarationHandCoded(poco, cursorCache, stringBuilder);
+            BuildMessageDeclarationHandCoded(poco, writerContext, stringBuilder);
         }
 
         /// <summary>
@@ -68,11 +68,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>FlowDeclaration:FlowUsage=UsageDeclarationValuePart?('of'ownedRelationship+=FlowPayloadFeatureMember)?('from'ownedRelationship+=FlowEndMember'to'ownedRelationship+=FlowEndMember)?|ownedRelationship+=FlowEndMember'to'ownedRelationship+=FlowEndMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Flows.IFlowUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFlowDeclaration(SysML2.NET.Core.POCO.Systems.Flows.IFlowUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFlowDeclaration(SysML2.NET.Core.POCO.Systems.Flows.IFlowUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildFlowDeclarationHandCoded(poco, cursorCache, stringBuilder);
+            BuildFlowDeclarationHandCoded(poco, writerContext, stringBuilder);
         }
 
         /// <summary>
@@ -80,14 +80,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>FlowUsage=OccurrenceUsagePrefix'flow'FlowDeclarationDefinitionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Flows.IFlowUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFlowUsage(SysML2.NET.Core.POCO.Systems.Flows.IFlowUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFlowUsage(SysML2.NET.Core.POCO.Systems.Flows.IFlowUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("flow ");
-            BuildFlowDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildDefinitionBody(poco, cursorCache, stringBuilder);
+            BuildFlowDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildDefinitionBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ForLoopActionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ForLoopActionUsageTextualNotationBuilder.cs
@@ -39,12 +39,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>ForLoopNode:ForLoopActionUsage=ActionNodePrefix'for'ownedRelationship+=ForVariableDeclarationMember'in'ownedRelationship+=NodeParameterMemberownedRelationship+=ActionBodyParameterMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IForLoopActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildForLoopNode(SysML2.NET.Core.POCO.Systems.Actions.IForLoopActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildForLoopNode(SysML2.NET.Core.POCO.Systems.Actions.IForLoopActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-            ActionUsageTextualNotationBuilder.BuildActionNodePrefix(poco, cursorCache, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            ActionUsageTextualNotationBuilder.BuildActionNodePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("for ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -52,7 +52,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
                 {
-                    FeatureMembershipTextualNotationBuilder.BuildForVariableDeclarationMember(elementAsFeatureMembership, cursorCache, stringBuilder);
+                    FeatureMembershipTextualNotationBuilder.BuildForVariableDeclarationMember(elementAsFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -64,7 +64,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildNodeParameterMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildNodeParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -75,7 +75,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildActionBodyParameterMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildActionBodyParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ForkNodeTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ForkNodeTextualNotationBuilder.cs
@@ -39,17 +39,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>ForkNode=ControlNodePrefixisComposite?='fork'UsageDeclarationActionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IForkNode" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildForkNode(SysML2.NET.Core.POCO.Systems.Actions.IForkNode poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildForkNode(SysML2.NET.Core.POCO.Systems.Actions.IForkNode poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildControlNodePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildControlNodePrefix(poco, writerContext, stringBuilder);
             if (poco.IsComposite)
             {
                 stringBuilder.Append(" fork ");
             }
-            UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildActionBody(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildActionBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FramedConcernMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FramedConcernMembershipTextualNotationBuilder.cs
@@ -39,15 +39,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>FramedConcernMember:FramedConcernMembership=MemberPrefix?'frame'ownedRelatedElement+=FramedConcernUsage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.IFramedConcernMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFramedConcernMember(SysML2.NET.Core.POCO.Systems.Requirements.IFramedConcernMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFramedConcernMember(SysML2.NET.Core.POCO.Systems.Requirements.IFramedConcernMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (poco.Visibility != SysML2.NET.Core.Root.Namespaces.VisibilityKind.Public)
             {
-                MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+                MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
             }
             stringBuilder.Append("frame ");
 
@@ -56,7 +56,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Requirements.IConcernUsage elementAsConcernUsage)
                 {
-                    ConcernUsageTextualNotationBuilder.BuildFramedConcernUsage(elementAsConcernUsage, cursorCache, stringBuilder);
+                    ConcernUsageTextualNotationBuilder.BuildFramedConcernUsage(elementAsConcernUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FunctionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/FunctionTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>Function=TypePrefix'function'ClassifierDeclarationFunctionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.IFunction" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFunction(SysML2.NET.Core.POCO.Kernel.Functions.IFunction poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFunction(SysML2.NET.Core.POCO.Kernel.Functions.IFunction poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            TypeTextualNotationBuilder.BuildTypePrefix(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("function ");
-            ClassifierTextualNotationBuilder.BuildClassifierDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildFunctionBody(poco, cursorCache, stringBuilder);
+            ClassifierTextualNotationBuilder.BuildClassifierDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildFunctionBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/IfActionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/IfActionUsageTextualNotationBuilder.cs
@@ -39,12 +39,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>IfNode:IfActionUsage=ActionNodePrefix'if'ownedRelationship+=ExpressionParameterMemberownedRelationship+=ActionBodyParameterMember('else'ownedRelationship+=(ActionBodyParameterMember|IfNodeParameterMember))?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IIfActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildIfNode(SysML2.NET.Core.POCO.Systems.Actions.IIfActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildIfNode(SysML2.NET.Core.POCO.Systems.Actions.IIfActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-            ActionUsageTextualNotationBuilder.BuildActionNodePrefix(poco, cursorCache, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            ActionUsageTextualNotationBuilder.BuildActionNodePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("if ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -52,7 +52,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildExpressionParameterMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildExpressionParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -63,7 +63,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildActionBodyParameterMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildActionBodyParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -75,10 +75,10 @@ namespace SysML2.NET.TextualNotation
                 switch (ownedRelationshipCursor.Current)
                 {
                     case SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership pocoParameterMembershipActionBodyParameterMember when pocoParameterMembershipActionBodyParameterMember.IsValidForActionBodyParameterMember():
-                        ParameterMembershipTextualNotationBuilder.BuildActionBodyParameterMember(pocoParameterMembershipActionBodyParameterMember, cursorCache, stringBuilder);
+                        ParameterMembershipTextualNotationBuilder.BuildActionBodyParameterMember(pocoParameterMembershipActionBodyParameterMember, writerContext, stringBuilder);
                         break;
                     case SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership pocoParameterMembership:
-                        ParameterMembershipTextualNotationBuilder.BuildIfNodeParameterMember(pocoParameterMembership, cursorCache, stringBuilder);
+                        ParameterMembershipTextualNotationBuilder.BuildIfNodeParameterMember(pocoParameterMembership, writerContext, stringBuilder);
                         break;
                 }
                 ownedRelationshipCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/IfActionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/IfActionUsageTextualNotationBuilder.cs
@@ -74,7 +74,7 @@ namespace SysML2.NET.TextualNotation
                 stringBuilder.Append("else ");
                 switch (ownedRelationshipCursor.Current)
                 {
-                    case SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership pocoParameterMembershipActionBodyParameterMember when pocoParameterMembershipActionBodyParameterMember.IsValidForActionBodyParameterMember():
+                    case SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership pocoParameterMembershipActionBodyParameterMember when pocoParameterMembershipActionBodyParameterMember.IsValidForActionBodyParameterMember(writerContext):
                         ParameterMembershipTextualNotationBuilder.BuildActionBodyParameterMember(pocoParameterMembershipActionBodyParameterMember, writerContext, stringBuilder);
                         break;
                     case SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership pocoParameterMembership:

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ImportTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ImportTextualNotationBuilder.cs
@@ -39,17 +39,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>ImportDeclaration:Import=MembershipImport|NamespaceImport</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IImport" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildImportDeclaration(SysML2.NET.Core.POCO.Root.Namespaces.IImport poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildImportDeclaration(SysML2.NET.Core.POCO.Root.Namespaces.IImport poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Root.Namespaces.IMembershipImport pocoMembershipImport:
-                    MembershipImportTextualNotationBuilder.BuildMembershipImport(pocoMembershipImport, cursorCache, stringBuilder);
+                    MembershipImportTextualNotationBuilder.BuildMembershipImport(pocoMembershipImport, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Root.Namespaces.INamespaceImport pocoNamespaceImport:
-                    NamespaceImportTextualNotationBuilder.BuildNamespaceImport(pocoNamespaceImport, cursorCache, stringBuilder);
+                    NamespaceImportTextualNotationBuilder.BuildNamespaceImport(pocoNamespaceImport, writerContext, stringBuilder);
                     break;
             }
 
@@ -60,9 +60,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>Import=visibility=VisibilityIndicator'import'(isImportAll?='all')?ImportDeclarationRelationshipBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IImport" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildImport(SysML2.NET.Core.POCO.Root.Namespaces.IImport poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildImport(SysML2.NET.Core.POCO.Root.Namespaces.IImport poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             stringBuilder.Append(poco.Visibility.ToString().ToLower());
             stringBuilder.Append(' ');
@@ -74,8 +74,8 @@ namespace SysML2.NET.TextualNotation
                 stringBuilder.Append(' ');
             }
 
-            BuildImportDeclaration(poco, cursorCache, stringBuilder);
-            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, cursorCache, stringBuilder);
+            BuildImportDeclaration(poco, writerContext, stringBuilder);
+            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/IncludeUseCaseUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/IncludeUseCaseUsageTextualNotationBuilder.cs
@@ -39,12 +39,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>IncludeUseCaseUsage=OccurrenceUsagePrefix'include'(ownedRelationship+=OwnedReferenceSubsettingFeatureSpecializationPart?|'use''case'UsageDeclaration)ValuePart?CaseBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.UseCases.IIncludeUseCaseUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildIncludeUseCaseUsage(SysML2.NET.Core.POCO.Systems.UseCases.IIncludeUseCaseUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildIncludeUseCaseUsage(SysML2.NET.Core.POCO.Systems.UseCases.IIncludeUseCaseUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("include ");
             if (poco.OwnedRelationship.OfType<SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting>().Any())
             {
@@ -54,7 +54,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting elementAsReferenceSubsetting)
                     {
-                        ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, cursorCache, stringBuilder);
+                        ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -62,23 +62,23 @@ namespace SysML2.NET.TextualNotation
 
                 if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
                 {
-                    FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, cursorCache, stringBuilder);
+                    FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, writerContext, stringBuilder);
                 }
             }
             else
             {
                 stringBuilder.Append("use ");
                 stringBuilder.Append("case ");
-                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
             }
 
             stringBuilder.Append(' ');
 
             if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
-                FeatureTextualNotationBuilder.BuildValuePart(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }
-            TypeTextualNotationBuilder.BuildCaseBody(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildCaseBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/IndexExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/IndexExpressionTextualNotationBuilder.cs
@@ -39,18 +39,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>IndexExpression=ownedRelationship+=PrimaryArgumentMember'#''('ownedRelationship+=SequenceExpressionListMember')'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.IIndexExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildIndexExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IIndexExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildIndexExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IIndexExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildPrimaryArgumentMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildPrimaryArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -63,7 +63,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
                 {
-                    FeatureMembershipTextualNotationBuilder.BuildSequenceExpressionListMember(elementAsFeatureMembership, cursorCache, stringBuilder);
+                    FeatureMembershipTextualNotationBuilder.BuildSequenceExpressionListMember(elementAsFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/InteractionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/InteractionTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>Interaction=TypePrefix'interaction'ClassifierDeclarationTypeBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Interactions.IInteraction" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildInteraction(SysML2.NET.Core.POCO.Kernel.Interactions.IInteraction poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildInteraction(SysML2.NET.Core.POCO.Kernel.Interactions.IInteraction poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            TypeTextualNotationBuilder.BuildTypePrefix(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("interaction ");
-            ClassifierTextualNotationBuilder.BuildClassifierDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildTypeBody(poco, cursorCache, stringBuilder);
+            ClassifierTextualNotationBuilder.BuildClassifierDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypeBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/InterfaceDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/InterfaceDefinitionTextualNotationBuilder.cs
@@ -39,15 +39,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>InterfaceDefinition=OccurrenceDefinitionPrefix'interface''def'DefinitionDeclarationInterfaceBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildInterfaceDefinition(SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildInterfaceDefinition(SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, cursorCache, stringBuilder);
+            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("interface ");
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildInterfaceBody(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildInterfaceBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/InterfaceUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/InterfaceUsageTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>InterfaceUsageDeclaration:InterfaceUsage=UsageDeclarationValuePart?('connect'InterfacePart)?|InterfacePart</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildInterfaceUsageDeclaration(SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildInterfaceUsageDeclaration(SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildInterfaceUsageDeclarationHandCoded(poco, cursorCache, stringBuilder);
+            BuildInterfaceUsageDeclarationHandCoded(poco, writerContext, stringBuilder);
         }
 
         /// <summary>
@@ -51,17 +51,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>InterfacePart:InterfaceUsage=BinaryInterfacePart|NaryInterfacePart</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildInterfacePart(SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildInterfacePart(SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceUsage pocoInterfaceUsageBinaryInterfacePart when pocoInterfaceUsageBinaryInterfacePart.IsValidForBinaryInterfacePart():
-                    BuildBinaryInterfacePart(pocoInterfaceUsageBinaryInterfacePart, cursorCache, stringBuilder);
+                    BuildBinaryInterfacePart(pocoInterfaceUsageBinaryInterfacePart, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildNaryInterfacePart(poco, cursorCache, stringBuilder);
+                    BuildNaryInterfacePart(poco, writerContext, stringBuilder);
                     break;
             }
 
@@ -72,18 +72,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>BinaryInterfacePart:InterfaceUsage=ownedRelationship+=InterfaceEndMember'to'ownedRelationship+=InterfaceEndMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildBinaryInterfacePart(SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildBinaryInterfacePart(SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
-                    EndFeatureMembershipTextualNotationBuilder.BuildInterfaceEndMember(elementAsEndFeatureMembership, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildInterfaceEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -95,7 +95,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
-                    EndFeatureMembershipTextualNotationBuilder.BuildInterfaceEndMember(elementAsEndFeatureMembership, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildInterfaceEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -108,11 +108,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>NaryInterfacePart:InterfaceUsage='('ownedRelationship+=InterfaceEndMember','ownedRelationship+=InterfaceEndMember(','ownedRelationship+=InterfaceEndMember)*')'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNaryInterfacePart(SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNaryInterfacePart(SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append("(");
 
             if (ownedRelationshipCursor.Current != null)
@@ -120,7 +120,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
-                    EndFeatureMembershipTextualNotationBuilder.BuildInterfaceEndMember(elementAsEndFeatureMembership, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildInterfaceEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -132,7 +132,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
-                    EndFeatureMembershipTextualNotationBuilder.BuildInterfaceEndMember(elementAsEndFeatureMembership, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildInterfaceEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -147,7 +147,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                     {
-                        EndFeatureMembershipTextualNotationBuilder.BuildInterfaceEndMember(elementAsEndFeatureMembership, cursorCache, stringBuilder);
+                        EndFeatureMembershipTextualNotationBuilder.BuildInterfaceEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -162,14 +162,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>InterfaceUsage=OccurrenceUsagePrefix'interface'InterfaceUsageDeclarationInterfaceBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildInterfaceUsage(SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildInterfaceUsage(SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("interface ");
-            BuildInterfaceUsageDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildInterfaceBody(poco, cursorCache, stringBuilder);
+            BuildInterfaceUsageDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildInterfaceBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/InterfaceUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/InterfaceUsageTextualNotationBuilder.cs
@@ -57,7 +57,7 @@ namespace SysML2.NET.TextualNotation
         {
             switch (poco)
             {
-                case SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceUsage pocoInterfaceUsageBinaryInterfacePart when pocoInterfaceUsageBinaryInterfacePart.IsValidForBinaryInterfacePart():
+                case SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceUsage pocoInterfaceUsageBinaryInterfacePart when pocoInterfaceUsageBinaryInterfacePart.IsValidForBinaryInterfacePart(writerContext):
                     BuildBinaryInterfacePart(pocoInterfaceUsageBinaryInterfacePart, writerContext, stringBuilder);
                     break;
                 default:

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/IntersectingTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/IntersectingTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>Intersecting=intersectingType=[QualifiedName]|ownedRelatedElement+=OwnedFeatureChain</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IIntersecting" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildIntersecting(SysML2.NET.Core.POCO.Core.Types.IIntersecting poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildIntersecting(SysML2.NET.Core.POCO.Core.Types.IIntersecting poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
             if (poco.IntersectingType != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.IntersectingType);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.IntersectingType, writerContext);
                 stringBuilder.Append(' ');
             }
             else
@@ -57,7 +57,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                     {
-                        FeatureTextualNotationBuilder.BuildOwnedFeatureChain(elementAsFeature, cursorCache, stringBuilder);
+                        FeatureTextualNotationBuilder.BuildOwnedFeatureChain(elementAsFeature, writerContext, stringBuilder);
                     }
                 }
             }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/IntersectingTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/IntersectingTextualNotationBuilder.cs
@@ -46,7 +46,7 @@ namespace SysML2.NET.TextualNotation
             var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
             if (poco.IntersectingType != null)
             {
-                stringBuilder.Append(poco.IntersectingType.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.IntersectingType);
                 stringBuilder.Append(' ');
             }
             else

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/InvariantTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/InvariantTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>Invariant=FeaturePrefix'inv'('true'|isNegated?='false')?FeatureDeclarationValuePart?FunctionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.IInvariant" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildInvariant(SysML2.NET.Core.POCO.Kernel.Functions.IInvariant poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildInvariant(SysML2.NET.Core.POCO.Kernel.Functions.IInvariant poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            SharedTextualNotationBuilder.BuildFeaturePrefix(poco, cursorCache, stringBuilder);
+            SharedTextualNotationBuilder.BuildFeaturePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("inv ");
             if (!poco.IsNegated)
             {
@@ -54,13 +54,13 @@ namespace SysML2.NET.TextualNotation
             {
                 stringBuilder.Append(" false ");
             }
-            FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, cursorCache, stringBuilder);
+            FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, writerContext, stringBuilder);
 
             if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
-                FeatureTextualNotationBuilder.BuildValuePart(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }
-            TypeTextualNotationBuilder.BuildFunctionBody(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildFunctionBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/InvocationExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/InvocationExpressionTextualNotationBuilder.cs
@@ -39,18 +39,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>FunctionOperationExpression:InvocationExpression=ownedRelationship+=PrimaryArgumentMember'-&gt;'ownedRelationship+=InvocationTypeMember(ownedRelationship+=BodyArgumentMember|ownedRelationship+=FunctionReferenceArgumentMember|ArgumentList)ownedRelationship+=EmptyResultMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.IInvocationExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFunctionOperationExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IInvocationExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFunctionOperationExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IInvocationExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildPrimaryArgumentMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildPrimaryArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -59,7 +59,7 @@ namespace SysML2.NET.TextualNotation
 
             if (ownedRelationshipCursor.Current != null)
             {
-                BuildInvocationTypeMember(poco, cursorCache, stringBuilder);
+                BuildInvocationTypeMember(poco, writerContext, stringBuilder);
             }
             ownedRelationshipCursor.Move();
 
@@ -71,7 +71,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                     {
-                        ParameterMembershipTextualNotationBuilder.BuildBodyArgumentMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                        ParameterMembershipTextualNotationBuilder.BuildBodyArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
                     }
                 }
             }
@@ -83,13 +83,13 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                     {
-                        ParameterMembershipTextualNotationBuilder.BuildFunctionReferenceArgumentMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                        ParameterMembershipTextualNotationBuilder.BuildFunctionReferenceArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
                     }
                 }
             }
             else
             {
-                FeatureTextualNotationBuilder.BuildArgumentList(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildArgumentList(poco, writerContext, stringBuilder);
             }
             stringBuilder.Append(' ');
 
@@ -98,7 +98,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
                 {
-                    ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, cursorCache, stringBuilder);
+                    ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -111,30 +111,30 @@ namespace SysML2.NET.TextualNotation
         /// <para>InvocationExpression:InvocationExpression=ownedRelationship+=InstantiatedTypeMemberArgumentListownedRelationship+=EmptyResultMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.IInvocationExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildInvocationExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IInvocationExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildInvocationExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IInvocationExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership elementAsMembership)
                 {
-                    MembershipTextualNotationBuilder.BuildInstantiatedTypeMember(elementAsMembership, cursorCache, stringBuilder);
+                    MembershipTextualNotationBuilder.BuildInstantiatedTypeMember(elementAsMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
 
-            FeatureTextualNotationBuilder.BuildArgumentList(poco, cursorCache, stringBuilder);
+            FeatureTextualNotationBuilder.BuildArgumentList(poco, writerContext, stringBuilder);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
                 {
-                    ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, cursorCache, stringBuilder);
+                    ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ItemDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ItemDefinitionTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>ItemDefinition=OccurrenceDefinitionPrefix'item''def'Definition</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Items.IItemDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildItemDefinition(SysML2.NET.Core.POCO.Systems.Items.IItemDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildItemDefinition(SysML2.NET.Core.POCO.Systems.Items.IItemDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, cursorCache, stringBuilder);
+            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("item ");
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinition(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinition(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ItemUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ItemUsageTextualNotationBuilder.cs
@@ -39,13 +39,13 @@ namespace SysML2.NET.TextualNotation
         /// <para>ItemUsage=OccurrenceUsagePrefix'item'Usage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Items.IItemUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildItemUsage(SysML2.NET.Core.POCO.Systems.Items.IItemUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildItemUsage(SysML2.NET.Core.POCO.Systems.Items.IItemUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("item ");
-            UsageTextualNotationBuilder.BuildUsage(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsage(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/JoinNodeTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/JoinNodeTextualNotationBuilder.cs
@@ -39,17 +39,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>JoinNode=ControlNodePrefixisComposite?='join'UsageDeclarationActionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IJoinNode" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildJoinNode(SysML2.NET.Core.POCO.Systems.Actions.IJoinNode poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildJoinNode(SysML2.NET.Core.POCO.Systems.Actions.IJoinNode poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildControlNodePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildControlNodePrefix(poco, writerContext, stringBuilder);
             if (poco.IsComposite)
             {
                 stringBuilder.Append(" join ");
             }
-            UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildActionBody(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildActionBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/LibraryPackageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/LibraryPackageTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>LibraryPackage=(isStandard?='standard')'library'(ownedRelationship+=PrefixMetadataMember)*PackageDeclarationPackageBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Packages.ILibraryPackage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildLibraryPackage(SysML2.NET.Core.POCO.Kernel.Packages.ILibraryPackage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildLibraryPackage(SysML2.NET.Core.POCO.Kernel.Packages.ILibraryPackage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             if (poco.IsStandard)
             {
                 stringBuilder.Append(" standard ");
@@ -60,14 +60,14 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                     {
-                        OwningMembershipTextualNotationBuilder.BuildPrefixMetadataMember(elementAsOwningMembership, cursorCache, stringBuilder);
+                        OwningMembershipTextualNotationBuilder.BuildPrefixMetadataMember(elementAsOwningMembership, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
 
             }
-            PackageTextualNotationBuilder.BuildPackageDeclaration(poco, cursorCache, stringBuilder);
-            PackageTextualNotationBuilder.BuildPackageBody(poco, cursorCache, stringBuilder);
+            PackageTextualNotationBuilder.BuildPackageDeclaration(poco, writerContext, stringBuilder);
+            PackageTextualNotationBuilder.BuildPackageBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/LiteralBooleanTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/LiteralBooleanTextualNotationBuilder.cs
@@ -39,9 +39,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>LiteralBoolean=value=BooleanValue</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.ILiteralBoolean" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildLiteralBoolean(SysML2.NET.Core.POCO.Kernel.Expressions.ILiteralBoolean poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildLiteralBoolean(SysML2.NET.Core.POCO.Kernel.Expressions.ILiteralBoolean poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             stringBuilder.Append(poco.Value.ToString().ToLower());
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/LiteralExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/LiteralExpressionTextualNotationBuilder.cs
@@ -39,26 +39,26 @@ namespace SysML2.NET.TextualNotation
         /// <para>LiteralExpression=LiteralBoolean|LiteralString|LiteralInteger|LiteralReal|LiteralInfinity</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.ILiteralExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildLiteralExpression(SysML2.NET.Core.POCO.Kernel.Expressions.ILiteralExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildLiteralExpression(SysML2.NET.Core.POCO.Kernel.Expressions.ILiteralExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Kernel.Expressions.ILiteralBoolean pocoLiteralBoolean:
-                    LiteralBooleanTextualNotationBuilder.BuildLiteralBoolean(pocoLiteralBoolean, cursorCache, stringBuilder);
+                    LiteralBooleanTextualNotationBuilder.BuildLiteralBoolean(pocoLiteralBoolean, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Expressions.ILiteralString pocoLiteralString:
-                    LiteralStringTextualNotationBuilder.BuildLiteralString(pocoLiteralString, cursorCache, stringBuilder);
+                    LiteralStringTextualNotationBuilder.BuildLiteralString(pocoLiteralString, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Expressions.ILiteralInteger pocoLiteralInteger:
-                    LiteralIntegerTextualNotationBuilder.BuildLiteralInteger(pocoLiteralInteger, cursorCache, stringBuilder);
+                    LiteralIntegerTextualNotationBuilder.BuildLiteralInteger(pocoLiteralInteger, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Expressions.ILiteralInfinity pocoLiteralInfinity:
-                    LiteralInfinityTextualNotationBuilder.BuildLiteralInfinity(pocoLiteralInfinity, cursorCache, stringBuilder);
+                    LiteralInfinityTextualNotationBuilder.BuildLiteralInfinity(pocoLiteralInfinity, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Root.Elements.IElement pocoElement:
-                    SharedTextualNotationBuilder.BuildLiteralReal((SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue)pocoElement, cursorCache, stringBuilder);
+                    SharedTextualNotationBuilder.BuildLiteralReal((SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue)pocoElement, writerContext, stringBuilder);
                     break;
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/LiteralInfinityTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/LiteralInfinityTextualNotationBuilder.cs
@@ -39,9 +39,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>LiteralInfinity='*'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.ILiteralInfinity" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildLiteralInfinity(SysML2.NET.Core.POCO.Kernel.Expressions.ILiteralInfinity poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildLiteralInfinity(SysML2.NET.Core.POCO.Kernel.Expressions.ILiteralInfinity poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             stringBuilder.Append("*");
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/LiteralIntegerTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/LiteralIntegerTextualNotationBuilder.cs
@@ -39,9 +39,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>LiteralInteger=value=DECIMAL_VALUE</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.ILiteralInteger" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildLiteralInteger(SysML2.NET.Core.POCO.Kernel.Expressions.ILiteralInteger poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildLiteralInteger(SysML2.NET.Core.POCO.Kernel.Expressions.ILiteralInteger poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             stringBuilder.Append(poco.Value.ToString());
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/LiteralStringTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/LiteralStringTextualNotationBuilder.cs
@@ -39,9 +39,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>LiteralString=value=STRING_VALUE</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.ILiteralString" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildLiteralString(SysML2.NET.Core.POCO.Kernel.Expressions.ILiteralString poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildLiteralString(SysML2.NET.Core.POCO.Kernel.Expressions.ILiteralString poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             stringBuilder.Append(poco.Value);
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MembershipExposeTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MembershipExposeTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>MembershipExpose=MembershipImport</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.IMembershipExpose" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMembershipExpose(SysML2.NET.Core.POCO.Systems.Views.IMembershipExpose poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMembershipExpose(SysML2.NET.Core.POCO.Systems.Views.IMembershipExpose poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            MembershipImportTextualNotationBuilder.BuildMembershipImport(poco, cursorCache, stringBuilder);
+            MembershipImportTextualNotationBuilder.BuildMembershipImport(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MembershipImportTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MembershipImportTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>MembershipImport=importedMembership=[QualifiedName]('::'isRecursive?='**')?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IMembershipImport" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMembershipImport(SysML2.NET.Core.POCO.Root.Namespaces.IMembershipImport poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMembershipImport(SysML2.NET.Core.POCO.Root.Namespaces.IMembershipImport poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.ImportedMembership != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.ImportedMembership);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.ImportedMembership, writerContext);
                 stringBuilder.Append(' ');
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MembershipImportTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MembershipImportTextualNotationBuilder.cs
@@ -46,7 +46,7 @@ namespace SysML2.NET.TextualNotation
 
             if (poco.ImportedMembership != null)
             {
-                stringBuilder.Append(poco.ImportedMembership.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.ImportedMembership);
                 stringBuilder.Append(' ');
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MembershipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MembershipTextualNotationBuilder.cs
@@ -39,9 +39,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>MemberPrefix:Membership=(visibility=VisibilityIndicator)?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMemberPrefix(SysML2.NET.Core.POCO.Root.Namespaces.IMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMemberPrefix(SysML2.NET.Core.POCO.Root.Namespaces.IMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.Visibility != SysML2.NET.Core.Root.Namespaces.VisibilityKind.Public)
@@ -58,11 +58,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>AliasMember:Membership=MemberPrefix'alias'('&lt;'memberShortName=NAME'&gt;')?(memberName=NAME)?'for'memberElement=[QualifiedName]RelationshipBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildAliasMember(SysML2.NET.Core.POCO.Root.Namespaces.IMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildAliasMember(SysML2.NET.Core.POCO.Root.Namespaces.IMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            BuildMemberPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("alias ");
 
             if (!string.IsNullOrWhiteSpace(poco.MemberShortName))
@@ -84,10 +84,10 @@ namespace SysML2.NET.TextualNotation
 
             if (poco.MemberElement != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.MemberElement);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.MemberElement, writerContext);
                 stringBuilder.Append(' ');
             }
-            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, cursorCache, stringBuilder);
+            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, writerContext, stringBuilder);
 
         }
 
@@ -96,26 +96,26 @@ namespace SysML2.NET.TextualNotation
         /// <para>FeatureChainMember:Membership=memberElement=[QualifiedName]|OwnedFeatureChainMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFeatureChainMember(SysML2.NET.Core.POCO.Root.Namespaces.IMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFeatureChainMember(SysML2.NET.Core.POCO.Root.Namespaces.IMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.MemberElement != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.MemberElement);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.MemberElement, writerContext);
                 stringBuilder.Append(' ');
             }
             else
             {
-                var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+                var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
                 if (ownedRelatedElementCursor.Current != null)
                 {
 
                     if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                     {
-                        FeatureTextualNotationBuilder.BuildOwnedFeatureChain(elementAsFeature, cursorCache, stringBuilder);
+                        FeatureTextualNotationBuilder.BuildOwnedFeatureChain(elementAsFeature, writerContext, stringBuilder);
                     }
                 }
                 ownedRelatedElementCursor.Move();
@@ -129,9 +129,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>FeatureReferenceMember:Membership=memberElement=FeatureReference</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFeatureReferenceMember(SysML2.NET.Core.POCO.Root.Namespaces.IMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFeatureReferenceMember(SysML2.NET.Core.POCO.Root.Namespaces.IMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.MemberElement != null)
@@ -139,7 +139,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (poco.MemberElement is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                 {
-                    FeatureTextualNotationBuilder.BuildFeatureReference(elementAsFeature, cursorCache, stringBuilder);
+                    FeatureTextualNotationBuilder.BuildFeatureReference(elementAsFeature, writerContext, stringBuilder);
                 }
             }
 
@@ -150,14 +150,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>ElementReferenceMember:Membership=memberElement=[QualifiedName]</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildElementReferenceMember(SysML2.NET.Core.POCO.Root.Namespaces.IMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildElementReferenceMember(SysML2.NET.Core.POCO.Root.Namespaces.IMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.MemberElement != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.MemberElement);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.MemberElement, writerContext);
                 stringBuilder.Append(' ');
             }
 
@@ -168,9 +168,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>InstantiatedTypeMember:Membership=memberElement=InstantiatedTypeReference|OwnedFeatureChainMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildInstantiatedTypeMember(SysML2.NET.Core.POCO.Root.Namespaces.IMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildInstantiatedTypeMember(SysML2.NET.Core.POCO.Root.Namespaces.IMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.MemberElement != null)
@@ -178,19 +178,19 @@ namespace SysML2.NET.TextualNotation
 
                 if (poco.MemberElement is SysML2.NET.Core.POCO.Core.Types.IType elementAsType)
                 {
-                    TypeTextualNotationBuilder.BuildInstantiatedTypeReference(elementAsType, cursorCache, stringBuilder);
+                    TypeTextualNotationBuilder.BuildInstantiatedTypeReference(elementAsType, writerContext, stringBuilder);
                 }
             }
             else
             {
-                var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+                var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
                 if (ownedRelatedElementCursor.Current != null)
                 {
 
                     if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                     {
-                        FeatureTextualNotationBuilder.BuildOwnedFeatureChain(elementAsFeature, cursorCache, stringBuilder);
+                        FeatureTextualNotationBuilder.BuildOwnedFeatureChain(elementAsFeature, writerContext, stringBuilder);
                     }
                 }
                 ownedRelatedElementCursor.Move();
@@ -204,23 +204,23 @@ namespace SysML2.NET.TextualNotation
         /// <para>MetadataBodyElement:Membership=NonFeatureMember|MetadataBodyFeatureMember|AliasMember|Import</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMetadataBodyElement(SysML2.NET.Core.POCO.Root.Namespaces.IMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMetadataBodyElement(SysML2.NET.Core.POCO.Root.Namespaces.IMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Core.Types.IFeatureMembership pocoFeatureMembership:
-                    FeatureMembershipTextualNotationBuilder.BuildMetadataBodyFeatureMember(pocoFeatureMembership, cursorCache, stringBuilder);
+                    FeatureMembershipTextualNotationBuilder.BuildMetadataBodyFeatureMember(pocoFeatureMembership, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership pocoOwningMembership:
-                    OwningMembershipTextualNotationBuilder.BuildNonFeatureMember(pocoOwningMembership, cursorCache, stringBuilder);
+                    OwningMembershipTextualNotationBuilder.BuildNonFeatureMember(pocoOwningMembership, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Root.Namespaces.IImport pocoImport:
-                    ImportTextualNotationBuilder.BuildImport(pocoImport, cursorCache, stringBuilder);
+                    ImportTextualNotationBuilder.BuildImport(pocoImport, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildAliasMember(poco, cursorCache, stringBuilder);
+                    BuildAliasMember(poco, writerContext, stringBuilder);
                     break;
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MembershipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MembershipTextualNotationBuilder.cs
@@ -84,7 +84,7 @@ namespace SysML2.NET.TextualNotation
 
             if (poco.MemberElement != null)
             {
-                stringBuilder.Append(poco.MemberElement.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.MemberElement);
                 stringBuilder.Append(' ');
             }
             RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, cursorCache, stringBuilder);
@@ -103,7 +103,7 @@ namespace SysML2.NET.TextualNotation
 
             if (poco.MemberElement != null)
             {
-                stringBuilder.Append(poco.MemberElement.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.MemberElement);
                 stringBuilder.Append(' ');
             }
             else
@@ -157,7 +157,7 @@ namespace SysML2.NET.TextualNotation
 
             if (poco.MemberElement != null)
             {
-                stringBuilder.Append(poco.MemberElement.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.MemberElement);
                 stringBuilder.Append(' ');
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MergeNodeTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MergeNodeTextualNotationBuilder.cs
@@ -39,17 +39,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>MergeNode=ControlNodePrefixisComposite?='merge'UsageDeclarationActionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IMergeNode" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMergeNode(SysML2.NET.Core.POCO.Systems.Actions.IMergeNode poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMergeNode(SysML2.NET.Core.POCO.Systems.Actions.IMergeNode poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildControlNodePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildControlNodePrefix(poco, writerContext, stringBuilder);
             if (poco.IsComposite)
             {
                 stringBuilder.Append(" merge ");
             }
-            UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildActionBody(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildActionBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MetaclassTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MetaclassTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>Metaclass=TypePrefix'metaclass'ClassifierDeclarationTypeBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Metadata.IMetaclass" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMetaclass(SysML2.NET.Core.POCO.Kernel.Metadata.IMetaclass poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMetaclass(SysML2.NET.Core.POCO.Kernel.Metadata.IMetaclass poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            TypeTextualNotationBuilder.BuildTypePrefix(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("metaclass ");
-            ClassifierTextualNotationBuilder.BuildClassifierDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildTypeBody(poco, cursorCache, stringBuilder);
+            ClassifierTextualNotationBuilder.BuildClassifierDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypeBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MetadataAccessExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MetadataAccessExpressionTextualNotationBuilder.cs
@@ -39,18 +39,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>MetadataReference:MetadataAccessExpression=ownedRelationship+=ElementReferenceMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.IMetadataAccessExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMetadataReference(SysML2.NET.Core.POCO.Kernel.Expressions.IMetadataAccessExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMetadataReference(SysML2.NET.Core.POCO.Kernel.Expressions.IMetadataAccessExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership elementAsMembership)
                 {
-                    MembershipTextualNotationBuilder.BuildElementReferenceMember(elementAsMembership, cursorCache, stringBuilder);
+                    MembershipTextualNotationBuilder.BuildElementReferenceMember(elementAsMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -63,18 +63,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>MetadataAccessExpression=ownedRelationship+=ElementReferenceMember'.''metadata'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.IMetadataAccessExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMetadataAccessExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IMetadataAccessExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMetadataAccessExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IMetadataAccessExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership elementAsMembership)
                 {
-                    MembershipTextualNotationBuilder.BuildElementReferenceMember(elementAsMembership, cursorCache, stringBuilder);
+                    MembershipTextualNotationBuilder.BuildElementReferenceMember(elementAsMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MetadataDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MetadataDefinitionTextualNotationBuilder.cs
@@ -39,9 +39,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>MetadataDefinition=(isAbstract?='abstract')?DefinitionExtensionKeyword*'metadata''def'Definition</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Metadata.IMetadataDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMetadataDefinition(SysML2.NET.Core.POCO.Systems.Metadata.IMetadataDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMetadataDefinition(SysML2.NET.Core.POCO.Systems.Metadata.IMetadataDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.IsAbstract)
@@ -50,15 +50,15 @@ namespace SysML2.NET.TextualNotation
                 stringBuilder.Append(' ');
             }
 
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership)
             {
-                DefinitionTextualNotationBuilder.BuildDefinitionExtensionKeyword(poco, cursorCache, stringBuilder);
+                DefinitionTextualNotationBuilder.BuildDefinitionExtensionKeyword(poco, writerContext, stringBuilder);
             }
 
             stringBuilder.Append("metadata ");
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinition(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinition(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MetadataFeatureTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MetadataFeatureTextualNotationBuilder.cs
@@ -39,18 +39,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>PrefixMetadataFeature:MetadataFeature=ownedRelationship+=OwnedFeatureTyping</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Metadata.IMetadataFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPrefixMetadataFeature(SysML2.NET.Core.POCO.Kernel.Metadata.IMetadataFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPrefixMetadataFeature(SysML2.NET.Core.POCO.Kernel.Metadata.IMetadataFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping elementAsFeatureTyping)
                 {
-                    FeatureTypingTextualNotationBuilder.BuildOwnedFeatureTyping(elementAsFeatureTyping, cursorCache, stringBuilder);
+                    FeatureTypingTextualNotationBuilder.BuildOwnedFeatureTyping(elementAsFeatureTyping, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -63,15 +63,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>MetadataFeatureDeclaration:MetadataFeature=(Identification(':'|'typed''by'))?ownedRelationship+=OwnedFeatureTyping</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Metadata.IMetadataFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMetadataFeatureDeclaration(SysML2.NET.Core.POCO.Kernel.Metadata.IMetadataFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMetadataFeatureDeclaration(SysML2.NET.Core.POCO.Kernel.Metadata.IMetadataFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName))
             {
-                ElementTextualNotationBuilder.BuildIdentification(poco, cursorCache, stringBuilder);
+                ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
                 stringBuilder.Append(": ");
                 stringBuilder.Append(' ');
             }
@@ -82,7 +82,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping elementAsFeatureTyping)
                 {
-                    FeatureTypingTextualNotationBuilder.BuildOwnedFeatureTyping(elementAsFeatureTyping, cursorCache, stringBuilder);
+                    FeatureTypingTextualNotationBuilder.BuildOwnedFeatureTyping(elementAsFeatureTyping, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -95,11 +95,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>MetadataFeature=(ownedRelationship+=PrefixMetadataMember)*('@'|'metadata')MetadataFeatureDeclaration('about'ownedRelationship+=Annotation(','ownedRelationship+=Annotation)*)?MetadataBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Metadata.IMetadataFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMetadataFeature(SysML2.NET.Core.POCO.Kernel.Metadata.IMetadataFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMetadataFeature(SysML2.NET.Core.POCO.Kernel.Metadata.IMetadataFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership owningMembershipGuard && owningMembershipGuard.OwnedRelatedElement.OfType<SysML2.NET.Core.POCO.Systems.Metadata.IMetadataUsage>().Any())
             {
@@ -109,7 +109,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                     {
-                        OwningMembershipTextualNotationBuilder.BuildPrefixMetadataMember(elementAsOwningMembership, cursorCache, stringBuilder);
+                        OwningMembershipTextualNotationBuilder.BuildPrefixMetadataMember(elementAsOwningMembership, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -117,7 +117,7 @@ namespace SysML2.NET.TextualNotation
             }
             stringBuilder.Append(" @ ");
             stringBuilder.Append(' ');
-            BuildMetadataFeatureDeclaration(poco, cursorCache, stringBuilder);
+            BuildMetadataFeatureDeclaration(poco, writerContext, stringBuilder);
 
             if (ownedRelationshipCursor.Current != null)
             {
@@ -128,11 +128,11 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Annotations.IAnnotation elementAsAnnotation)
                     {
-                        AnnotationTextualNotationBuilder.BuildAnnotation(elementAsAnnotation, cursorCache, stringBuilder);
+                        AnnotationTextualNotationBuilder.BuildAnnotation(elementAsAnnotation, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
 
                 while (ownedRelationshipCursor.Current != null && ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Annotations.IAnnotation)
                 {
@@ -143,7 +143,7 @@ namespace SysML2.NET.TextualNotation
 
                         if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Annotations.IAnnotation elementAsAnnotation)
                         {
-                            AnnotationTextualNotationBuilder.BuildAnnotation(elementAsAnnotation, cursorCache, stringBuilder);
+                            AnnotationTextualNotationBuilder.BuildAnnotation(elementAsAnnotation, writerContext, stringBuilder);
                         }
                     }
                     ownedRelationshipCursor.Move();
@@ -152,7 +152,7 @@ namespace SysML2.NET.TextualNotation
                 stringBuilder.Append(' ');
             }
 
-            TypeTextualNotationBuilder.BuildMetadataBody(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildMetadataBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MetadataUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MetadataUsageTextualNotationBuilder.cs
@@ -39,18 +39,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>PrefixMetadataUsage:MetadataUsage=ownedRelationship+=OwnedFeatureTyping</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Metadata.IMetadataUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPrefixMetadataUsage(SysML2.NET.Core.POCO.Systems.Metadata.IMetadataUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPrefixMetadataUsage(SysML2.NET.Core.POCO.Systems.Metadata.IMetadataUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping elementAsFeatureTyping)
                 {
-                    FeatureTypingTextualNotationBuilder.BuildOwnedFeatureTyping(elementAsFeatureTyping, cursorCache, stringBuilder);
+                    FeatureTypingTextualNotationBuilder.BuildOwnedFeatureTyping(elementAsFeatureTyping, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -63,15 +63,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>MetadataUsageDeclaration:MetadataUsage=(Identification(':'|'typed''by'))?ownedRelationship+=OwnedFeatureTyping</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Metadata.IMetadataUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMetadataUsageDeclaration(SysML2.NET.Core.POCO.Systems.Metadata.IMetadataUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMetadataUsageDeclaration(SysML2.NET.Core.POCO.Systems.Metadata.IMetadataUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName))
             {
-                ElementTextualNotationBuilder.BuildIdentification(poco, cursorCache, stringBuilder);
+                ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
                 stringBuilder.Append(": ");
                 stringBuilder.Append(' ');
             }
@@ -82,7 +82,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping elementAsFeatureTyping)
                 {
-                    FeatureTypingTextualNotationBuilder.BuildOwnedFeatureTyping(elementAsFeatureTyping, cursorCache, stringBuilder);
+                    FeatureTypingTextualNotationBuilder.BuildOwnedFeatureTyping(elementAsFeatureTyping, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -95,19 +95,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>MetadataUsage=UsageExtensionKeyword*('@'|'metadata')MetadataUsageDeclaration('about'ownedRelationship+=Annotation(','ownedRelationship+=Annotation)*)?MetadataBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Metadata.IMetadataUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMetadataUsage(SysML2.NET.Core.POCO.Systems.Metadata.IMetadataUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMetadataUsage(SysML2.NET.Core.POCO.Systems.Metadata.IMetadataUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership)
             {
-                UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, writerContext, stringBuilder);
             }
 
             stringBuilder.Append(" @ ");
             stringBuilder.Append(' ');
-            BuildMetadataUsageDeclaration(poco, cursorCache, stringBuilder);
+            BuildMetadataUsageDeclaration(poco, writerContext, stringBuilder);
 
             if (ownedRelationshipCursor.Current != null)
             {
@@ -118,11 +118,11 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Annotations.IAnnotation elementAsAnnotation)
                     {
-                        AnnotationTextualNotationBuilder.BuildAnnotation(elementAsAnnotation, cursorCache, stringBuilder);
+                        AnnotationTextualNotationBuilder.BuildAnnotation(elementAsAnnotation, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
 
                 while (ownedRelationshipCursor.Current != null && ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Annotations.IAnnotation)
                 {
@@ -133,7 +133,7 @@ namespace SysML2.NET.TextualNotation
 
                         if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Annotations.IAnnotation elementAsAnnotation)
                         {
-                            AnnotationTextualNotationBuilder.BuildAnnotation(elementAsAnnotation, cursorCache, stringBuilder);
+                            AnnotationTextualNotationBuilder.BuildAnnotation(elementAsAnnotation, writerContext, stringBuilder);
                         }
                     }
                     ownedRelationshipCursor.Move();
@@ -142,7 +142,7 @@ namespace SysML2.NET.TextualNotation
                 stringBuilder.Append(' ');
             }
 
-            TypeTextualNotationBuilder.BuildMetadataBody(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildMetadataBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MultiplicityRangeTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MultiplicityRangeTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedMultiplicityRange:MultiplicityRange=MultiplicityBounds</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Multiplicities.IMultiplicityRange" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedMultiplicityRange(SysML2.NET.Core.POCO.Kernel.Multiplicities.IMultiplicityRange poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedMultiplicityRange(SysML2.NET.Core.POCO.Kernel.Multiplicities.IMultiplicityRange poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildMultiplicityBounds(poco, cursorCache, stringBuilder);
+            BuildMultiplicityBounds(poco, writerContext, stringBuilder);
 
         }
 
@@ -52,11 +52,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>MultiplicityBounds:MultiplicityRange='['(ownedRelationship+=MultiplicityExpressionMember'..')?ownedRelationship+=MultiplicityExpressionMember']'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Multiplicities.IMultiplicityRange" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMultiplicityBounds(SysML2.NET.Core.POCO.Kernel.Multiplicities.IMultiplicityRange poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMultiplicityBounds(SysML2.NET.Core.POCO.Kernel.Multiplicities.IMultiplicityRange poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append("[");
 
             if (ownedRelationshipCursor.Current != null)
@@ -67,11 +67,11 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                     {
-                        OwningMembershipTextualNotationBuilder.BuildMultiplicityExpressionMember(elementAsOwningMembership, cursorCache, stringBuilder);
+                        OwningMembershipTextualNotationBuilder.BuildMultiplicityExpressionMember(elementAsOwningMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
                 stringBuilder.Append(".. ");
                 stringBuilder.Append(' ');
             }
@@ -82,7 +82,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                 {
-                    OwningMembershipTextualNotationBuilder.BuildMultiplicityExpressionMember(elementAsOwningMembership, cursorCache, stringBuilder);
+                    OwningMembershipTextualNotationBuilder.BuildMultiplicityExpressionMember(elementAsOwningMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -96,11 +96,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>MultiplicityRange='['(ownedRelationship+=MultiplicityExpressionMember'..')?ownedRelationship+=MultiplicityExpressionMember']'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Multiplicities.IMultiplicityRange" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMultiplicityRange(SysML2.NET.Core.POCO.Kernel.Multiplicities.IMultiplicityRange poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMultiplicityRange(SysML2.NET.Core.POCO.Kernel.Multiplicities.IMultiplicityRange poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append("[");
 
             if (ownedRelationshipCursor.Current != null)
@@ -111,11 +111,11 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                     {
-                        OwningMembershipTextualNotationBuilder.BuildMultiplicityExpressionMember(elementAsOwningMembership, cursorCache, stringBuilder);
+                        OwningMembershipTextualNotationBuilder.BuildMultiplicityExpressionMember(elementAsOwningMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
                 stringBuilder.Append(".. ");
                 stringBuilder.Append(' ');
             }
@@ -126,7 +126,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                 {
-                    OwningMembershipTextualNotationBuilder.BuildMultiplicityExpressionMember(elementAsOwningMembership, cursorCache, stringBuilder);
+                    OwningMembershipTextualNotationBuilder.BuildMultiplicityExpressionMember(elementAsOwningMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MultiplicityTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/MultiplicityTextualNotationBuilder.cs
@@ -39,9 +39,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>EmptyMultiplicity:Multiplicity={}</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IMultiplicity" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildEmptyMultiplicity(SysML2.NET.Core.POCO.Core.Types.IMultiplicity poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildEmptyMultiplicity(SysML2.NET.Core.POCO.Core.Types.IMultiplicity poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
         }
@@ -51,14 +51,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>MultiplicitySubset:Multiplicity='multiplicity'IdentificationSubsetsTypeBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IMultiplicity" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMultiplicitySubset(SysML2.NET.Core.POCO.Core.Types.IMultiplicity poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMultiplicitySubset(SysML2.NET.Core.POCO.Core.Types.IMultiplicity poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             stringBuilder.Append("multiplicity ");
-            ElementTextualNotationBuilder.BuildIdentification(poco, cursorCache, stringBuilder);
-            FeatureTextualNotationBuilder.BuildSubsets(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildTypeBody(poco, cursorCache, stringBuilder);
+            ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
+            FeatureTextualNotationBuilder.BuildSubsets(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypeBody(poco, writerContext, stringBuilder);
 
         }
 
@@ -67,17 +67,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>Multiplicity=MultiplicitySubset|MultiplicityRange</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IMultiplicity" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMultiplicity(SysML2.NET.Core.POCO.Core.Types.IMultiplicity poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMultiplicity(SysML2.NET.Core.POCO.Core.Types.IMultiplicity poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Kernel.Multiplicities.IMultiplicityRange pocoMultiplicityRange:
-                    MultiplicityRangeTextualNotationBuilder.BuildMultiplicityRange(pocoMultiplicityRange, cursorCache, stringBuilder);
+                    MultiplicityRangeTextualNotationBuilder.BuildMultiplicityRange(pocoMultiplicityRange, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildMultiplicitySubset(poco, cursorCache, stringBuilder);
+                    BuildMultiplicitySubset(poco, writerContext, stringBuilder);
                     break;
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/NamespaceExposeTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/NamespaceExposeTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>NamespaceExpose=NamespaceImport</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.INamespaceExpose" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNamespaceExpose(SysML2.NET.Core.POCO.Systems.Views.INamespaceExpose poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNamespaceExpose(SysML2.NET.Core.POCO.Systems.Views.INamespaceExpose poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            NamespaceImportTextualNotationBuilder.BuildNamespaceImport(poco, cursorCache, stringBuilder);
+            NamespaceImportTextualNotationBuilder.BuildNamespaceImport(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/NamespaceImportTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/NamespaceImportTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>NamespaceImport=importedNamespace=[QualifiedName]'::''*'('::'isRecursive?='**')?|importedNamespace=FilterPackage{ownedRelatedElement+=importedNamespace}</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.INamespaceImport" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNamespaceImport(SysML2.NET.Core.POCO.Root.Namespaces.INamespaceImport poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNamespaceImport(SysML2.NET.Core.POCO.Root.Namespaces.INamespaceImport poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildNamespaceImportHandCoded(poco, cursorCache, stringBuilder);
+            BuildNamespaceImportHandCoded(poco, writerContext, stringBuilder);
         }
     }
 }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/NamespaceTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/NamespaceTextualNotationBuilder.cs
@@ -39,29 +39,29 @@ namespace SysML2.NET.TextualNotation
         /// <para>RootNamespace:Namespace=PackageBodyElement*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.INamespace" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildRootNamespace(SysML2.NET.Core.POCO.Root.Namespaces.INamespace poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildRootNamespace(SysML2.NET.Core.POCO.Root.Namespaces.INamespace poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             while (ownedRelationshipCursor.Current != null)
             {
                 switch (ownedRelationshipCursor.Current)
                 {
                     case SysML2.NET.Core.POCO.Kernel.Packages.IElementFilterMembership elementFilterMembership:
-                        ElementFilterMembershipTextualNotationBuilder.BuildElementFilterMember(elementFilterMembership, cursorCache, stringBuilder);
+                        ElementFilterMembershipTextualNotationBuilder.BuildElementFilterMember(elementFilterMembership, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
                     case SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership owningMembership:
-                        OwningMembershipTextualNotationBuilder.BuildPackageMember(owningMembership, cursorCache, stringBuilder);
+                        OwningMembershipTextualNotationBuilder.BuildPackageMember(owningMembership, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
                     case SysML2.NET.Core.POCO.Root.Namespaces.IMembership membership:
-                        MembershipTextualNotationBuilder.BuildAliasMember(membership, cursorCache, stringBuilder);
+                        MembershipTextualNotationBuilder.BuildAliasMember(membership, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
                     case SysML2.NET.Core.POCO.Root.Namespaces.IImport import:
-                        ImportTextualNotationBuilder.BuildImport(import, cursorCache, stringBuilder);
+                        ImportTextualNotationBuilder.BuildImport(import, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
                     default:
@@ -79,12 +79,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>NamespaceDeclaration:Namespace='namespace'Identification</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.INamespace" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNamespaceDeclaration(SysML2.NET.Core.POCO.Root.Namespaces.INamespace poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNamespaceDeclaration(SysML2.NET.Core.POCO.Root.Namespaces.INamespace poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             stringBuilder.Append("namespace ");
-            ElementTextualNotationBuilder.BuildIdentification(poco, cursorCache, stringBuilder);
+            ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
 
         }
 
@@ -93,11 +93,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>NamespaceBody:Namespace=';'|'{'NamespaceBodyElement*'}'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.INamespace" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNamespaceBody(SysML2.NET.Core.POCO.Root.Namespaces.INamespace poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNamespaceBody(SysML2.NET.Core.POCO.Root.Namespaces.INamespace poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            if (cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
+            if (writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
             {
                 stringBuilder.AppendLine(";");
             }
@@ -105,10 +105,10 @@ namespace SysML2.NET.TextualNotation
             {
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
-                var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 while (ownedRelationshipCursor.Current != null)
                 {
-                    BuildNamespaceBodyElement(poco, cursorCache, stringBuilder);
+                    BuildNamespaceBodyElement(poco, writerContext, stringBuilder);
                 }
                 stringBuilder.AppendLine("}");
             }
@@ -120,23 +120,23 @@ namespace SysML2.NET.TextualNotation
         /// <para>NamespaceBodyElement:Namespace=ownedRelationship+=NamespaceMember|ownedRelationship+=AliasMember|ownedRelationship+=Import</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.INamespace" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNamespaceBodyElement(SysML2.NET.Core.POCO.Root.Namespaces.INamespace poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNamespaceBodyElement(SysML2.NET.Core.POCO.Root.Namespaces.INamespace poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             switch (ownedRelationshipCursor.Current)
             {
                 case SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership owningMembership:
-                    OwningMembershipTextualNotationBuilder.BuildNamespaceMember(owningMembership, cursorCache, stringBuilder);
+                    OwningMembershipTextualNotationBuilder.BuildNamespaceMember(owningMembership, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                     break;
                 case SysML2.NET.Core.POCO.Root.Namespaces.IMembership membership:
-                    MembershipTextualNotationBuilder.BuildAliasMember(membership, cursorCache, stringBuilder);
+                    MembershipTextualNotationBuilder.BuildAliasMember(membership, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                     break;
                 case SysML2.NET.Core.POCO.Root.Namespaces.IImport import:
-                    ImportTextualNotationBuilder.BuildImport(import, cursorCache, stringBuilder);
+                    ImportTextualNotationBuilder.BuildImport(import, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                     break;
                 default:
@@ -151,11 +151,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>Namespace=(ownedRelationship+=PrefixMetadataMember)*NamespaceDeclarationNamespaceBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.INamespace" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNamespace(SysML2.NET.Core.POCO.Root.Namespaces.INamespace poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNamespace(SysML2.NET.Core.POCO.Root.Namespaces.INamespace poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership owningMembershipGuard && owningMembershipGuard.OwnedRelatedElement.OfType<SysML2.NET.Core.POCO.Systems.Metadata.IMetadataUsage>().Any())
             {
@@ -165,14 +165,14 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                     {
-                        OwningMembershipTextualNotationBuilder.BuildPrefixMetadataMember(elementAsOwningMembership, cursorCache, stringBuilder);
+                        OwningMembershipTextualNotationBuilder.BuildPrefixMetadataMember(elementAsOwningMembership, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
 
             }
-            BuildNamespaceDeclaration(poco, cursorCache, stringBuilder);
-            BuildNamespaceBody(poco, cursorCache, stringBuilder);
+            BuildNamespaceDeclaration(poco, writerContext, stringBuilder);
+            BuildNamespaceBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/NullExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/NullExpressionTextualNotationBuilder.cs
@@ -39,9 +39,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>NullExpression:NullExpression='null'|'('')'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.INullExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNullExpression(SysML2.NET.Core.POCO.Kernel.Expressions.INullExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNullExpression(SysML2.NET.Core.POCO.Kernel.Expressions.INullExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             stringBuilder.Append("null ");
         }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ObjectiveMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ObjectiveMembershipTextualNotationBuilder.cs
@@ -39,12 +39,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>ObjectiveMember:ObjectiveMembership=MemberPrefix'objective'ownedRelatedElement+=ObjectiveRequirementUsage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Cases.IObjectiveMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildObjectiveMember(SysML2.NET.Core.POCO.Systems.Cases.IObjectiveMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildObjectiveMember(SysML2.NET.Core.POCO.Systems.Cases.IObjectiveMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("objective ");
 
             if (ownedRelatedElementCursor.Current != null)
@@ -52,7 +52,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Requirements.IRequirementUsage elementAsRequirementUsage)
                 {
-                    RequirementUsageTextualNotationBuilder.BuildObjectiveRequirementUsage(elementAsRequirementUsage, cursorCache, stringBuilder);
+                    RequirementUsageTextualNotationBuilder.BuildObjectiveRequirementUsage(elementAsRequirementUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/OccurrenceDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/OccurrenceDefinitionTextualNotationBuilder.cs
@@ -39,15 +39,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>OccurrenceDefinitionPrefix:OccurrenceDefinition=BasicDefinitionPrefix?(isIndividual?='individual'ownedRelationship+=EmptyMultiplicityMember)?DefinitionExtensionKeyword*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOccurrenceDefinitionPrefix(SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOccurrenceDefinitionPrefix(SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (poco.IsAbstract || poco.IsVariation)
             {
-                SharedTextualNotationBuilder.BuildBasicDefinitionPrefix(poco, cursorCache, stringBuilder);
+                SharedTextualNotationBuilder.BuildBasicDefinitionPrefix(poco, writerContext, stringBuilder);
             }
 
             if (poco.IsIndividual && ownedRelationshipCursor.Current != null)
@@ -59,17 +59,17 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                     {
-                        OwningMembershipTextualNotationBuilder.BuildEmptyMultiplicityMember(elementAsOwningMembership, cursorCache, stringBuilder);
+                        OwningMembershipTextualNotationBuilder.BuildEmptyMultiplicityMember(elementAsOwningMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
                 stringBuilder.Append(' ');
             }
 
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership owningMembershipGuard && owningMembershipGuard.OwnedRelatedElement.OfType<SysML2.NET.Core.POCO.Systems.Metadata.IMetadataUsage>().Any())
             {
-                DefinitionTextualNotationBuilder.BuildDefinitionExtensionKeyword(poco, cursorCache, stringBuilder);
+                DefinitionTextualNotationBuilder.BuildDefinitionExtensionKeyword(poco, writerContext, stringBuilder);
             }
 
 
@@ -80,15 +80,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>IndividualDefinition:OccurrenceDefinition=BasicDefinitionPrefix?isIndividual?='individual'DefinitionExtensionKeyword*'def'DefinitionownedRelationship+=EmptyMultiplicityMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildIndividualDefinition(SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildIndividualDefinition(SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (poco.IsAbstract || poco.IsVariation)
             {
-                SharedTextualNotationBuilder.BuildBasicDefinitionPrefix(poco, cursorCache, stringBuilder);
+                SharedTextualNotationBuilder.BuildBasicDefinitionPrefix(poco, writerContext, stringBuilder);
             }
             if (poco.IsIndividual)
             {
@@ -96,18 +96,18 @@ namespace SysML2.NET.TextualNotation
             }
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership)
             {
-                DefinitionTextualNotationBuilder.BuildDefinitionExtensionKeyword(poco, cursorCache, stringBuilder);
+                DefinitionTextualNotationBuilder.BuildDefinitionExtensionKeyword(poco, writerContext, stringBuilder);
             }
 
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinition(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinition(poco, writerContext, stringBuilder);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                 {
-                    OwningMembershipTextualNotationBuilder.BuildEmptyMultiplicityMember(elementAsOwningMembership, cursorCache, stringBuilder);
+                    OwningMembershipTextualNotationBuilder.BuildEmptyMultiplicityMember(elementAsOwningMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -120,14 +120,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>OccurrenceDefinition=OccurrenceDefinitionPrefix'occurrence''def'Definition</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOccurrenceDefinition(SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOccurrenceDefinition(SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildOccurrenceDefinitionPrefix(poco, cursorCache, stringBuilder);
+            BuildOccurrenceDefinitionPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("occurrence ");
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinition(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinition(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/OccurrenceUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/OccurrenceUsageTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>OccurrenceUsagePrefix:OccurrenceUsage=BasicUsagePrefix(isIndividual?='individual')?(portionKind=PortionKind{isPortion=true})?UsageExtensionKeyword*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOccurrenceUsagePrefix(SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOccurrenceUsagePrefix(SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            UsageTextualNotationBuilder.BuildBasicUsagePrefix(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildBasicUsagePrefix(poco, writerContext, stringBuilder);
 
             if (poco.IsIndividual)
             {
@@ -60,10 +60,10 @@ namespace SysML2.NET.TextualNotation
                 stringBuilder.Append(' ');
             }
 
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership owningMembershipGuard && owningMembershipGuard.OwnedRelatedElement.OfType<SysML2.NET.Core.POCO.Systems.Metadata.IMetadataUsage>().Any())
             {
-                UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, writerContext, stringBuilder);
             }
 
 
@@ -74,22 +74,22 @@ namespace SysML2.NET.TextualNotation
         /// <para>IndividualUsage:OccurrenceUsage=BasicUsagePrefixisIndividual?='individual'UsageExtensionKeyword*Usage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildIndividualUsage(SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildIndividualUsage(SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            UsageTextualNotationBuilder.BuildBasicUsagePrefix(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildBasicUsagePrefix(poco, writerContext, stringBuilder);
             if (poco.IsIndividual)
             {
                 stringBuilder.Append(" individual ");
             }
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership)
             {
-                UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, writerContext, stringBuilder);
             }
 
-            UsageTextualNotationBuilder.BuildUsage(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsage(poco, writerContext, stringBuilder);
 
         }
 
@@ -98,11 +98,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>PortionUsage:OccurrenceUsage=BasicUsagePrefix(isIndividual?='individual')?portionKind=PortionKindUsageExtensionKeyword*Usage{isPortion=true}</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPortionUsage(SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPortionUsage(SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            UsageTextualNotationBuilder.BuildBasicUsagePrefix(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildBasicUsagePrefix(poco, writerContext, stringBuilder);
 
             if (poco.IsIndividual)
             {
@@ -112,13 +112,13 @@ namespace SysML2.NET.TextualNotation
 
             stringBuilder.Append(poco.PortionKind.ToString().ToLower());
             stringBuilder.Append(' ');
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership)
             {
-                UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, writerContext, stringBuilder);
             }
 
-            UsageTextualNotationBuilder.BuildUsage(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsage(poco, writerContext, stringBuilder);
             // NonParsing Assignment Element : isPortion = true => Does not have to be process
 
         }
@@ -128,11 +128,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>ControlNodePrefix:OccurrenceUsage=RefPrefix(isIndividual?='individual')?(portionKind=PortionKind{isPortion=true})?UsageExtensionKeyword*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildControlNodePrefix(SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildControlNodePrefix(SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            UsageTextualNotationBuilder.BuildRefPrefix(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildRefPrefix(poco, writerContext, stringBuilder);
 
             if (poco.IsIndividual)
             {
@@ -149,10 +149,10 @@ namespace SysML2.NET.TextualNotation
                 stringBuilder.Append(' ');
             }
 
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership owningMembershipGuard && owningMembershipGuard.OwnedRelatedElement.OfType<SysML2.NET.Core.POCO.Systems.Metadata.IMetadataUsage>().Any())
             {
-                UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, writerContext, stringBuilder);
             }
 
 
@@ -163,13 +163,13 @@ namespace SysML2.NET.TextualNotation
         /// <para>OccurrenceUsage=OccurrenceUsagePrefix'occurrence'Usage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOccurrenceUsage(SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOccurrenceUsage(SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("occurrence ");
-            UsageTextualNotationBuilder.BuildUsage(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsage(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/OperatorExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/OperatorExpressionTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>ConditionalExpression:OperatorExpression=operator='if'ownedRelationship+=ArgumentMember'?'ownedRelationship+=ArgumentExpressionMember'else'ownedRelationship+=ArgumentExpressionMemberownedRelationship+=EmptyResultMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildConditionalExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildConditionalExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append(poco.Operator);
 
             if (ownedRelationshipCursor.Current != null)
@@ -51,7 +51,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -63,7 +63,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildArgumentExpressionMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildArgumentExpressionMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -75,7 +75,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildArgumentExpressionMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildArgumentExpressionMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -86,7 +86,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
                 {
-                    ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, cursorCache, stringBuilder);
+                    ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -99,18 +99,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>ConditionalBinaryOperatorExpression:OperatorExpression=ownedRelationship+=ArgumentMemberoperator=ConditionalBinaryOperatorownedRelationship+=ArgumentExpressionMemberownedRelationship+=EmptyResultMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildConditionalBinaryOperatorExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildConditionalBinaryOperatorExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -122,7 +122,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildArgumentExpressionMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildArgumentExpressionMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -133,7 +133,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
                 {
-                    ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, cursorCache, stringBuilder);
+                    ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -146,18 +146,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>BinaryOperatorExpression:OperatorExpression=ownedRelationship+=ArgumentMemberoperator=BinaryOperatorownedRelationship+=ArgumentMemberownedRelationship+=EmptyResultMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildBinaryOperatorExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildBinaryOperatorExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -169,7 +169,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -180,7 +180,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
                 {
-                    ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, cursorCache, stringBuilder);
+                    ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -193,11 +193,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>UnaryOperatorExpression:OperatorExpression=operator=UnaryOperatorownedRelationship+=ArgumentMemberownedRelationship+=EmptyResultMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildUnaryOperatorExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildUnaryOperatorExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append(poco.Operator);
 
             if (ownedRelationshipCursor.Current != null)
@@ -205,7 +205,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -216,7 +216,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
                 {
-                    ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, cursorCache, stringBuilder);
+                    ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -229,11 +229,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>ClassificationExpression:OperatorExpression=(ownedRelationship+=ArgumentMember)?(operator=ClassificationTestOperatorownedRelationship+=TypeReferenceMember|operator=CastOperatorownedRelationship+=TypeResultMember)ownedRelationship+=EmptyResultMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildClassificationExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildClassificationExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
@@ -243,15 +243,15 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                     {
-                        ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                        ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
                 stringBuilder.Append(' ');
             }
 
-            BuildClassificationExpressionHandCoded(poco, cursorCache, stringBuilder);
+            BuildClassificationExpressionHandCoded(poco, writerContext, stringBuilder);
             stringBuilder.Append(' ');
 
             if (ownedRelationshipCursor.Current != null)
@@ -259,7 +259,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
                 {
-                    ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, cursorCache, stringBuilder);
+                    ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -272,23 +272,23 @@ namespace SysML2.NET.TextualNotation
         /// <para>MetaclassificationExpression:OperatorExpression=ownedRelationship+=MetadataArgumentMember(operator=ClassificationTestOperatorownedRelationship+=TypeReferenceMember|operator=MetaCastOperatorownedRelationship+=TypeResultMember)ownedRelationship+=EmptyResultMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMetaclassificationExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMetaclassificationExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildMetadataArgumentMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildMetadataArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
 
-            BuildMetaclassificationExpressionHandCoded(poco, cursorCache, stringBuilder);
+            BuildMetaclassificationExpressionHandCoded(poco, writerContext, stringBuilder);
             stringBuilder.Append(' ');
 
             if (ownedRelationshipCursor.Current != null)
@@ -296,7 +296,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
                 {
-                    ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, cursorCache, stringBuilder);
+                    ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -309,11 +309,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>ExtentExpression:OperatorExpression=operator='all'ownedRelationship+=TypeReferenceMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildExtentExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildExtentExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append(poco.Operator);
 
             if (ownedRelationshipCursor.Current != null)
@@ -321,7 +321,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildTypeReferenceMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildTypeReferenceMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -334,18 +334,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>BracketExpression:OperatorExpression=ownedRelationship+=PrimaryArgumentMemberoperator='['ownedRelationship+=SequenceExpressionListMember']'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildBracketExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildBracketExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildPrimaryArgumentMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildPrimaryArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -357,7 +357,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
                 {
-                    FeatureMembershipTextualNotationBuilder.BuildSequenceExpressionListMember(elementAsFeatureMembership, cursorCache, stringBuilder);
+                    FeatureMembershipTextualNotationBuilder.BuildSequenceExpressionListMember(elementAsFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -371,18 +371,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>SequenceOperatorExpression:OperatorExpression=ownedRelationship+=OwnedExpressionMemberoperator=','ownedRelationship+=SequenceExpressionListMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSequenceOperatorExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSequenceOperatorExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
                 {
-                    FeatureMembershipTextualNotationBuilder.BuildOwnedExpressionMember(elementAsFeatureMembership, cursorCache, stringBuilder);
+                    FeatureMembershipTextualNotationBuilder.BuildOwnedExpressionMember(elementAsFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -394,7 +394,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
                 {
-                    FeatureMembershipTextualNotationBuilder.BuildSequenceExpressionListMember(elementAsFeatureMembership, cursorCache, stringBuilder);
+                    FeatureMembershipTextualNotationBuilder.BuildSequenceExpressionListMember(elementAsFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/OwningMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/OwningMembershipTextualNotationBuilder.cs
@@ -39,18 +39,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>AnnotatingMember:OwningMembership=ownedRelatedElement+=AnnotatingElement</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildAnnotatingMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildAnnotatingMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Root.Annotations.IAnnotatingElement elementAsAnnotatingElement)
                 {
-                    AnnotatingElementTextualNotationBuilder.BuildAnnotatingElement(elementAsAnnotatingElement, cursorCache, stringBuilder);
+                    AnnotatingElementTextualNotationBuilder.BuildAnnotatingElement(elementAsAnnotatingElement, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -63,21 +63,21 @@ namespace SysML2.NET.TextualNotation
         /// <para>PackageMember:OwningMembership=MemberPrefix(ownedRelatedElement+=DefinitionElement|ownedRelatedElement=UsageElement)</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPackageMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPackageMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
             if (ownedRelatedElementCursor.Current != null)
             {
                 switch (ownedRelatedElementCursor.Current)
                 {
                     case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage usage:
-                        UsageTextualNotationBuilder.BuildUsageElement(usage, cursorCache, stringBuilder);
+                        UsageTextualNotationBuilder.BuildUsageElement(usage, writerContext, stringBuilder);
                         break;
                     case { } element:
-                        ElementTextualNotationBuilder.BuildDefinitionElement(element, cursorCache, stringBuilder);
+                        ElementTextualNotationBuilder.BuildDefinitionElement(element, writerContext, stringBuilder);
                         break;
                 }
                 ownedRelatedElementCursor.Move();
@@ -91,19 +91,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>DefinitionMember:OwningMembership=MemberPrefixownedRelatedElement+=DefinitionElement</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildDefinitionMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildDefinitionMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Root.Elements.IElement elementAsElement)
                 {
-                    ElementTextualNotationBuilder.BuildDefinitionElement(elementAsElement, cursorCache, stringBuilder);
+                    ElementTextualNotationBuilder.BuildDefinitionElement(elementAsElement, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -116,18 +116,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedCrossFeatureMember:OwningMembership=ownedRelatedElement+=OwnedCrossFeature</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedCrossFeatureMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedCrossFeatureMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
-                    ReferenceUsageTextualNotationBuilder.BuildOwnedCrossFeature(elementAsReferenceUsage, cursorCache, stringBuilder);
+                    ReferenceUsageTextualNotationBuilder.BuildOwnedCrossFeature(elementAsReferenceUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -140,18 +140,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedMultiplicity:OwningMembership=ownedRelatedElement+=MultiplicityRange</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedMultiplicity(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedMultiplicity(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Multiplicities.IMultiplicityRange elementAsMultiplicityRange)
                 {
-                    MultiplicityRangeTextualNotationBuilder.BuildMultiplicityRange(elementAsMultiplicityRange, cursorCache, stringBuilder);
+                    MultiplicityRangeTextualNotationBuilder.BuildMultiplicityRange(elementAsMultiplicityRange, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -164,18 +164,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>MultiplicityExpressionMember:OwningMembership=ownedRelatedElement+=(LiteralExpression|FeatureReferenceExpression)</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMultiplicityExpressionMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMultiplicityExpressionMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
             switch (ownedRelatedElementCursor.Current)
             {
                 case SysML2.NET.Core.POCO.Kernel.Expressions.ILiteralExpression pocoLiteralExpression:
-                    LiteralExpressionTextualNotationBuilder.BuildLiteralExpression(pocoLiteralExpression, cursorCache, stringBuilder);
+                    LiteralExpressionTextualNotationBuilder.BuildLiteralExpression(pocoLiteralExpression, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression pocoFeatureReferenceExpression:
-                    FeatureReferenceExpressionTextualNotationBuilder.BuildFeatureReferenceExpression(pocoFeatureReferenceExpression, cursorCache, stringBuilder);
+                    FeatureReferenceExpressionTextualNotationBuilder.BuildFeatureReferenceExpression(pocoFeatureReferenceExpression, writerContext, stringBuilder);
                     break;
             }
             ownedRelatedElementCursor.Move();
@@ -188,18 +188,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>EmptyMultiplicityMember:OwningMembership=ownedRelatedElement+=EmptyMultiplicity</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildEmptyMultiplicityMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildEmptyMultiplicityMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Types.IMultiplicity elementAsMultiplicity)
                 {
-                    MultiplicityTextualNotationBuilder.BuildEmptyMultiplicity(elementAsMultiplicity, cursorCache, stringBuilder);
+                    MultiplicityTextualNotationBuilder.BuildEmptyMultiplicity(elementAsMultiplicity, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -212,18 +212,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>ConjugatedPortDefinitionMember:OwningMembership=ownedRelatedElement+=ConjugatedPortDefinition</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildConjugatedPortDefinitionMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildConjugatedPortDefinitionMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Ports.IConjugatedPortDefinition elementAsConjugatedPortDefinition)
                 {
-                    ConjugatedPortDefinitionTextualNotationBuilder.BuildConjugatedPortDefinition(elementAsConjugatedPortDefinition, cursorCache, stringBuilder);
+                    ConjugatedPortDefinitionTextualNotationBuilder.BuildConjugatedPortDefinition(elementAsConjugatedPortDefinition, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -236,18 +236,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedCrossMultiplicityMember:OwningMembership=ownedRelatedElement+=OwnedCrossMultiplicity</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedCrossMultiplicityMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedCrossMultiplicityMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                 {
-                    FeatureTextualNotationBuilder.BuildOwnedCrossMultiplicity(elementAsFeature, cursorCache, stringBuilder);
+                    FeatureTextualNotationBuilder.BuildOwnedCrossMultiplicity(elementAsFeature, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -260,18 +260,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedFeatureChainMember:OwningMembership=ownedRelatedElement+=OwnedFeatureChain</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedFeatureChainMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedFeatureChainMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                 {
-                    FeatureTextualNotationBuilder.BuildOwnedFeatureChain(elementAsFeature, cursorCache, stringBuilder);
+                    FeatureTextualNotationBuilder.BuildOwnedFeatureChain(elementAsFeature, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -284,18 +284,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>TransitionSuccessionMember:OwningMembership=ownedRelatedElement+=TransitionSuccession</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTransitionSuccessionMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTransitionSuccessionMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Connectors.ISuccession elementAsSuccession)
                 {
-                    SuccessionTextualNotationBuilder.BuildTransitionSuccession(elementAsSuccession, cursorCache, stringBuilder);
+                    SuccessionTextualNotationBuilder.BuildTransitionSuccession(elementAsSuccession, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -308,11 +308,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>PrefixMetadataMember:OwningMembership='#'ownedRelatedElement=PrefixMetadataUsage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPrefixMetadataMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPrefixMetadataMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
             stringBuilder.Append("#");
 
             if (ownedRelatedElementCursor.Current != null)
@@ -320,7 +320,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Metadata.IMetadataUsage elementAsMetadataUsage)
                 {
-                    MetadataUsageTextualNotationBuilder.BuildPrefixMetadataUsage(elementAsMetadataUsage, cursorCache, stringBuilder);
+                    MetadataUsageTextualNotationBuilder.BuildPrefixMetadataUsage(elementAsMetadataUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -333,17 +333,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>NamespaceMember:OwningMembership=NonFeatureMember|NamespaceFeatureMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNamespaceMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNamespaceMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership pocoOwningMembershipNonFeatureMember when pocoOwningMembershipNonFeatureMember.IsValidForNonFeatureMember():
-                    BuildNonFeatureMember(pocoOwningMembershipNonFeatureMember, cursorCache, stringBuilder);
+                    BuildNonFeatureMember(pocoOwningMembershipNonFeatureMember, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildNamespaceFeatureMember(poco, cursorCache, stringBuilder);
+                    BuildNamespaceFeatureMember(poco, writerContext, stringBuilder);
                     break;
             }
 
@@ -354,19 +354,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>NonFeatureMember:OwningMembership=MemberPrefixownedRelatedElement+=MemberElement</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNonFeatureMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNonFeatureMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Root.Elements.IElement elementAsElement)
                 {
-                    ElementTextualNotationBuilder.BuildMemberElement(elementAsElement, cursorCache, stringBuilder);
+                    ElementTextualNotationBuilder.BuildMemberElement(elementAsElement, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -379,19 +379,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>NamespaceFeatureMember:OwningMembership=MemberPrefixownedRelatedElement+=FeatureElement</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNamespaceFeatureMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNamespaceFeatureMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                 {
-                    FeatureTextualNotationBuilder.BuildFeatureElement(elementAsFeature, cursorCache, stringBuilder);
+                    FeatureTextualNotationBuilder.BuildFeatureElement(elementAsFeature, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -404,17 +404,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>FeatureMember:OwningMembership=TypeFeatureMember|OwnedFeatureMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFeatureMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFeatureMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Core.Types.IFeatureMembership pocoFeatureMembership:
-                    FeatureMembershipTextualNotationBuilder.BuildOwnedFeatureMember(pocoFeatureMembership, cursorCache, stringBuilder);
+                    FeatureMembershipTextualNotationBuilder.BuildOwnedFeatureMember(pocoFeatureMembership, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildTypeFeatureMember(poco, cursorCache, stringBuilder);
+                    BuildTypeFeatureMember(poco, writerContext, stringBuilder);
                     break;
             }
 
@@ -425,12 +425,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>TypeFeatureMember:OwningMembership=MemberPrefix'member'ownedRelatedElement+=FeatureElement</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTypeFeatureMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTypeFeatureMember(SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("member ");
 
             if (ownedRelatedElementCursor.Current != null)
@@ -438,7 +438,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                 {
-                    FeatureTextualNotationBuilder.BuildFeatureElement(elementAsFeature, cursorCache, stringBuilder);
+                    FeatureTextualNotationBuilder.BuildFeatureElement(elementAsFeature, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/OwningMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/OwningMembershipTextualNotationBuilder.cs
@@ -339,7 +339,7 @@ namespace SysML2.NET.TextualNotation
         {
             switch (poco)
             {
-                case SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership pocoOwningMembershipNonFeatureMember when pocoOwningMembershipNonFeatureMember.IsValidForNonFeatureMember():
+                case SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership pocoOwningMembershipNonFeatureMember when pocoOwningMembershipNonFeatureMember.IsValidForNonFeatureMember(writerContext):
                     BuildNonFeatureMember(pocoOwningMembershipNonFeatureMember, writerContext, stringBuilder);
                     break;
                 default:

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/PackageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/PackageTextualNotationBuilder.cs
@@ -39,12 +39,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>PackageDeclaration:Package='package'Identification</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Packages.IPackage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPackageDeclaration(SysML2.NET.Core.POCO.Kernel.Packages.IPackage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPackageDeclaration(SysML2.NET.Core.POCO.Kernel.Packages.IPackage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             stringBuilder.Append("package ");
-            ElementTextualNotationBuilder.BuildIdentification(poco, cursorCache, stringBuilder);
+            ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
 
         }
 
@@ -53,11 +53,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>PackageBody:Package=';'|'{'PackageBodyElement*'}'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Packages.IPackage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPackageBody(SysML2.NET.Core.POCO.Kernel.Packages.IPackage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPackageBody(SysML2.NET.Core.POCO.Kernel.Packages.IPackage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            if (cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
+            if (writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
             {
                 stringBuilder.AppendLine(";");
             }
@@ -65,10 +65,10 @@ namespace SysML2.NET.TextualNotation
             {
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
-                var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 while (ownedRelationshipCursor.Current != null)
                 {
-                    BuildPackageBodyElement(poco, cursorCache, stringBuilder);
+                    BuildPackageBodyElement(poco, writerContext, stringBuilder);
                 }
                 stringBuilder.AppendLine("}");
             }
@@ -80,27 +80,27 @@ namespace SysML2.NET.TextualNotation
         /// <para>PackageBodyElement:Package=ownedRelationship+=PackageMember|ownedRelationship+=ElementFilterMember|ownedRelationship+=AliasMember|ownedRelationship+=Import</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Packages.IPackage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPackageBodyElement(SysML2.NET.Core.POCO.Kernel.Packages.IPackage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPackageBodyElement(SysML2.NET.Core.POCO.Kernel.Packages.IPackage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             switch (ownedRelationshipCursor.Current)
             {
                 case SysML2.NET.Core.POCO.Kernel.Packages.IElementFilterMembership elementFilterMembership:
-                    ElementFilterMembershipTextualNotationBuilder.BuildElementFilterMember(elementFilterMembership, cursorCache, stringBuilder);
+                    ElementFilterMembershipTextualNotationBuilder.BuildElementFilterMember(elementFilterMembership, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                     break;
                 case SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership owningMembership:
-                    OwningMembershipTextualNotationBuilder.BuildPackageMember(owningMembership, cursorCache, stringBuilder);
+                    OwningMembershipTextualNotationBuilder.BuildPackageMember(owningMembership, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                     break;
                 case SysML2.NET.Core.POCO.Root.Namespaces.IMembership membership:
-                    MembershipTextualNotationBuilder.BuildAliasMember(membership, cursorCache, stringBuilder);
+                    MembershipTextualNotationBuilder.BuildAliasMember(membership, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                     break;
                 case SysML2.NET.Core.POCO.Root.Namespaces.IImport import:
-                    ImportTextualNotationBuilder.BuildImport(import, cursorCache, stringBuilder);
+                    ImportTextualNotationBuilder.BuildImport(import, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                     break;
                 default:
@@ -115,15 +115,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>FilterPackage:Package=ownedRelationship+=FilterPackageImport(ownedRelationship+=FilterPackageMember)+</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Packages.IPackage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFilterPackage(SysML2.NET.Core.POCO.Kernel.Packages.IPackage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFilterPackage(SysML2.NET.Core.POCO.Kernel.Packages.IPackage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
-                BuildFilterPackageImport(poco, cursorCache, stringBuilder);
+                BuildFilterPackageImport(poco, writerContext, stringBuilder);
             }
             ownedRelationshipCursor.Move();
 
@@ -136,7 +136,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Packages.IElementFilterMembership elementAsElementFilterMembership)
                     {
-                        ElementFilterMembershipTextualNotationBuilder.BuildFilterPackageMember(elementAsElementFilterMembership, cursorCache, stringBuilder);
+                        ElementFilterMembershipTextualNotationBuilder.BuildFilterPackageMember(elementAsElementFilterMembership, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -150,11 +150,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>Package=(ownedRelationship+=PrefixMetadataMember)*PackageDeclarationPackageBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Packages.IPackage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPackage(SysML2.NET.Core.POCO.Kernel.Packages.IPackage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPackage(SysML2.NET.Core.POCO.Kernel.Packages.IPackage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership owningMembershipGuard && owningMembershipGuard.OwnedRelatedElement.OfType<SysML2.NET.Core.POCO.Systems.Metadata.IMetadataUsage>().Any())
             {
@@ -164,14 +164,14 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                     {
-                        OwningMembershipTextualNotationBuilder.BuildPrefixMetadataMember(elementAsOwningMembership, cursorCache, stringBuilder);
+                        OwningMembershipTextualNotationBuilder.BuildPrefixMetadataMember(elementAsOwningMembership, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
 
             }
-            BuildPackageDeclaration(poco, cursorCache, stringBuilder);
-            BuildPackageBody(poco, cursorCache, stringBuilder);
+            BuildPackageDeclaration(poco, writerContext, stringBuilder);
+            BuildPackageBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ParameterMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ParameterMembershipTextualNotationBuilder.cs
@@ -39,18 +39,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>MessageEventMember:ParameterMembership=ownedRelatedElement+=MessageEvent</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMessageEventMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMessageEventMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Occurrences.IEventOccurrenceUsage elementAsEventOccurrenceUsage)
                 {
-                    EventOccurrenceUsageTextualNotationBuilder.BuildMessageEvent(elementAsEventOccurrenceUsage, cursorCache, stringBuilder);
+                    EventOccurrenceUsageTextualNotationBuilder.BuildMessageEvent(elementAsEventOccurrenceUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -63,18 +63,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>PayloadParameterMember:ParameterMembership=ownedRelatedElement+=PayloadParameter</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPayloadParameterMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPayloadParameterMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
-                    ReferenceUsageTextualNotationBuilder.BuildPayloadParameter(elementAsReferenceUsage, cursorCache, stringBuilder);
+                    ReferenceUsageTextualNotationBuilder.BuildPayloadParameter(elementAsReferenceUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -87,14 +87,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>ArgumentMember:ParameterMembership=ownedMemberParameter=Argument</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildArgumentMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildArgumentMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.ownedMemberParameter != null)
             {
-                FeatureTextualNotationBuilder.BuildArgument(poco.ownedMemberParameter, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildArgument(poco.ownedMemberParameter, writerContext, stringBuilder);
             }
 
         }
@@ -104,18 +104,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>ArgumentExpressionMember:ParameterMembership=ownedRelatedElement+=ArgumentExpression</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildArgumentExpressionMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildArgumentExpressionMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                 {
-                    FeatureTextualNotationBuilder.BuildArgumentExpression(elementAsFeature, cursorCache, stringBuilder);
+                    FeatureTextualNotationBuilder.BuildArgumentExpression(elementAsFeature, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -128,18 +128,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>NodeParameterMember:ParameterMembership=ownedRelatedElement+=NodeParameter</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNodeParameterMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNodeParameterMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
-                    ReferenceUsageTextualNotationBuilder.BuildNodeParameter(elementAsReferenceUsage, cursorCache, stringBuilder);
+                    ReferenceUsageTextualNotationBuilder.BuildNodeParameter(elementAsReferenceUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -152,18 +152,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>EmptyParameterMember:ParameterMembership=ownedRelatedElement+=EmptyUsage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildEmptyParameterMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildEmptyParameterMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
-                    ReferenceUsageTextualNotationBuilder.BuildEmptyUsage(elementAsReferenceUsage, cursorCache, stringBuilder);
+                    ReferenceUsageTextualNotationBuilder.BuildEmptyUsage(elementAsReferenceUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -176,18 +176,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>AssignmentTargetMember:ParameterMembership=ownedRelatedElement+=AssignmentTargetParameter</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildAssignmentTargetMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildAssignmentTargetMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
-                    ReferenceUsageTextualNotationBuilder.BuildAssignmentTargetParameter(elementAsReferenceUsage, cursorCache, stringBuilder);
+                    ReferenceUsageTextualNotationBuilder.BuildAssignmentTargetParameter(elementAsReferenceUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -200,18 +200,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>ExpressionParameterMember:ParameterMembership=ownedRelatedElement+=OwnedExpression</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildExpressionParameterMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildExpressionParameterMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IExpression elementAsExpression)
                 {
-                    ExpressionTextualNotationBuilder.BuildOwnedExpression(elementAsExpression, cursorCache, stringBuilder);
+                    ExpressionTextualNotationBuilder.BuildOwnedExpression(elementAsExpression, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -224,18 +224,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>ActionBodyParameterMember:ParameterMembership=ownedRelatedElement+=ActionBodyParameter</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildActionBodyParameterMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildActionBodyParameterMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Actions.IActionUsage elementAsActionUsage)
                 {
-                    ActionUsageTextualNotationBuilder.BuildActionBodyParameter(elementAsActionUsage, cursorCache, stringBuilder);
+                    ActionUsageTextualNotationBuilder.BuildActionBodyParameter(elementAsActionUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -248,18 +248,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>IfNodeParameterMember:ParameterMembership=ownedRelatedElement+=IfNode</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildIfNodeParameterMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildIfNodeParameterMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Actions.IIfActionUsage elementAsIfActionUsage)
                 {
-                    IfActionUsageTextualNotationBuilder.BuildIfNode(elementAsIfActionUsage, cursorCache, stringBuilder);
+                    IfActionUsageTextualNotationBuilder.BuildIfNode(elementAsIfActionUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -272,18 +272,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>MetadataArgumentMember:ParameterMembership=ownedRelatedElement+=MetadataArgument</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMetadataArgumentMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMetadataArgumentMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                 {
-                    FeatureTextualNotationBuilder.BuildMetadataArgument(elementAsFeature, cursorCache, stringBuilder);
+                    FeatureTextualNotationBuilder.BuildMetadataArgument(elementAsFeature, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -296,14 +296,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>TypeReferenceMember:ParameterMembership=ownedMemberFeature=TypeReference</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTypeReferenceMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTypeReferenceMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.ownedMemberFeature != null)
             {
-                FeatureTextualNotationBuilder.BuildTypeReference(poco.ownedMemberFeature, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildTypeReference(poco.ownedMemberFeature, writerContext, stringBuilder);
             }
 
         }
@@ -313,14 +313,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>PrimaryArgumentMember:ParameterMembership=ownedMemberParameter=PrimaryArgument</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPrimaryArgumentMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPrimaryArgumentMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.ownedMemberParameter != null)
             {
-                FeatureTextualNotationBuilder.BuildPrimaryArgument(poco.ownedMemberParameter, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildPrimaryArgument(poco.ownedMemberParameter, writerContext, stringBuilder);
             }
 
         }
@@ -330,14 +330,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>NonFeatureChainPrimaryArgumentMember:ParameterMembership=ownedMemberParameter=PrimaryArgument</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNonFeatureChainPrimaryArgumentMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNonFeatureChainPrimaryArgumentMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.ownedMemberParameter != null)
             {
-                FeatureTextualNotationBuilder.BuildPrimaryArgument(poco.ownedMemberParameter, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildPrimaryArgument(poco.ownedMemberParameter, writerContext, stringBuilder);
             }
 
         }
@@ -347,14 +347,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>BodyArgumentMember:ParameterMembership=ownedMemberParameter=BodyArgument</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildBodyArgumentMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildBodyArgumentMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.ownedMemberParameter != null)
             {
-                FeatureTextualNotationBuilder.BuildBodyArgument(poco.ownedMemberParameter, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildBodyArgument(poco.ownedMemberParameter, writerContext, stringBuilder);
             }
 
         }
@@ -364,14 +364,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>FunctionReferenceArgumentMember:ParameterMembership=ownedMemberParameter=FunctionReferenceArgument</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFunctionReferenceArgumentMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFunctionReferenceArgumentMember(SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.ownedMemberParameter != null)
             {
-                FeatureTextualNotationBuilder.BuildFunctionReferenceArgument(poco.ownedMemberParameter, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildFunctionReferenceArgument(poco.ownedMemberParameter, writerContext, stringBuilder);
             }
 
         }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/PartDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/PartDefinitionTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>PartDefinition=OccurrenceDefinitionPrefix'part''def'Definition</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Parts.IPartDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPartDefinition(SysML2.NET.Core.POCO.Systems.Parts.IPartDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPartDefinition(SysML2.NET.Core.POCO.Systems.Parts.IPartDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, cursorCache, stringBuilder);
+            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("part ");
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinition(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinition(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/PartUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/PartUsageTextualNotationBuilder.cs
@@ -39,18 +39,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>ActorUsage:PartUsage='actor'UsageExtensionKeyword*Usage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Parts.IPartUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildActorUsage(SysML2.NET.Core.POCO.Systems.Parts.IPartUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildActorUsage(SysML2.NET.Core.POCO.Systems.Parts.IPartUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             stringBuilder.Append("actor ");
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership)
             {
-                UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, writerContext, stringBuilder);
             }
 
-            UsageTextualNotationBuilder.BuildUsage(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsage(poco, writerContext, stringBuilder);
 
         }
 
@@ -59,18 +59,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>StakeholderUsage:PartUsage='stakeholder'UsageExtensionKeyword*Usage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Parts.IPartUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildStakeholderUsage(SysML2.NET.Core.POCO.Systems.Parts.IPartUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildStakeholderUsage(SysML2.NET.Core.POCO.Systems.Parts.IPartUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             stringBuilder.Append("stakeholder ");
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership)
             {
-                UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, writerContext, stringBuilder);
             }
 
-            UsageTextualNotationBuilder.BuildUsage(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsage(poco, writerContext, stringBuilder);
 
         }
 
@@ -79,13 +79,13 @@ namespace SysML2.NET.TextualNotation
         /// <para>PartUsage=OccurrenceUsagePrefix'part'Usage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Parts.IPartUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPartUsage(SysML2.NET.Core.POCO.Systems.Parts.IPartUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPartUsage(SysML2.NET.Core.POCO.Systems.Parts.IPartUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("part ");
-            UsageTextualNotationBuilder.BuildUsage(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsage(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/PayloadFeatureTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/PayloadFeatureTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>FlowPayloadFeature:PayloadFeature=PayloadFeature</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Interactions.IPayloadFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFlowPayloadFeature(SysML2.NET.Core.POCO.Kernel.Interactions.IPayloadFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFlowPayloadFeature(SysML2.NET.Core.POCO.Kernel.Interactions.IPayloadFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            FeatureTextualNotationBuilder.BuildPayloadFeature(poco, cursorCache, stringBuilder);
+            FeatureTextualNotationBuilder.BuildPayloadFeature(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/PerformActionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/PerformActionUsageTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>PerformActionUsageDeclaration:PerformActionUsage=(ownedRelationship+=OwnedReferenceSubsettingFeatureSpecializationPart?|'action'UsageDeclaration)ValuePart?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IPerformActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPerformActionUsageDeclaration(SysML2.NET.Core.POCO.Systems.Actions.IPerformActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPerformActionUsageDeclaration(SysML2.NET.Core.POCO.Systems.Actions.IPerformActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             if (poco.OwnedRelationship.OfType<SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting>().Any())
             {
 
@@ -52,7 +52,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting elementAsReferenceSubsetting)
                     {
-                        ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, cursorCache, stringBuilder);
+                        ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -60,20 +60,20 @@ namespace SysML2.NET.TextualNotation
 
                 if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
                 {
-                    FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, cursorCache, stringBuilder);
+                    FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, writerContext, stringBuilder);
                 }
             }
             else
             {
                 stringBuilder.Append("action ");
-                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
             }
 
             stringBuilder.Append(' ');
 
             if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
-                FeatureTextualNotationBuilder.BuildValuePart(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }
 
         }
@@ -83,12 +83,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>StatePerformActionUsage:PerformActionUsage=PerformActionUsageDeclarationActionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IPerformActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildStatePerformActionUsage(SysML2.NET.Core.POCO.Systems.Actions.IPerformActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildStatePerformActionUsage(SysML2.NET.Core.POCO.Systems.Actions.IPerformActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildPerformActionUsageDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildActionBody(poco, cursorCache, stringBuilder);
+            BuildPerformActionUsageDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildActionBody(poco, writerContext, stringBuilder);
 
         }
 
@@ -97,20 +97,20 @@ namespace SysML2.NET.TextualNotation
         /// <para>TransitionPerformActionUsage:PerformActionUsage=PerformActionUsageDeclaration('{'ActionBodyItem*'}')?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IPerformActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTransitionPerformActionUsage(SysML2.NET.Core.POCO.Systems.Actions.IPerformActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTransitionPerformActionUsage(SysML2.NET.Core.POCO.Systems.Actions.IPerformActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildPerformActionUsageDeclaration(poco, cursorCache, stringBuilder);
+            BuildPerformActionUsageDeclaration(poco, writerContext, stringBuilder);
 
             if (poco.OwnedRelationship.Count != 0 || poco.importedMembership.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsVariation || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.isReference || poco.IsIndividual || poco.PortionKind.HasValue || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
-                var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 while (ownedRelationshipCursor.Current != null)
                 {
-                    TypeTextualNotationBuilder.BuildActionBodyItem(poco, cursorCache, stringBuilder);
+                    TypeTextualNotationBuilder.BuildActionBodyItem(poco, writerContext, stringBuilder);
                 }
 
                 stringBuilder.AppendLine("}");
@@ -124,14 +124,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>PerformActionUsage=OccurrenceUsagePrefix'perform'PerformActionUsageDeclarationActionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IPerformActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPerformActionUsage(SysML2.NET.Core.POCO.Systems.Actions.IPerformActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPerformActionUsage(SysML2.NET.Core.POCO.Systems.Actions.IPerformActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("perform ");
-            BuildPerformActionUsageDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildActionBody(poco, cursorCache, stringBuilder);
+            BuildPerformActionUsageDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildActionBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/PortConjugationTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/PortConjugationTextualNotationBuilder.cs
@@ -39,9 +39,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>PortConjugation={}</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Ports.IPortConjugation" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPortConjugation(SysML2.NET.Core.POCO.Systems.Ports.IPortConjugation poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPortConjugation(SysML2.NET.Core.POCO.Systems.Ports.IPortConjugation poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
         }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/PortDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/PortDefinitionTextualNotationBuilder.cs
@@ -39,22 +39,22 @@ namespace SysML2.NET.TextualNotation
         /// <para>PortDefinition=DefinitionPrefix'port''def'DefinitionownedRelationship+=ConjugatedPortDefinitionMember{conjugatedPortDefinition.ownedPortConjugator.originalPortDefinition=this}</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Ports.IPortDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPortDefinition(SysML2.NET.Core.POCO.Systems.Ports.IPortDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPortDefinition(SysML2.NET.Core.POCO.Systems.Ports.IPortDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-            DefinitionTextualNotationBuilder.BuildDefinitionPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            DefinitionTextualNotationBuilder.BuildDefinitionPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("port ");
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinition(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinition(poco, writerContext, stringBuilder);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                 {
-                    OwningMembershipTextualNotationBuilder.BuildConjugatedPortDefinitionMember(elementAsOwningMembership, cursorCache, stringBuilder);
+                    OwningMembershipTextualNotationBuilder.BuildConjugatedPortDefinitionMember(elementAsOwningMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/PortUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/PortUsageTextualNotationBuilder.cs
@@ -39,15 +39,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>DefaultInterfaceEnd:PortUsage=isEnd?='end'Usage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Ports.IPortUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildDefaultInterfaceEnd(SysML2.NET.Core.POCO.Systems.Ports.IPortUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildDefaultInterfaceEnd(SysML2.NET.Core.POCO.Systems.Ports.IPortUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             if (poco.IsEnd)
             {
                 stringBuilder.Append(" end ");
             }
-            UsageTextualNotationBuilder.BuildUsage(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsage(poco, writerContext, stringBuilder);
 
         }
 
@@ -56,11 +56,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>InterfaceEnd:PortUsage=(ownedRelationship+=OwnedCrossMultiplicityMember)?(declaredName=NAMEREFERENCES)?ownedRelationship+=OwnedReferenceSubsetting</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Ports.IPortUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildInterfaceEnd(SysML2.NET.Core.POCO.Systems.Ports.IPortUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildInterfaceEnd(SysML2.NET.Core.POCO.Systems.Ports.IPortUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
@@ -70,11 +70,11 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                     {
-                        OwningMembershipTextualNotationBuilder.BuildOwnedCrossMultiplicityMember(elementAsOwningMembership, cursorCache, stringBuilder);
+                        OwningMembershipTextualNotationBuilder.BuildOwnedCrossMultiplicityMember(elementAsOwningMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
                 stringBuilder.Append(' ');
             }
 
@@ -92,7 +92,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting elementAsReferenceSubsetting)
                 {
-                    ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, cursorCache, stringBuilder);
+                    ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -105,13 +105,13 @@ namespace SysML2.NET.TextualNotation
         /// <para>PortUsage=OccurrenceUsagePrefix'port'Usage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Ports.IPortUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPortUsage(SysML2.NET.Core.POCO.Systems.Ports.IPortUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPortUsage(SysML2.NET.Core.POCO.Systems.Ports.IPortUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("port ");
-            UsageTextualNotationBuilder.BuildUsage(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsage(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/PortionKindTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/PortionKindTextualNotationBuilder.cs
@@ -39,9 +39,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>PortionKind='snapshot'|'timeslice'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.Systems.Occurrences.PortionKind" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPortionKind(SysML2.NET.Core.Systems.Occurrences.PortionKind poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPortionKind(SysML2.NET.Core.Systems.Occurrences.PortionKind poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
         }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/PredicateTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/PredicateTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>Predicate=TypePrefix'predicate'ClassifierDeclarationFunctionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.IPredicate" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPredicate(SysML2.NET.Core.POCO.Kernel.Functions.IPredicate poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPredicate(SysML2.NET.Core.POCO.Kernel.Functions.IPredicate poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            TypeTextualNotationBuilder.BuildTypePrefix(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("predicate ");
-            ClassifierTextualNotationBuilder.BuildClassifierDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildFunctionBody(poco, cursorCache, stringBuilder);
+            ClassifierTextualNotationBuilder.BuildClassifierDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildFunctionBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/RedefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/RedefinitionTextualNotationBuilder.cs
@@ -39,17 +39,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedRedefinition:Redefinition=redefinedFeature=[QualifiedName]|redefinedFeature=OwnedFeatureChain{ownedRelatedElement+=redefinedFeature}</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IRedefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedRedefinition(SysML2.NET.Core.POCO.Core.Features.IRedefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedRedefinition(SysML2.NET.Core.POCO.Core.Features.IRedefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             if (poco.OwnedRelatedElement.Contains(poco.RedefinedFeature) && poco.RedefinedFeature is SysML2.NET.Core.POCO.Core.Features.IFeature chainedRedefinedFeatureAsFeature)
             {
-                FeatureTextualNotationBuilder.BuildOwnedFeatureChain(chainedRedefinedFeatureAsFeature, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildOwnedFeatureChain(chainedRedefinedFeatureAsFeature, writerContext, stringBuilder);
             }
             else if (poco.RedefinedFeature != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.RedefinedFeature);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.RedefinedFeature, writerContext);
                 stringBuilder.Append(' ');
             }
 
@@ -60,14 +60,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>FlowFeatureRedefinition:Redefinition=redefinedFeature=[QualifiedName]</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IRedefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFlowFeatureRedefinition(SysML2.NET.Core.POCO.Core.Features.IRedefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFlowFeatureRedefinition(SysML2.NET.Core.POCO.Core.Features.IRedefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.RedefinedFeature != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.RedefinedFeature);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.RedefinedFeature, writerContext);
                 stringBuilder.Append(' ');
             }
 
@@ -78,14 +78,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>ParameterRedefinition:Redefinition=redefinedFeature=[QualifiedName]</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IRedefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildParameterRedefinition(SysML2.NET.Core.POCO.Core.Features.IRedefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildParameterRedefinition(SysML2.NET.Core.POCO.Core.Features.IRedefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.RedefinedFeature != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.RedefinedFeature);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.RedefinedFeature, writerContext);
                 stringBuilder.Append(' ');
             }
 
@@ -96,23 +96,23 @@ namespace SysML2.NET.TextualNotation
         /// <para>Redefinition=('specialization'Identification)?'redefinition'SpecificTypeREDEFINESGeneralTypeRelationshipBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IRedefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildRedefinition(SysML2.NET.Core.POCO.Core.Features.IRedefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildRedefinition(SysML2.NET.Core.POCO.Core.Features.IRedefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName))
             {
                 stringBuilder.Append("specialization ");
-                ElementTextualNotationBuilder.BuildIdentification(poco, cursorCache, stringBuilder);
+                ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
                 stringBuilder.Append(' ');
             }
 
             stringBuilder.Append("redefinition ");
-            SpecializationTextualNotationBuilder.BuildSpecificType(poco, cursorCache, stringBuilder);
+            SpecializationTextualNotationBuilder.BuildSpecificType(poco, writerContext, stringBuilder);
             stringBuilder.Append(" :>> ");
-            SpecializationTextualNotationBuilder.BuildGeneralType(poco, cursorCache, stringBuilder);
-            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, cursorCache, stringBuilder);
+            SpecializationTextualNotationBuilder.BuildGeneralType(poco, writerContext, stringBuilder);
+            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/RedefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/RedefinitionTextualNotationBuilder.cs
@@ -49,7 +49,7 @@ namespace SysML2.NET.TextualNotation
             }
             else if (poco.RedefinedFeature != null)
             {
-                stringBuilder.Append(poco.RedefinedFeature.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.RedefinedFeature);
                 stringBuilder.Append(' ');
             }
 
@@ -67,7 +67,7 @@ namespace SysML2.NET.TextualNotation
 
             if (poco.RedefinedFeature != null)
             {
-                stringBuilder.Append(poco.RedefinedFeature.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.RedefinedFeature);
                 stringBuilder.Append(' ');
             }
 
@@ -85,7 +85,7 @@ namespace SysML2.NET.TextualNotation
 
             if (poco.RedefinedFeature != null)
             {
-                stringBuilder.Append(poco.RedefinedFeature.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.RedefinedFeature);
                 stringBuilder.Append(' ');
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ReferenceSubsettingTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ReferenceSubsettingTextualNotationBuilder.cs
@@ -49,7 +49,7 @@ namespace SysML2.NET.TextualNotation
             }
             else if (poco.ReferencedFeature != null)
             {
-                stringBuilder.Append(poco.ReferencedFeature.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.ReferencedFeature);
                 stringBuilder.Append(' ');
             }
 
@@ -70,7 +70,7 @@ namespace SysML2.NET.TextualNotation
             }
             else if (poco.ReferencedFeature != null)
             {
-                stringBuilder.Append(poco.ReferencedFeature.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.ReferencedFeature);
                 stringBuilder.Append(' ');
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ReferenceSubsettingTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ReferenceSubsettingTextualNotationBuilder.cs
@@ -39,17 +39,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedReferenceSubsetting:ReferenceSubsetting=referencedFeature=[QualifiedName]|referencedFeature=OwnedFeatureChain{ownedRelatedElement+=referenceFeature}</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedReferenceSubsetting(SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedReferenceSubsetting(SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             if (poco.OwnedRelatedElement.Contains(poco.ReferencedFeature) && poco.ReferencedFeature is SysML2.NET.Core.POCO.Core.Features.IFeature chainedReferencedFeatureAsFeature)
             {
-                FeatureTextualNotationBuilder.BuildOwnedFeatureChain(chainedReferencedFeatureAsFeature, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildOwnedFeatureChain(chainedReferencedFeatureAsFeature, writerContext, stringBuilder);
             }
             else if (poco.ReferencedFeature != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.ReferencedFeature);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.ReferencedFeature, writerContext);
                 stringBuilder.Append(' ');
             }
 
@@ -60,17 +60,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>FlowEndSubsetting:ReferenceSubsetting=referencedFeature=[QualifiedName]|referencedFeature=FeatureChainPrefix{ownedRelatedElement+=referencedFeature}</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFlowEndSubsetting(SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFlowEndSubsetting(SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             if (poco.OwnedRelatedElement.Contains(poco.ReferencedFeature) && poco.ReferencedFeature is SysML2.NET.Core.POCO.Core.Features.IFeature chainedReferencedFeatureAsFeature)
             {
-                FeatureTextualNotationBuilder.BuildFeatureChainPrefix(chainedReferencedFeatureAsFeature, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildFeatureChainPrefix(chainedReferencedFeatureAsFeature, writerContext, stringBuilder);
             }
             else if (poco.ReferencedFeature != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.ReferencedFeature);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.ReferencedFeature, writerContext);
                 stringBuilder.Append(' ');
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ReferenceUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ReferenceUsageTextualNotationBuilder.cs
@@ -39,12 +39,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedCrossFeature:ReferenceUsage=BasicUsagePrefixUsageDeclaration</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedCrossFeature(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedCrossFeature(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            UsageTextualNotationBuilder.BuildBasicUsagePrefix(poco, cursorCache, stringBuilder);
-            UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildBasicUsagePrefix(poco, writerContext, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
 
         }
 
@@ -53,12 +53,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>DefaultReferenceUsage:ReferenceUsage=RefPrefixUsage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildDefaultReferenceUsage(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildDefaultReferenceUsage(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            UsageTextualNotationBuilder.BuildRefPrefix(poco, cursorCache, stringBuilder);
-            UsageTextualNotationBuilder.BuildUsage(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildRefPrefix(poco, writerContext, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsage(poco, writerContext, stringBuilder);
 
         }
 
@@ -67,28 +67,28 @@ namespace SysML2.NET.TextualNotation
         /// <para>VariantReference:ReferenceUsage=ownedRelationship+=OwnedReferenceSubsettingFeatureSpecialization*UsageBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildVariantReference(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildVariantReference(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting elementAsReferenceSubsetting)
                 {
-                    ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, cursorCache, stringBuilder);
+                    ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
 
             while (ownedRelationshipCursor.Current is not null and not SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage)
             {
-                FeatureTextualNotationBuilder.BuildFeatureSpecialization(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildFeatureSpecialization(poco, writerContext, stringBuilder);
             }
 
-            UsageTextualNotationBuilder.BuildUsageBody(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsageBody(poco, writerContext, stringBuilder);
 
         }
 
@@ -97,11 +97,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>SourceEnd:ReferenceUsage=(ownedRelationship+=OwnedMultiplicity)?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSourceEnd(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSourceEnd(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
@@ -111,11 +111,11 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                     {
-                        OwningMembershipTextualNotationBuilder.BuildOwnedMultiplicity(elementAsOwningMembership, cursorCache, stringBuilder);
+                        OwningMembershipTextualNotationBuilder.BuildOwnedMultiplicity(elementAsOwningMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
             }
 
 
@@ -126,11 +126,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>ConnectorEnd:ReferenceUsage=(ownedRelationship+=OwnedCrossMultiplicityMember)?(declaredName=NAMEREFERENCES)?ownedRelationship+=OwnedReferenceSubsetting</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildConnectorEnd(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildConnectorEnd(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
@@ -140,11 +140,11 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                     {
-                        OwningMembershipTextualNotationBuilder.BuildOwnedCrossMultiplicityMember(elementAsOwningMembership, cursorCache, stringBuilder);
+                        OwningMembershipTextualNotationBuilder.BuildOwnedCrossMultiplicityMember(elementAsOwningMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
                 stringBuilder.Append(' ');
             }
 
@@ -162,7 +162,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting elementAsReferenceSubsetting)
                 {
-                    ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, cursorCache, stringBuilder);
+                    ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -175,18 +175,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>FlowFeature:ReferenceUsage=ownedRelationship+=FlowFeatureRedefinition</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFlowFeature(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFlowFeature(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition elementAsRedefinition)
                 {
-                    RedefinitionTextualNotationBuilder.BuildFlowFeatureRedefinition(elementAsRedefinition, cursorCache, stringBuilder);
+                    RedefinitionTextualNotationBuilder.BuildFlowFeatureRedefinition(elementAsRedefinition, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -199,11 +199,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>PayloadParameter:ReferenceUsage=PayloadFeature|IdentificationPayloadFeatureSpecializationPart?TriggerValuePart</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildPayloadParameter(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildPayloadParameter(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildPayloadParameterHandCoded(poco, cursorCache, stringBuilder);
+            BuildPayloadParameterHandCoded(poco, writerContext, stringBuilder);
         }
 
         /// <summary>
@@ -211,18 +211,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>NodeParameter:ReferenceUsage=ownedRelationship+=FeatureBinding</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNodeParameter(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNodeParameter(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                 {
-                    FeatureValueTextualNotationBuilder.BuildFeatureBinding(elementAsFeatureValue, cursorCache, stringBuilder);
+                    FeatureValueTextualNotationBuilder.BuildFeatureBinding(elementAsFeatureValue, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -235,9 +235,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>EmptyUsage:ReferenceUsage={}</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildEmptyUsage(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildEmptyUsage(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
         }
@@ -247,11 +247,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>AssignmentTargetParameter:ReferenceUsage=(ownedRelationship+=AssignmentTargetBinding'.')?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildAssignmentTargetParameter(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildAssignmentTargetParameter(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
@@ -261,11 +261,11 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                     {
-                        FeatureValueTextualNotationBuilder.BuildAssignmentTargetBinding(elementAsFeatureValue, cursorCache, stringBuilder);
+                        FeatureValueTextualNotationBuilder.BuildAssignmentTargetBinding(elementAsFeatureValue, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
                 stringBuilder.Append(".");
             }
 
@@ -277,11 +277,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>ForVariableDeclaration:ReferenceUsage=UsageDeclaration</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildForVariableDeclaration(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildForVariableDeclaration(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
 
         }
 
@@ -290,9 +290,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>EmptyFeature:ReferenceUsage={}</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildEmptyFeature(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildEmptyFeature(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
         }
@@ -302,18 +302,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>SubjectUsage:ReferenceUsage='subject'UsageExtensionKeyword*Usage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSubjectUsage(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSubjectUsage(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             stringBuilder.Append("subject ");
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership)
             {
-                UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, writerContext, stringBuilder);
             }
 
-            UsageTextualNotationBuilder.BuildUsage(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsage(poco, writerContext, stringBuilder);
 
         }
 
@@ -322,18 +322,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>SatisfactionParameter:ReferenceUsage=ownedRelationship+=SatisfactionFeatureValue</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSatisfactionParameter(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSatisfactionParameter(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                 {
-                    FeatureValueTextualNotationBuilder.BuildSatisfactionFeatureValue(elementAsFeatureValue, cursorCache, stringBuilder);
+                    FeatureValueTextualNotationBuilder.BuildSatisfactionFeatureValue(elementAsFeatureValue, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -346,11 +346,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>MetadataBodyUsage:ReferenceUsage='ref'?(':&gt;&gt;'|'redefines')?ownedRelationship+=OwnedRedefinitionFeatureSpecializationPart?ValuePart?MetadataBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMetadataBodyUsage(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMetadataBodyUsage(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append("ref ");
             stringBuilder.Append(" :>> ");
 
@@ -359,7 +359,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition elementAsRedefinition)
                 {
-                    RedefinitionTextualNotationBuilder.BuildOwnedRedefinition(elementAsRedefinition, cursorCache, stringBuilder);
+                    RedefinitionTextualNotationBuilder.BuildOwnedRedefinition(elementAsRedefinition, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -367,14 +367,14 @@ namespace SysML2.NET.TextualNotation
 
             if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
             {
-                FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, writerContext, stringBuilder);
             }
 
             if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
-                FeatureTextualNotationBuilder.BuildValuePart(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }
-            TypeTextualNotationBuilder.BuildMetadataBody(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildMetadataBody(poco, writerContext, stringBuilder);
 
         }
 
@@ -383,23 +383,23 @@ namespace SysML2.NET.TextualNotation
         /// <para>ReferenceUsage=(EndUsagePrefix|RefPrefix)'ref'Usage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildReferenceUsage(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildReferenceUsage(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage pocoUsageRefPrefix when pocoUsageRefPrefix.IsDerived:
-                    UsageTextualNotationBuilder.BuildRefPrefix(pocoUsageRefPrefix, cursorCache, stringBuilder);
+                    UsageTextualNotationBuilder.BuildRefPrefix(pocoUsageRefPrefix, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage pocoUsage:
-                    UsageTextualNotationBuilder.BuildEndUsagePrefix(pocoUsage, cursorCache, stringBuilder);
+                    UsageTextualNotationBuilder.BuildEndUsagePrefix(pocoUsage, writerContext, stringBuilder);
                     break;
             }
 
             stringBuilder.Append(' ');
             stringBuilder.Append("ref ");
-            UsageTextualNotationBuilder.BuildUsage(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsage(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/RelationshipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/RelationshipTextualNotationBuilder.cs
@@ -39,17 +39,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>RelationshipBody:Relationship=';'|'{'(ownedRelationship+=OwnedAnnotation)*'}'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Elements.IRelationship" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildRelationshipBody(SysML2.NET.Core.POCO.Root.Elements.IRelationship poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildRelationshipBody(SysML2.NET.Core.POCO.Root.Elements.IRelationship poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            if (cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
+            if (writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
             {
                 stringBuilder.AppendLine(";");
             }
             else
             {
-                var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
 
@@ -61,7 +61,7 @@ namespace SysML2.NET.TextualNotation
 
                         if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Annotations.IAnnotation elementAsAnnotation)
                         {
-                            AnnotationTextualNotationBuilder.BuildOwnedAnnotation(elementAsAnnotation, cursorCache, stringBuilder);
+                            AnnotationTextualNotationBuilder.BuildOwnedAnnotation(elementAsAnnotation, writerContext, stringBuilder);
                         }
                     }
                     ownedRelationshipCursor.Move();
@@ -77,11 +77,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>RelationshipOwnedElement:Relationship=ownedRelatedElement+=OwnedRelatedElement|ownedRelationship+=OwnedAnnotation</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Elements.IRelationship" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildRelationshipOwnedElement(SysML2.NET.Core.POCO.Root.Elements.IRelationship poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildRelationshipOwnedElement(SysML2.NET.Core.POCO.Root.Elements.IRelationship poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildRelationshipOwnedElementHandCoded(poco, cursorCache, stringBuilder);
+            BuildRelationshipOwnedElementHandCoded(poco, writerContext, stringBuilder);
         }
     }
 }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/RenderingDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/RenderingDefinitionTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>RenderingDefinition=OccurrenceDefinitionPrefix'rendering''def'Definition</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.IRenderingDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildRenderingDefinition(SysML2.NET.Core.POCO.Systems.Views.IRenderingDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildRenderingDefinition(SysML2.NET.Core.POCO.Systems.Views.IRenderingDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, cursorCache, stringBuilder);
+            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("rendering ");
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinition(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinition(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/RenderingUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/RenderingUsageTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>ViewRenderingUsage:RenderingUsage=ownedRelationship+=OwnedReferenceSubsettingFeatureSpecializationPart?UsageBody|(UsageExtensionKeyword*'rendering'|UsageExtensionKeyword+)Usage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.IRenderingUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildViewRenderingUsage(SysML2.NET.Core.POCO.Systems.Views.IRenderingUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildViewRenderingUsage(SysML2.NET.Core.POCO.Systems.Views.IRenderingUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildViewRenderingUsageHandCoded(poco, cursorCache, stringBuilder);
+            BuildViewRenderingUsageHandCoded(poco, writerContext, stringBuilder);
         }
 
         /// <summary>
@@ -51,13 +51,13 @@ namespace SysML2.NET.TextualNotation
         /// <para>RenderingUsage=OccurrenceUsagePrefix'rendering'Usage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.IRenderingUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildRenderingUsage(SysML2.NET.Core.POCO.Systems.Views.IRenderingUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildRenderingUsage(SysML2.NET.Core.POCO.Systems.Views.IRenderingUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("rendering ");
-            UsageTextualNotationBuilder.BuildUsage(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsage(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/RequirementConstraintMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/RequirementConstraintMembershipTextualNotationBuilder.cs
@@ -39,24 +39,24 @@ namespace SysML2.NET.TextualNotation
         /// <para>RequirementConstraintMember:RequirementConstraintMembership=MemberPrefix?RequirementKindownedRelatedElement+=RequirementConstraintUsage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.IRequirementConstraintMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildRequirementConstraintMember(SysML2.NET.Core.POCO.Systems.Requirements.IRequirementConstraintMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildRequirementConstraintMember(SysML2.NET.Core.POCO.Systems.Requirements.IRequirementConstraintMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (poco.Visibility != SysML2.NET.Core.Root.Namespaces.VisibilityKind.Public)
             {
-                MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+                MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
             }
-            BuildRequirementKind(poco, cursorCache, stringBuilder);
+            BuildRequirementKind(poco, writerContext, stringBuilder);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Constraints.IConstraintUsage elementAsConstraintUsage)
                 {
-                    ConstraintUsageTextualNotationBuilder.BuildRequirementConstraintUsage(elementAsConstraintUsage, cursorCache, stringBuilder);
+                    ConstraintUsageTextualNotationBuilder.BuildRequirementConstraintUsage(elementAsConstraintUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -69,9 +69,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>RequirementKind:RequirementConstraintMembership='assume'{kind='assumption'}|'require'{kind='requirement'}</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.IRequirementConstraintMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildRequirementKind(SysML2.NET.Core.POCO.Systems.Requirements.IRequirementConstraintMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildRequirementKind(SysML2.NET.Core.POCO.Systems.Requirements.IRequirementConstraintMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco.Kind)
             {

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/RequirementDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/RequirementDefinitionTextualNotationBuilder.cs
@@ -39,15 +39,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>RequirementDefinition=OccurrenceDefinitionPrefix'requirement''def'DefinitionDeclarationRequirementBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.IRequirementDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildRequirementDefinition(SysML2.NET.Core.POCO.Systems.Requirements.IRequirementDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildRequirementDefinition(SysML2.NET.Core.POCO.Systems.Requirements.IRequirementDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, cursorCache, stringBuilder);
+            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("requirement ");
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildRequirementBody(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildRequirementBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/RequirementUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/RequirementUsageTextualNotationBuilder.cs
@@ -39,18 +39,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>ObjectiveRequirementUsage:RequirementUsage=UsageExtensionKeyword*ConstraintUsageDeclarationRequirementBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.IRequirementUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildObjectiveRequirementUsage(SysML2.NET.Core.POCO.Systems.Requirements.IRequirementUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildObjectiveRequirementUsage(SysML2.NET.Core.POCO.Systems.Requirements.IRequirementUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership)
             {
-                UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, writerContext, stringBuilder);
             }
 
-            ConstraintUsageTextualNotationBuilder.BuildConstraintUsageDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildRequirementBody(poco, cursorCache, stringBuilder);
+            ConstraintUsageTextualNotationBuilder.BuildConstraintUsageDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildRequirementBody(poco, writerContext, stringBuilder);
 
         }
 
@@ -59,11 +59,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>RequirementVerificationUsage:RequirementUsage=ownedRelationship+=OwnedReferenceSubsettingFeatureSpecialization*RequirementBody|(UsageExtensionKeyword*'requirement'|UsageExtensionKeyword+)ConstraintUsageDeclarationRequirementBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.IRequirementUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildRequirementVerificationUsage(SysML2.NET.Core.POCO.Systems.Requirements.IRequirementUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildRequirementVerificationUsage(SysML2.NET.Core.POCO.Systems.Requirements.IRequirementUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildRequirementVerificationUsageHandCoded(poco, cursorCache, stringBuilder);
+            BuildRequirementVerificationUsageHandCoded(poco, writerContext, stringBuilder);
         }
 
         /// <summary>
@@ -71,14 +71,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>RequirementUsage=OccurrenceUsagePrefix'requirement'ConstraintUsageDeclarationRequirementBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.IRequirementUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildRequirementUsage(SysML2.NET.Core.POCO.Systems.Requirements.IRequirementUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildRequirementUsage(SysML2.NET.Core.POCO.Systems.Requirements.IRequirementUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("requirement ");
-            ConstraintUsageTextualNotationBuilder.BuildConstraintUsageDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildRequirementBody(poco, cursorCache, stringBuilder);
+            ConstraintUsageTextualNotationBuilder.BuildConstraintUsageDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildRequirementBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/RequirementVerificationMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/RequirementVerificationMembershipTextualNotationBuilder.cs
@@ -39,12 +39,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>RequirementVerificationMember:RequirementVerificationMembership=MemberPrefix'verify'{kind='requirement'}ownedRelatedElement+=RequirementVerificationUsage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.VerificationCases.IRequirementVerificationMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildRequirementVerificationMember(SysML2.NET.Core.POCO.Systems.VerificationCases.IRequirementVerificationMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildRequirementVerificationMember(SysML2.NET.Core.POCO.Systems.VerificationCases.IRequirementVerificationMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("verify ");
             // NonParsing Assignment Element : kind = 'requirement' => Does not have to be process
 
@@ -53,7 +53,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Requirements.IRequirementUsage elementAsRequirementUsage)
                 {
-                    RequirementUsageTextualNotationBuilder.BuildRequirementVerificationUsage(elementAsRequirementUsage, cursorCache, stringBuilder);
+                    RequirementUsageTextualNotationBuilder.BuildRequirementVerificationUsage(elementAsRequirementUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ResultExpressionMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ResultExpressionMembershipTextualNotationBuilder.cs
@@ -39,15 +39,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>ResultExpressionMember:ResultExpressionMembership=MemberPrefix?ownedRelatedElement+=OwnedExpression</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.IResultExpressionMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildResultExpressionMember(SysML2.NET.Core.POCO.Kernel.Functions.IResultExpressionMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildResultExpressionMember(SysML2.NET.Core.POCO.Kernel.Functions.IResultExpressionMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (poco.Visibility != SysML2.NET.Core.Root.Namespaces.VisibilityKind.Public)
             {
-                MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+                MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
             }
 
             if (ownedRelatedElementCursor.Current != null)
@@ -55,7 +55,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IExpression elementAsExpression)
                 {
-                    ExpressionTextualNotationBuilder.BuildOwnedExpression(elementAsExpression, cursorCache, stringBuilder);
+                    ExpressionTextualNotationBuilder.BuildOwnedExpression(elementAsExpression, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ReturnParameterMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ReturnParameterMembershipTextualNotationBuilder.cs
@@ -39,15 +39,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>ReturnParameterMember:ReturnParameterMembership=MemberPrefix?'return'ownedRelatedElement+=UsageElement</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildReturnParameterMember(SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildReturnParameterMember(SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (poco.Visibility != SysML2.NET.Core.Root.Namespaces.VisibilityKind.Public)
             {
-                MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+                MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
             }
             stringBuilder.Append("return ");
 
@@ -56,7 +56,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage elementAsUsage)
                 {
-                    UsageTextualNotationBuilder.BuildUsageElement(elementAsUsage, cursorCache, stringBuilder);
+                    UsageTextualNotationBuilder.BuildUsageElement(elementAsUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -69,12 +69,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>ReturnFeatureMember:ReturnParameterMembership=MemberPrefix'return'ownedRelatedElement+=FeatureElement</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildReturnFeatureMember(SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildReturnFeatureMember(SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("return ");
 
             if (ownedRelatedElementCursor.Current != null)
@@ -82,7 +82,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                 {
-                    FeatureTextualNotationBuilder.BuildFeatureElement(elementAsFeature, cursorCache, stringBuilder);
+                    FeatureTextualNotationBuilder.BuildFeatureElement(elementAsFeature, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -95,18 +95,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>EmptyResultMember:ReturnParameterMembership=ownedRelatedElement+=EmptyFeature</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildEmptyResultMember(SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildEmptyResultMember(SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
-                    ReferenceUsageTextualNotationBuilder.BuildEmptyFeature(elementAsReferenceUsage, cursorCache, stringBuilder);
+                    ReferenceUsageTextualNotationBuilder.BuildEmptyFeature(elementAsReferenceUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -119,18 +119,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>ConstructorResultMember:ReturnParameterMembership=ownedRelatedElement+=ConstructorResult</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildConstructorResultMember(SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildConstructorResultMember(SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                 {
-                    FeatureTextualNotationBuilder.BuildConstructorResult(elementAsFeature, cursorCache, stringBuilder);
+                    FeatureTextualNotationBuilder.BuildConstructorResult(elementAsFeature, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SatisfyRequirementUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SatisfyRequirementUsageTextualNotationBuilder.cs
@@ -39,12 +39,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>SatisfyRequirementUsage=OccurrenceUsagePrefix'assert'(isNegated?='not')'satisfy'(ownedRelationship+=OwnedReferenceSubsettingFeatureSpecializationPart?|'requirement'UsageDeclaration)ValuePart?('by'ownedRelationship+=SatisfactionSubjectMember)?RequirementBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.ISatisfyRequirementUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSatisfyRequirementUsage(SysML2.NET.Core.POCO.Systems.Requirements.ISatisfyRequirementUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSatisfyRequirementUsage(SysML2.NET.Core.POCO.Systems.Requirements.ISatisfyRequirementUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("assert ");
             if (poco.IsNegated)
             {
@@ -61,7 +61,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting elementAsReferenceSubsetting)
                     {
-                        ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, cursorCache, stringBuilder);
+                        ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -69,20 +69,20 @@ namespace SysML2.NET.TextualNotation
 
                 if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
                 {
-                    FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, cursorCache, stringBuilder);
+                    FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, writerContext, stringBuilder);
                 }
             }
             else
             {
                 stringBuilder.Append("requirement ");
-                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
             }
 
             stringBuilder.Append(' ');
 
             if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
-                FeatureTextualNotationBuilder.BuildValuePart(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }
 
             if (ownedRelationshipCursor.Current != null)
@@ -94,15 +94,15 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.Requirements.ISubjectMembership elementAsSubjectMembership)
                     {
-                        SubjectMembershipTextualNotationBuilder.BuildSatisfactionSubjectMember(elementAsSubjectMembership, cursorCache, stringBuilder);
+                        SubjectMembershipTextualNotationBuilder.BuildSatisfactionSubjectMember(elementAsSubjectMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
                 stringBuilder.Append(' ');
             }
 
-            TypeTextualNotationBuilder.BuildRequirementBody(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildRequirementBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SelectExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SelectExpressionTextualNotationBuilder.cs
@@ -39,18 +39,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>SelectExpression=ownedRelationship+=PrimaryArgumentMember'.?'ownedRelationship+=BodyArgumentMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Expressions.ISelectExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSelectExpression(SysML2.NET.Core.POCO.Kernel.Expressions.ISelectExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSelectExpression(SysML2.NET.Core.POCO.Kernel.Expressions.ISelectExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildPrimaryArgumentMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildPrimaryArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -62,7 +62,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildBodyArgumentMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildBodyArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SendActionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SendActionUsageTextualNotationBuilder.cs
@@ -39,20 +39,20 @@ namespace SysML2.NET.TextualNotation
         /// <para>SendNode:SendActionUsage=OccurrenceUsagePrefixActionUsageDeclaration?'send'(ownedRelationship+=NodeParameterMemberSenderReceiverPart?|ownedRelationship+=EmptyParameterMemberSenderReceiverPart)?ActionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.ISendActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSendNode(SysML2.NET.Core.POCO.Systems.Actions.ISendActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSendNode(SysML2.NET.Core.POCO.Systems.Actions.ISendActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsVariation || poco.IsConstant || poco.IsEnd || poco.isReference || poco.IsIndividual || poco.PortionKind.HasValue || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
-                ActionUsageTextualNotationBuilder.BuildActionUsageDeclaration(poco, cursorCache, stringBuilder);
+                ActionUsageTextualNotationBuilder.BuildActionUsageDeclaration(poco, writerContext, stringBuilder);
             }
             stringBuilder.Append("send ");
-            BuildSendNodeHandCoded(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildActionBody(poco, cursorCache, stringBuilder);
+            BuildSendNodeHandCoded(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildActionBody(poco, writerContext, stringBuilder);
 
         }
 
@@ -61,15 +61,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>SendNodeDeclaration:SendActionUsage=ActionNodeUsageDeclaration?'send'ownedRelationship+=NodeParameterMemberSenderReceiverPart?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.ISendActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSendNodeDeclaration(SysML2.NET.Core.POCO.Systems.Actions.ISendActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSendNodeDeclaration(SysML2.NET.Core.POCO.Systems.Actions.ISendActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
             {
-                ActionUsageTextualNotationBuilder.BuildActionNodeUsageDeclaration(poco, cursorCache, stringBuilder);
+                ActionUsageTextualNotationBuilder.BuildActionNodeUsageDeclaration(poco, writerContext, stringBuilder);
             }
             stringBuilder.Append("send ");
 
@@ -78,7 +78,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildNodeParameterMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildNodeParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -86,7 +86,7 @@ namespace SysML2.NET.TextualNotation
 
             if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsVariation || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.isReference || poco.IsIndividual || poco.PortionKind.HasValue || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
-                BuildSenderReceiverPart(poco, cursorCache, stringBuilder);
+                BuildSenderReceiverPart(poco, writerContext, stringBuilder);
             }
 
         }
@@ -96,11 +96,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>SenderReceiverPart:SendActionUsage='via'ownedRelationship+=NodeParameterMember('to'ownedRelationship+=NodeParameterMember)?|ownedRelationship+=EmptyParameterMember'to'ownedRelationship+=NodeParameterMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.ISendActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSenderReceiverPart(SysML2.NET.Core.POCO.Systems.Actions.ISendActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSenderReceiverPart(SysML2.NET.Core.POCO.Systems.Actions.ISendActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildSenderReceiverPartHandCoded(poco, cursorCache, stringBuilder);
+            BuildSenderReceiverPartHandCoded(poco, writerContext, stringBuilder);
         }
 
         /// <summary>
@@ -108,12 +108,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>StateSendActionUsage:SendActionUsage=SendNodeDeclarationActionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.ISendActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildStateSendActionUsage(SysML2.NET.Core.POCO.Systems.Actions.ISendActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildStateSendActionUsage(SysML2.NET.Core.POCO.Systems.Actions.ISendActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildSendNodeDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildActionBody(poco, cursorCache, stringBuilder);
+            BuildSendNodeDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildActionBody(poco, writerContext, stringBuilder);
 
         }
 
@@ -122,20 +122,20 @@ namespace SysML2.NET.TextualNotation
         /// <para>TransitionSendActionUsage:SendActionUsage=SendNodeDeclaration('{'ActionBodyItem*'}')?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.ISendActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTransitionSendActionUsage(SysML2.NET.Core.POCO.Systems.Actions.ISendActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTransitionSendActionUsage(SysML2.NET.Core.POCO.Systems.Actions.ISendActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildSendNodeDeclaration(poco, cursorCache, stringBuilder);
+            BuildSendNodeDeclaration(poco, writerContext, stringBuilder);
 
             if (poco.OwnedRelationship.Count != 0 || poco.importedMembership.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsVariation || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.isReference || poco.IsIndividual || poco.PortionKind.HasValue || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
-                var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 while (ownedRelationshipCursor.Current != null)
                 {
-                    TypeTextualNotationBuilder.BuildActionBodyItem(poco, cursorCache, stringBuilder);
+                    TypeTextualNotationBuilder.BuildActionBodyItem(poco, writerContext, stringBuilder);
                 }
 
                 stringBuilder.AppendLine("}");

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SharedTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SharedTextualNotationBuilder.cs
@@ -42,9 +42,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>BasicDefinitionPrefix=isAbstract?='abstract'|isVariation?='variation'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildBasicDefinitionPrefix(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildBasicDefinitionPrefix(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             if (poco.IsAbstract)
             {
@@ -62,16 +62,16 @@ namespace SysML2.NET.TextualNotation
         /// <para>DependencyDeclaration=(Identification'from')?client+=[QualifiedName](','client+=[QualifiedName])*'to'supplier+=[QualifiedName](','supplier+=[QualifiedName])*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Dependencies.IDependency" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildDependencyDeclaration(SysML2.NET.Core.POCO.Root.Dependencies.IDependency poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildDependencyDeclaration(SysML2.NET.Core.POCO.Root.Dependencies.IDependency poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var clientCursor = cursorCache.GetOrCreateCursor(poco.Id, "client", poco.Client);
-            var supplierCursor = cursorCache.GetOrCreateCursor(poco.Id, "supplier", poco.Supplier);
+            var clientCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "client", poco.Client);
+            var supplierCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "supplier", poco.Supplier);
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName))
             {
-                ElementTextualNotationBuilder.BuildIdentification(poco, cursorCache, stringBuilder);
+                ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
                 stringBuilder.Append("from ");
                 stringBuilder.Append(' ');
             }
@@ -79,7 +79,7 @@ namespace SysML2.NET.TextualNotation
 
             if (clientCursor.Current != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, clientCursor.Current);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, clientCursor.Current, writerContext);
                 clientCursor.Move();
             }
 
@@ -89,7 +89,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (clientCursor.Current != null)
                 {
-                    SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, clientCursor.Current);
+                    SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, clientCursor.Current, writerContext);
                     clientCursor.Move();
                 }
                 clientCursor.Move();
@@ -99,7 +99,7 @@ namespace SysML2.NET.TextualNotation
 
             if (supplierCursor.Current != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, supplierCursor.Current);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, supplierCursor.Current, writerContext);
                 supplierCursor.Move();
             }
 
@@ -109,7 +109,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (supplierCursor.Current != null)
                 {
-                    SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, supplierCursor.Current);
+                    SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, supplierCursor.Current, writerContext);
                     supplierCursor.Move();
                 }
                 supplierCursor.Move();
@@ -123,12 +123,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>FeaturePrefix=(EndFeaturePrefix(ownedRelationship+=OwnedCrossFeatureMember)?|BasicFeaturePrefix)(ownedRelationship+=PrefixMetadataMember)*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFeaturePrefix(SysML2.NET.Core.POCO.Core.Features.IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFeaturePrefix(SysML2.NET.Core.POCO.Core.Features.IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-            BuildFeaturePrefixHandCoded(poco, cursorCache, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            BuildFeaturePrefixHandCoded(poco, writerContext, stringBuilder);
             stringBuilder.Append(' ');
 
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership owningMembershipGuard && owningMembershipGuard.OwnedRelatedElement.OfType<SysML2.NET.Core.POCO.Systems.Metadata.IMetadataUsage>().Any())
@@ -139,7 +139,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                     {
-                        OwningMembershipTextualNotationBuilder.BuildPrefixMetadataMember(elementAsOwningMembership, cursorCache, stringBuilder);
+                        OwningMembershipTextualNotationBuilder.BuildPrefixMetadataMember(elementAsOwningMembership, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -153,14 +153,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>LiteralReal=value=RealValue</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildLiteralReal(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildLiteralReal(SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.value != null)
             {
-                BuildRealValueHandCoded(poco.value, cursorCache, stringBuilder);
+                BuildRealValueHandCoded(poco.value, writerContext, stringBuilder);
             }
 
         }
@@ -170,11 +170,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>NonBehaviorBodyItem=ownedRelationship+=Import|ownedRelationship+=AliasMember|ownedRelationship+=DefinitionMember|ownedRelationship+=VariantUsageMember|ownedRelationship+=NonOccurrenceUsageMember|(ownedRelationship+=SourceSuccessionMember)?ownedRelationship+=StructureUsageMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Elements.IElement" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNonBehaviorBodyItem(SysML2.NET.Core.POCO.Root.Elements.IElement poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNonBehaviorBodyItem(SysML2.NET.Core.POCO.Root.Elements.IElement poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildNonBehaviorBodyItemHandCoded(poco, cursorCache, stringBuilder);
+            BuildNonBehaviorBodyItemHandCoded(poco, writerContext, stringBuilder);
         }
     }
 }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SharedTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SharedTextualNotationBuilder.cs
@@ -79,7 +79,7 @@ namespace SysML2.NET.TextualNotation
 
             if (clientCursor.Current != null)
             {
-                stringBuilder.Append(clientCursor.Current.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, clientCursor.Current);
                 clientCursor.Move();
             }
 
@@ -89,7 +89,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (clientCursor.Current != null)
                 {
-                    stringBuilder.Append(clientCursor.Current.qualifiedName);
+                    SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, clientCursor.Current);
                     clientCursor.Move();
                 }
                 clientCursor.Move();
@@ -99,7 +99,7 @@ namespace SysML2.NET.TextualNotation
 
             if (supplierCursor.Current != null)
             {
-                stringBuilder.Append(supplierCursor.Current.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, supplierCursor.Current);
                 supplierCursor.Move();
             }
 
@@ -109,7 +109,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (supplierCursor.Current != null)
                 {
-                    stringBuilder.Append(supplierCursor.Current.qualifiedName);
+                    SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, supplierCursor.Current);
                     supplierCursor.Move();
                 }
                 supplierCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SpecializationTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SpecializationTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedSpecialization:Specialization=GeneralType</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.ISpecialization" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedSpecialization(SysML2.NET.Core.POCO.Core.Types.ISpecialization poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedSpecialization(SysML2.NET.Core.POCO.Core.Types.ISpecialization poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildGeneralType(poco, cursorCache, stringBuilder);
+            BuildGeneralType(poco, writerContext, stringBuilder);
 
         }
 
@@ -52,17 +52,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>SpecificType:Specialization=specific=[QualifiedName]|specific+=OwnedFeatureChain{ownedRelatedElement+=specific}</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.ISpecialization" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSpecificType(SysML2.NET.Core.POCO.Core.Types.ISpecialization poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSpecificType(SysML2.NET.Core.POCO.Core.Types.ISpecialization poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             if (poco.OwnedRelatedElement.Contains(poco.Specific) && poco.Specific is SysML2.NET.Core.POCO.Core.Features.IFeature chainedSpecificAsFeature)
             {
-                FeatureTextualNotationBuilder.BuildOwnedFeatureChain(chainedSpecificAsFeature, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildOwnedFeatureChain(chainedSpecificAsFeature, writerContext, stringBuilder);
             }
             else if (poco.Specific != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.Specific);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.Specific, writerContext);
                 stringBuilder.Append(' ');
             }
 
@@ -73,17 +73,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>GeneralType:Specialization=general=[QualifiedName]|general+=OwnedFeatureChain{ownedRelatedElement+=general}</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.ISpecialization" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildGeneralType(SysML2.NET.Core.POCO.Core.Types.ISpecialization poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildGeneralType(SysML2.NET.Core.POCO.Core.Types.ISpecialization poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             if (poco.OwnedRelatedElement.Contains(poco.General) && poco.General is SysML2.NET.Core.POCO.Core.Features.IFeature chainedGeneralAsFeature)
             {
-                FeatureTextualNotationBuilder.BuildOwnedFeatureChain(chainedGeneralAsFeature, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildOwnedFeatureChain(chainedGeneralAsFeature, writerContext, stringBuilder);
             }
             else if (poco.General != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.General);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.General, writerContext);
                 stringBuilder.Append(' ');
             }
 
@@ -94,23 +94,23 @@ namespace SysML2.NET.TextualNotation
         /// <para>Specialization=('specialization'Identification)?'subtype'SpecificTypeSPECIALIZESGeneralTypeRelationshipBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.ISpecialization" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSpecialization(SysML2.NET.Core.POCO.Core.Types.ISpecialization poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSpecialization(SysML2.NET.Core.POCO.Core.Types.ISpecialization poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName))
             {
                 stringBuilder.Append("specialization ");
-                ElementTextualNotationBuilder.BuildIdentification(poco, cursorCache, stringBuilder);
+                ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
                 stringBuilder.Append(' ');
             }
 
             stringBuilder.Append("subtype ");
-            BuildSpecificType(poco, cursorCache, stringBuilder);
+            BuildSpecificType(poco, writerContext, stringBuilder);
             stringBuilder.Append(" :> ");
-            BuildGeneralType(poco, cursorCache, stringBuilder);
-            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, cursorCache, stringBuilder);
+            BuildGeneralType(poco, writerContext, stringBuilder);
+            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SpecializationTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SpecializationTextualNotationBuilder.cs
@@ -62,7 +62,7 @@ namespace SysML2.NET.TextualNotation
             }
             else if (poco.Specific != null)
             {
-                stringBuilder.Append(poco.Specific.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.Specific);
                 stringBuilder.Append(' ');
             }
 
@@ -83,7 +83,7 @@ namespace SysML2.NET.TextualNotation
             }
             else if (poco.General != null)
             {
-                stringBuilder.Append(poco.General.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.General);
                 stringBuilder.Append(' ');
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/StakeholderMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/StakeholderMembershipTextualNotationBuilder.cs
@@ -39,19 +39,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>StakeholderMember:StakeholderMembership=MemberPrefixownedRelatedElement+=StakeholderUsage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.IStakeholderMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildStakeholderMember(SysML2.NET.Core.POCO.Systems.Requirements.IStakeholderMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildStakeholderMember(SysML2.NET.Core.POCO.Systems.Requirements.IStakeholderMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Parts.IPartUsage elementAsPartUsage)
                 {
-                    PartUsageTextualNotationBuilder.BuildStakeholderUsage(elementAsPartUsage, cursorCache, stringBuilder);
+                    PartUsageTextualNotationBuilder.BuildStakeholderUsage(elementAsPartUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/StateDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/StateDefinitionTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>StateDefBody:StateDefinition=';'|(isParallel?='parallel')?'{'StateBodyItem*'}'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.IStateDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildStateDefBody(SysML2.NET.Core.POCO.Systems.States.IStateDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildStateDefBody(SysML2.NET.Core.POCO.Systems.States.IStateDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            if (cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
+            if (writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
             {
                 stringBuilder.AppendLine(";");
             }
@@ -58,10 +58,10 @@ namespace SysML2.NET.TextualNotation
 
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
-                var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 while (ownedRelationshipCursor.Current != null)
                 {
-                    TypeTextualNotationBuilder.BuildStateBodyItem(poco, cursorCache, stringBuilder);
+                    TypeTextualNotationBuilder.BuildStateBodyItem(poco, writerContext, stringBuilder);
                 }
                 stringBuilder.AppendLine("}");
             }
@@ -73,15 +73,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>StateDefinition=OccurrenceDefinitionPrefix'state''def'DefinitionDeclarationStateDefBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.IStateDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildStateDefinition(SysML2.NET.Core.POCO.Systems.States.IStateDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildStateDefinition(SysML2.NET.Core.POCO.Systems.States.IStateDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, cursorCache, stringBuilder);
+            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("state ");
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, cursorCache, stringBuilder);
-            BuildStateDefBody(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, writerContext, stringBuilder);
+            BuildStateDefBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/StateSubactionMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/StateSubactionMembershipTextualNotationBuilder.cs
@@ -39,12 +39,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>EntryActionMember:StateSubactionMembership=MemberPrefixkind='entry'ownedRelatedElement+=StateActionUsage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.IStateSubactionMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildEntryActionMember(SysML2.NET.Core.POCO.Systems.States.IStateSubactionMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildEntryActionMember(SysML2.NET.Core.POCO.Systems.States.IStateSubactionMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append(poco.Kind.ToString().ToLower());
             stringBuilder.Append(' ');
 
@@ -53,7 +53,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Actions.IActionUsage elementAsActionUsage)
                 {
-                    ActionUsageTextualNotationBuilder.BuildStateActionUsage(elementAsActionUsage, cursorCache, stringBuilder);
+                    ActionUsageTextualNotationBuilder.BuildStateActionUsage(elementAsActionUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -66,12 +66,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>DoActionMember:StateSubactionMembership=MemberPrefixkind='do'ownedRelatedElement+=StateActionUsage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.IStateSubactionMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildDoActionMember(SysML2.NET.Core.POCO.Systems.States.IStateSubactionMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildDoActionMember(SysML2.NET.Core.POCO.Systems.States.IStateSubactionMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append(poco.Kind.ToString().ToLower());
             stringBuilder.Append(' ');
 
@@ -80,7 +80,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Actions.IActionUsage elementAsActionUsage)
                 {
-                    ActionUsageTextualNotationBuilder.BuildStateActionUsage(elementAsActionUsage, cursorCache, stringBuilder);
+                    ActionUsageTextualNotationBuilder.BuildStateActionUsage(elementAsActionUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -93,12 +93,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>ExitActionMember:StateSubactionMembership=MemberPrefixkind='exit'ownedRelatedElement+=StateActionUsage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.IStateSubactionMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildExitActionMember(SysML2.NET.Core.POCO.Systems.States.IStateSubactionMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildExitActionMember(SysML2.NET.Core.POCO.Systems.States.IStateSubactionMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append(poco.Kind.ToString().ToLower());
             stringBuilder.Append(' ');
 
@@ -107,7 +107,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Actions.IActionUsage elementAsActionUsage)
                 {
-                    ActionUsageTextualNotationBuilder.BuildStateActionUsage(elementAsActionUsage, cursorCache, stringBuilder);
+                    ActionUsageTextualNotationBuilder.BuildStateActionUsage(elementAsActionUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/StateUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/StateUsageTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>StateUsageBody:StateUsage=';'|(isParallel?='parallel')?'{'StateBodyItem*'}'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.IStateUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildStateUsageBody(SysML2.NET.Core.POCO.Systems.States.IStateUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildStateUsageBody(SysML2.NET.Core.POCO.Systems.States.IStateUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            if (cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
+            if (writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
             {
                 stringBuilder.AppendLine(";");
             }
@@ -58,10 +58,10 @@ namespace SysML2.NET.TextualNotation
 
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
-                var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 while (ownedRelationshipCursor.Current != null)
                 {
-                    TypeTextualNotationBuilder.BuildStateBodyItem(poco, cursorCache, stringBuilder);
+                    TypeTextualNotationBuilder.BuildStateBodyItem(poco, writerContext, stringBuilder);
                 }
                 stringBuilder.AppendLine("}");
             }
@@ -73,14 +73,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>StateUsage=OccurrenceUsagePrefix'state'ActionUsageDeclarationStateUsageBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.IStateUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildStateUsage(SysML2.NET.Core.POCO.Systems.States.IStateUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildStateUsage(SysML2.NET.Core.POCO.Systems.States.IStateUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("state ");
-            ActionUsageTextualNotationBuilder.BuildActionUsageDeclaration(poco, cursorCache, stringBuilder);
-            BuildStateUsageBody(poco, cursorCache, stringBuilder);
+            ActionUsageTextualNotationBuilder.BuildActionUsageDeclaration(poco, writerContext, stringBuilder);
+            BuildStateUsageBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/StepTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/StepTextualNotationBuilder.cs
@@ -39,19 +39,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>Step=FeaturePrefix'step'FeatureDeclarationValuePart?TypeBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Behaviors.IStep" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildStep(SysML2.NET.Core.POCO.Kernel.Behaviors.IStep poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildStep(SysML2.NET.Core.POCO.Kernel.Behaviors.IStep poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            SharedTextualNotationBuilder.BuildFeaturePrefix(poco, cursorCache, stringBuilder);
+            SharedTextualNotationBuilder.BuildFeaturePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("step ");
-            FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, cursorCache, stringBuilder);
+            FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, writerContext, stringBuilder);
 
             if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
-                FeatureTextualNotationBuilder.BuildValuePart(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }
-            TypeTextualNotationBuilder.BuildTypeBody(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypeBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/StructureTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/StructureTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>Structure=TypePrefix'struct'ClassifierDeclarationTypeBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Structures.IStructure" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildStructure(SysML2.NET.Core.POCO.Kernel.Structures.IStructure poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildStructure(SysML2.NET.Core.POCO.Kernel.Structures.IStructure poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            TypeTextualNotationBuilder.BuildTypePrefix(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("struct ");
-            ClassifierTextualNotationBuilder.BuildClassifierDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildTypeBody(poco, cursorCache, stringBuilder);
+            ClassifierTextualNotationBuilder.BuildClassifierDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypeBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SubclassificationTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SubclassificationTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedSubclassification:Subclassification=superClassifier=[QualifiedName]</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Classifiers.ISubclassification" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedSubclassification(SysML2.NET.Core.POCO.Core.Classifiers.ISubclassification poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedSubclassification(SysML2.NET.Core.POCO.Core.Classifiers.ISubclassification poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.Superclassifier != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.Superclassifier);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.Superclassifier, writerContext);
                 stringBuilder.Append(' ');
             }
 
@@ -57,15 +57,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>Subclassification=('specialization'Identification)?'subclassifier'subclassifier=[QualifiedName]SPECIALIZESsuperclassifier=[QualifiedName]RelationshipBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Classifiers.ISubclassification" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSubclassification(SysML2.NET.Core.POCO.Core.Classifiers.ISubclassification poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSubclassification(SysML2.NET.Core.POCO.Core.Classifiers.ISubclassification poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName))
             {
                 stringBuilder.Append("specialization ");
-                ElementTextualNotationBuilder.BuildIdentification(poco, cursorCache, stringBuilder);
+                ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
                 stringBuilder.Append(' ');
             }
 
@@ -73,17 +73,17 @@ namespace SysML2.NET.TextualNotation
 
             if (poco.Subclassifier != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.Subclassifier);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.Subclassifier, writerContext);
                 stringBuilder.Append(' ');
             }
             stringBuilder.Append(" :> ");
 
             if (poco.Superclassifier != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.Superclassifier);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.Superclassifier, writerContext);
                 stringBuilder.Append(' ');
             }
-            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, cursorCache, stringBuilder);
+            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SubclassificationTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SubclassificationTextualNotationBuilder.cs
@@ -46,7 +46,7 @@ namespace SysML2.NET.TextualNotation
 
             if (poco.Superclassifier != null)
             {
-                stringBuilder.Append(poco.Superclassifier.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.Superclassifier);
                 stringBuilder.Append(' ');
             }
 
@@ -73,14 +73,14 @@ namespace SysML2.NET.TextualNotation
 
             if (poco.Subclassifier != null)
             {
-                stringBuilder.Append(poco.Subclassifier.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.Subclassifier);
                 stringBuilder.Append(' ');
             }
             stringBuilder.Append(" :> ");
 
             if (poco.Superclassifier != null)
             {
-                stringBuilder.Append(poco.Superclassifier.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.Superclassifier);
                 stringBuilder.Append(' ');
             }
             RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, cursorCache, stringBuilder);

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SubjectMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SubjectMembershipTextualNotationBuilder.cs
@@ -39,19 +39,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>SubjectMember:SubjectMembership=MemberPrefixownedRelatedElement+=SubjectUsage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.ISubjectMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSubjectMember(SysML2.NET.Core.POCO.Systems.Requirements.ISubjectMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSubjectMember(SysML2.NET.Core.POCO.Systems.Requirements.ISubjectMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
-                    ReferenceUsageTextualNotationBuilder.BuildSubjectUsage(elementAsReferenceUsage, cursorCache, stringBuilder);
+                    ReferenceUsageTextualNotationBuilder.BuildSubjectUsage(elementAsReferenceUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -64,18 +64,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>SatisfactionSubjectMember:SubjectMembership=ownedRelatedElement+=SatisfactionParameter</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Requirements.ISubjectMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSatisfactionSubjectMember(SysML2.NET.Core.POCO.Systems.Requirements.ISubjectMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSatisfactionSubjectMember(SysML2.NET.Core.POCO.Systems.Requirements.ISubjectMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
-                    ReferenceUsageTextualNotationBuilder.BuildSatisfactionParameter(elementAsReferenceUsage, cursorCache, stringBuilder);
+                    ReferenceUsageTextualNotationBuilder.BuildSatisfactionParameter(elementAsReferenceUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SubsettingTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SubsettingTextualNotationBuilder.cs
@@ -39,17 +39,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedSubsetting:Subsetting=subsettedFeature=[QualifiedName]|subsettedFeature=OwnedFeatureChain{ownedRelatedElement+=subsettedFeature}</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.ISubsetting" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedSubsetting(SysML2.NET.Core.POCO.Core.Features.ISubsetting poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedSubsetting(SysML2.NET.Core.POCO.Core.Features.ISubsetting poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             if (poco.OwnedRelatedElement.Contains(poco.SubsettedFeature) && poco.SubsettedFeature is SysML2.NET.Core.POCO.Core.Features.IFeature chainedSubsettedFeatureAsFeature)
             {
-                FeatureTextualNotationBuilder.BuildOwnedFeatureChain(chainedSubsettedFeatureAsFeature, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildOwnedFeatureChain(chainedSubsettedFeatureAsFeature, writerContext, stringBuilder);
             }
             else if (poco.SubsettedFeature != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.SubsettedFeature);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.SubsettedFeature, writerContext);
                 stringBuilder.Append(' ');
             }
 
@@ -60,23 +60,23 @@ namespace SysML2.NET.TextualNotation
         /// <para>Subsetting=('specialization'Identification)?'subset'SpecificTypeSUBSETSGeneralTypeRelationshipBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.ISubsetting" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSubsetting(SysML2.NET.Core.POCO.Core.Features.ISubsetting poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSubsetting(SysML2.NET.Core.POCO.Core.Features.ISubsetting poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName))
             {
                 stringBuilder.Append("specialization ");
-                ElementTextualNotationBuilder.BuildIdentification(poco, cursorCache, stringBuilder);
+                ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
                 stringBuilder.Append(' ');
             }
 
             stringBuilder.Append("subset ");
-            SpecializationTextualNotationBuilder.BuildSpecificType(poco, cursorCache, stringBuilder);
+            SpecializationTextualNotationBuilder.BuildSpecificType(poco, writerContext, stringBuilder);
             stringBuilder.Append(" :> ");
-            SpecializationTextualNotationBuilder.BuildGeneralType(poco, cursorCache, stringBuilder);
-            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, cursorCache, stringBuilder);
+            SpecializationTextualNotationBuilder.BuildGeneralType(poco, writerContext, stringBuilder);
+            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SubsettingTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SubsettingTextualNotationBuilder.cs
@@ -49,7 +49,7 @@ namespace SysML2.NET.TextualNotation
             }
             else if (poco.SubsettedFeature != null)
             {
-                stringBuilder.Append(poco.SubsettedFeature.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.SubsettedFeature);
                 stringBuilder.Append(' ');
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SuccessionAsUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SuccessionAsUsageTextualNotationBuilder.cs
@@ -39,18 +39,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>SourceSuccession:SuccessionAsUsage=ownedRelationship+=SourceEndMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Connections.ISuccessionAsUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSourceSuccession(SysML2.NET.Core.POCO.Systems.Connections.ISuccessionAsUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSourceSuccession(SysML2.NET.Core.POCO.Systems.Connections.ISuccessionAsUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
-                    EndFeatureMembershipTextualNotationBuilder.BuildSourceEndMember(elementAsEndFeatureMembership, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildSourceEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -63,18 +63,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>TargetSuccession:SuccessionAsUsage=ownedRelationship+=SourceEndMember'then'ownedRelationship+=ConnectorEndMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Connections.ISuccessionAsUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTargetSuccession(SysML2.NET.Core.POCO.Systems.Connections.ISuccessionAsUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTargetSuccession(SysML2.NET.Core.POCO.Systems.Connections.ISuccessionAsUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
-                    EndFeatureMembershipTextualNotationBuilder.BuildSourceEndMember(elementAsEndFeatureMembership, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildSourceEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -86,7 +86,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
-                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -99,17 +99,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>SuccessionAsUsage=UsagePrefix('succession'UsageDeclaration)?'first's.ownedRelationship+=ConnectorEndMember'then's.ownedRelationship+=ConnectorEndMemberUsageBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Connections.ISuccessionAsUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSuccessionAsUsage(SysML2.NET.Core.POCO.Systems.Connections.ISuccessionAsUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSuccessionAsUsage(SysML2.NET.Core.POCO.Systems.Connections.ISuccessionAsUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-            UsageTextualNotationBuilder.BuildUsagePrefix(poco, cursorCache, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            UsageTextualNotationBuilder.BuildUsagePrefix(poco, writerContext, stringBuilder);
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.OwnedRelatedElement.Count != 0 || poco.IsOrdered)
             {
                 stringBuilder.Append("succession ");
-                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
                 stringBuilder.Append(' ');
             }
 
@@ -120,7 +120,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
-                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -132,12 +132,12 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
-                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
 
-            UsageTextualNotationBuilder.BuildUsageBody(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsageBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SuccessionFlowTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SuccessionFlowTextualNotationBuilder.cs
@@ -39,15 +39,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>SuccessionFlow=FeaturePrefix'succession''flow'FlowDeclarationTypeBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Interactions.ISuccessionFlow" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSuccessionFlow(SysML2.NET.Core.POCO.Kernel.Interactions.ISuccessionFlow poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSuccessionFlow(SysML2.NET.Core.POCO.Kernel.Interactions.ISuccessionFlow poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            SharedTextualNotationBuilder.BuildFeaturePrefix(poco, cursorCache, stringBuilder);
+            SharedTextualNotationBuilder.BuildFeaturePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("succession ");
             stringBuilder.Append("flow ");
-            BuildFlowDeclarationHandCoded(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildTypeBody(poco, cursorCache, stringBuilder);
+            BuildFlowDeclarationHandCoded(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypeBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SuccessionFlowUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SuccessionFlowUsageTextualNotationBuilder.cs
@@ -39,15 +39,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>SuccessionFlowUsage=OccurrenceUsagePrefix'succession''flow'FlowDeclarationDefinitionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Flows.ISuccessionFlowUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSuccessionFlowUsage(SysML2.NET.Core.POCO.Systems.Flows.ISuccessionFlowUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSuccessionFlowUsage(SysML2.NET.Core.POCO.Systems.Flows.ISuccessionFlowUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("succession ");
             stringBuilder.Append("flow ");
-            FlowUsageTextualNotationBuilder.BuildFlowDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildDefinitionBody(poco, cursorCache, stringBuilder);
+            FlowUsageTextualNotationBuilder.BuildFlowDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildDefinitionBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SuccessionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/SuccessionTextualNotationBuilder.cs
@@ -39,18 +39,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>TransitionSuccession:Succession=ownedRelationship+=EmptyEndMemberownedRelationship+=ConnectorEndMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Connectors.ISuccession" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTransitionSuccession(SysML2.NET.Core.POCO.Kernel.Connectors.ISuccession poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTransitionSuccession(SysML2.NET.Core.POCO.Kernel.Connectors.ISuccession poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
-                    EndFeatureMembershipTextualNotationBuilder.BuildEmptyEndMember(elementAsEndFeatureMembership, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildEmptyEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -61,7 +61,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
-                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -74,11 +74,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>SuccessionDeclaration:Succession=FeatureDeclaration('first'ownedRelationship+=ConnectorEndMember'then'ownedRelationship+=ConnectorEndMember)?|(s.isSufficient?='all')?('first'?ownedRelationship+=ConnectorEndMember'then'ownedRelationship+=ConnectorEndMember)?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Connectors.ISuccession" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSuccessionDeclaration(SysML2.NET.Core.POCO.Kernel.Connectors.ISuccession poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSuccessionDeclaration(SysML2.NET.Core.POCO.Kernel.Connectors.ISuccession poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildSuccessionDeclarationHandCoded(poco, cursorCache, stringBuilder);
+            BuildSuccessionDeclarationHandCoded(poco, writerContext, stringBuilder);
         }
 
         /// <summary>
@@ -86,14 +86,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>Succession=FeaturePrefix'succession'SuccessionDeclarationTypeBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Connectors.ISuccession" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSuccession(SysML2.NET.Core.POCO.Kernel.Connectors.ISuccession poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSuccession(SysML2.NET.Core.POCO.Kernel.Connectors.ISuccession poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            SharedTextualNotationBuilder.BuildFeaturePrefix(poco, cursorCache, stringBuilder);
+            SharedTextualNotationBuilder.BuildFeaturePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("succession ");
-            BuildSuccessionDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildTypeBody(poco, cursorCache, stringBuilder);
+            BuildSuccessionDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildTypeBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/TerminateActionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/TerminateActionUsageTextualNotationBuilder.cs
@@ -39,16 +39,16 @@ namespace SysML2.NET.TextualNotation
         /// <para>TerminateNode:TerminateActionUsage=OccurrenceUsagePrefixActionNodeUsageDeclaration?'terminate'(ownedRelationship+=NodeParameterMember)?ActionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.ITerminateActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTerminateNode(SysML2.NET.Core.POCO.Systems.Actions.ITerminateActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTerminateNode(SysML2.NET.Core.POCO.Systems.Actions.ITerminateActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
             {
-                ActionUsageTextualNotationBuilder.BuildActionNodeUsageDeclaration(poco, cursorCache, stringBuilder);
+                ActionUsageTextualNotationBuilder.BuildActionNodeUsageDeclaration(poco, writerContext, stringBuilder);
             }
             stringBuilder.Append("terminate ");
 
@@ -60,15 +60,15 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                     {
-                        ParameterMembershipTextualNotationBuilder.BuildNodeParameterMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                        ParameterMembershipTextualNotationBuilder.BuildNodeParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
                 stringBuilder.Append(' ');
             }
 
-            TypeTextualNotationBuilder.BuildActionBody(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildActionBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/TextualRepresentationTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/TextualRepresentationTextualNotationBuilder.cs
@@ -39,15 +39,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>TextualRepresentation=('rep'Identification)?'language'language=STRING_VALUEbody=REGULAR_COMMENT</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Annotations.ITextualRepresentation" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTextualRepresentation(SysML2.NET.Core.POCO.Root.Annotations.ITextualRepresentation poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTextualRepresentation(SysML2.NET.Core.POCO.Root.Annotations.ITextualRepresentation poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName))
             {
                 stringBuilder.Append("rep ");
-                ElementTextualNotationBuilder.BuildIdentification(poco, cursorCache, stringBuilder);
+                ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
                 stringBuilder.Append(' ');
             }
 

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/TransitionFeatureMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/TransitionFeatureMembershipTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>TriggerActionMember:TransitionFeatureMembership='accept'{kind='trigger'}ownedRelatedElement+=TriggerAction</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.ITransitionFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTriggerActionMember(SysML2.NET.Core.POCO.Systems.States.ITransitionFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTriggerActionMember(SysML2.NET.Core.POCO.Systems.States.ITransitionFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
             stringBuilder.Append("accept ");
             // NonParsing Assignment Element : kind = 'trigger' => Does not have to be process
 
@@ -52,7 +52,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage elementAsAcceptActionUsage)
                 {
-                    AcceptActionUsageTextualNotationBuilder.BuildTriggerAction(elementAsAcceptActionUsage, cursorCache, stringBuilder);
+                    AcceptActionUsageTextualNotationBuilder.BuildTriggerAction(elementAsAcceptActionUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -65,11 +65,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>GuardExpressionMember:TransitionFeatureMembership='if'{kind='guard'}ownedRelatedElement+=OwnedExpression</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.ITransitionFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildGuardExpressionMember(SysML2.NET.Core.POCO.Systems.States.ITransitionFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildGuardExpressionMember(SysML2.NET.Core.POCO.Systems.States.ITransitionFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
             stringBuilder.Append("if ");
             // NonParsing Assignment Element : kind = 'guard' => Does not have to be process
 
@@ -78,7 +78,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IExpression elementAsExpression)
                 {
-                    ExpressionTextualNotationBuilder.BuildOwnedExpression(elementAsExpression, cursorCache, stringBuilder);
+                    ExpressionTextualNotationBuilder.BuildOwnedExpression(elementAsExpression, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();
@@ -91,11 +91,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>EffectBehaviorMember:TransitionFeatureMembership='do'{kind='effect'}ownedRelatedElement+=EffectBehaviorUsage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.ITransitionFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildEffectBehaviorMember(SysML2.NET.Core.POCO.Systems.States.ITransitionFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildEffectBehaviorMember(SysML2.NET.Core.POCO.Systems.States.ITransitionFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
             stringBuilder.Append("do ");
             // NonParsing Assignment Element : kind = 'effect' => Does not have to be process
 
@@ -104,7 +104,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Actions.IActionUsage elementAsActionUsage)
                 {
-                    ActionUsageTextualNotationBuilder.BuildEffectBehaviorUsage(elementAsActionUsage, cursorCache, stringBuilder);
+                    ActionUsageTextualNotationBuilder.BuildEffectBehaviorUsage(elementAsActionUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/TransitionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/TransitionUsageTextualNotationBuilder.cs
@@ -39,18 +39,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>GuardedTargetSuccession:TransitionUsage=ownedRelationship+=GuardExpressionMember'then'ownedRelationship+=TransitionSuccessionMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.ITransitionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildGuardedTargetSuccession(SysML2.NET.Core.POCO.Systems.States.ITransitionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildGuardedTargetSuccession(SysML2.NET.Core.POCO.Systems.States.ITransitionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.States.ITransitionFeatureMembership elementAsTransitionFeatureMembership)
                 {
-                    TransitionFeatureMembershipTextualNotationBuilder.BuildGuardExpressionMember(elementAsTransitionFeatureMembership, cursorCache, stringBuilder);
+                    TransitionFeatureMembershipTextualNotationBuilder.BuildGuardExpressionMember(elementAsTransitionFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -62,7 +62,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                 {
-                    OwningMembershipTextualNotationBuilder.BuildTransitionSuccessionMember(elementAsOwningMembership, cursorCache, stringBuilder);
+                    OwningMembershipTextualNotationBuilder.BuildTransitionSuccessionMember(elementAsOwningMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -75,11 +75,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>DefaultTargetSuccession:TransitionUsage='else'ownedRelationship+=TransitionSuccessionMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.ITransitionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildDefaultTargetSuccession(SysML2.NET.Core.POCO.Systems.States.ITransitionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildDefaultTargetSuccession(SysML2.NET.Core.POCO.Systems.States.ITransitionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append("else ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -87,7 +87,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                 {
-                    OwningMembershipTextualNotationBuilder.BuildTransitionSuccessionMember(elementAsOwningMembership, cursorCache, stringBuilder);
+                    OwningMembershipTextualNotationBuilder.BuildTransitionSuccessionMember(elementAsOwningMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -100,16 +100,16 @@ namespace SysML2.NET.TextualNotation
         /// <para>GuardedSuccession:TransitionUsage=('succession'UsageDeclaration)?'first'ownedRelationship+=FeatureChainMemberownedRelationship+=GuardExpressionMember'then'ownedRelationship+=TransitionSuccessionMemberUsageBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.ITransitionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildGuardedSuccession(SysML2.NET.Core.POCO.Systems.States.ITransitionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildGuardedSuccession(SysML2.NET.Core.POCO.Systems.States.ITransitionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
             {
                 stringBuilder.Append("succession ");
-                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
                 stringBuilder.Append(' ');
             }
 
@@ -120,7 +120,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership elementAsMembership)
                 {
-                    MembershipTextualNotationBuilder.BuildFeatureChainMember(elementAsMembership, cursorCache, stringBuilder);
+                    MembershipTextualNotationBuilder.BuildFeatureChainMember(elementAsMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -131,7 +131,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.States.ITransitionFeatureMembership elementAsTransitionFeatureMembership)
                 {
-                    TransitionFeatureMembershipTextualNotationBuilder.BuildGuardExpressionMember(elementAsTransitionFeatureMembership, cursorCache, stringBuilder);
+                    TransitionFeatureMembershipTextualNotationBuilder.BuildGuardExpressionMember(elementAsTransitionFeatureMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -143,12 +143,12 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                 {
-                    OwningMembershipTextualNotationBuilder.BuildTransitionSuccessionMember(elementAsOwningMembership, cursorCache, stringBuilder);
+                    OwningMembershipTextualNotationBuilder.BuildTransitionSuccessionMember(elementAsOwningMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
 
-            UsageTextualNotationBuilder.BuildUsageBody(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsageBody(poco, writerContext, stringBuilder);
 
         }
 
@@ -157,23 +157,23 @@ namespace SysML2.NET.TextualNotation
         /// <para>TargetTransitionUsage:TransitionUsage=ownedRelationship+=EmptyParameterMember('transition'(ownedRelationship+=EmptyParameterMemberownedRelationship+=TriggerActionMember)?(ownedRelationship+=GuardExpressionMember)?(ownedRelationship+=EffectBehaviorMember)?|ownedRelationship+=EmptyParameterMemberownedRelationship+=TriggerActionMember(ownedRelationship+=GuardExpressionMember)?(ownedRelationship+=EffectBehaviorMember)?|ownedRelationship+=GuardExpressionMember(ownedRelationship+=EffectBehaviorMember)?)?'then'ownedRelationship+=TransitionSuccessionMemberActionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.ITransitionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTargetTransitionUsage(SysML2.NET.Core.POCO.Systems.States.ITransitionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTargetTransitionUsage(SysML2.NET.Core.POCO.Systems.States.ITransitionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildEmptyParameterMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildEmptyParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
 
-            BuildTargetTransitionUsageHandCoded(poco, cursorCache, stringBuilder);
+            BuildTargetTransitionUsageHandCoded(poco, writerContext, stringBuilder);
             stringBuilder.Append("then ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -181,12 +181,12 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                 {
-                    OwningMembershipTextualNotationBuilder.BuildTransitionSuccessionMember(elementAsOwningMembership, cursorCache, stringBuilder);
+                    OwningMembershipTextualNotationBuilder.BuildTransitionSuccessionMember(elementAsOwningMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
 
-            TypeTextualNotationBuilder.BuildActionBody(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildActionBody(poco, writerContext, stringBuilder);
 
         }
 
@@ -195,16 +195,16 @@ namespace SysML2.NET.TextualNotation
         /// <para>TransitionUsage='transition'(UsageDeclaration'first')?ownedRelationship+=FeatureChainMemberownedRelationship+=EmptyParameterMember(ownedRelationship+=EmptyParameterMemberownedRelationship+=TriggerActionMember)?(ownedRelationship+=GuardExpressionMember)?(ownedRelationship+=EffectBehaviorMember)?'then'ownedRelationship+=TransitionSuccessionMemberActionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.ITransitionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTransitionUsage(SysML2.NET.Core.POCO.Systems.States.ITransitionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTransitionUsage(SysML2.NET.Core.POCO.Systems.States.ITransitionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append("transition ");
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
             {
-                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
                 stringBuilder.Append("first ");
                 stringBuilder.Append(' ');
             }
@@ -215,7 +215,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership elementAsMembership)
                 {
-                    MembershipTextualNotationBuilder.BuildFeatureChainMember(elementAsMembership, cursorCache, stringBuilder);
+                    MembershipTextualNotationBuilder.BuildFeatureChainMember(elementAsMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -226,7 +226,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildEmptyParameterMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildEmptyParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -240,22 +240,22 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                     {
-                        ParameterMembershipTextualNotationBuilder.BuildEmptyParameterMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                        ParameterMembershipTextualNotationBuilder.BuildEmptyParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
 
                 if (ownedRelationshipCursor.Current != null)
                 {
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.States.ITransitionFeatureMembership elementAsTransitionFeatureMembership)
                     {
-                        TransitionFeatureMembershipTextualNotationBuilder.BuildTriggerActionMember(elementAsTransitionFeatureMembership, cursorCache, stringBuilder);
+                        TransitionFeatureMembershipTextualNotationBuilder.BuildTriggerActionMember(elementAsTransitionFeatureMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
                 stringBuilder.Append(' ');
             }
 
@@ -268,11 +268,11 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.States.ITransitionFeatureMembership elementAsTransitionFeatureMembership)
                     {
-                        TransitionFeatureMembershipTextualNotationBuilder.BuildGuardExpressionMember(elementAsTransitionFeatureMembership, cursorCache, stringBuilder);
+                        TransitionFeatureMembershipTextualNotationBuilder.BuildGuardExpressionMember(elementAsTransitionFeatureMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
                 stringBuilder.Append(' ');
             }
 
@@ -285,11 +285,11 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.States.ITransitionFeatureMembership elementAsTransitionFeatureMembership)
                     {
-                        TransitionFeatureMembershipTextualNotationBuilder.BuildEffectBehaviorMember(elementAsTransitionFeatureMembership, cursorCache, stringBuilder);
+                        TransitionFeatureMembershipTextualNotationBuilder.BuildEffectBehaviorMember(elementAsTransitionFeatureMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
                 stringBuilder.Append(' ');
             }
 
@@ -300,12 +300,12 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                 {
-                    OwningMembershipTextualNotationBuilder.BuildTransitionSuccessionMember(elementAsOwningMembership, cursorCache, stringBuilder);
+                    OwningMembershipTextualNotationBuilder.BuildTransitionSuccessionMember(elementAsOwningMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
 
-            TypeTextualNotationBuilder.BuildActionBody(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildActionBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/TriggerInvocationExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/TriggerInvocationExpressionTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>TriggerExpression:TriggerInvocationExpression=kind=('at'|'after')ownedRelationship+=ArgumentMember|kind='when'ownedRelationship+=ArgumentExpressionMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.ITriggerInvocationExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTriggerExpression(SysML2.NET.Core.POCO.Systems.Actions.ITriggerInvocationExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTriggerExpression(SysML2.NET.Core.POCO.Systems.Actions.ITriggerInvocationExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildTriggerExpressionHandCoded(poco, cursorCache, stringBuilder);
+            BuildTriggerExpressionHandCoded(poco, writerContext, stringBuilder);
         }
     }
 }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/TypeFeaturingTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/TypeFeaturingTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>OwnedTypeFeaturing:TypeFeaturing=featuringType=[QualifiedName]</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.ITypeFeaturing" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOwnedTypeFeaturing(SysML2.NET.Core.POCO.Core.Features.ITypeFeaturing poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOwnedTypeFeaturing(SysML2.NET.Core.POCO.Core.Features.ITypeFeaturing poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.FeaturingType != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.FeaturingType);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.FeaturingType, writerContext);
                 stringBuilder.Append(' ');
             }
 
@@ -57,15 +57,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>TypeFeaturing='featuring'(Identification'of')?featureOfType=[QualifiedName]'by'featuringType=[QualifiedName]RelationshipBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.ITypeFeaturing" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTypeFeaturing(SysML2.NET.Core.POCO.Core.Features.ITypeFeaturing poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTypeFeaturing(SysML2.NET.Core.POCO.Core.Features.ITypeFeaturing poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             stringBuilder.Append("featuring ");
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName))
             {
-                ElementTextualNotationBuilder.BuildIdentification(poco, cursorCache, stringBuilder);
+                ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
                 stringBuilder.Append("of ");
                 stringBuilder.Append(' ');
             }
@@ -73,17 +73,17 @@ namespace SysML2.NET.TextualNotation
 
             if (poco.FeatureOfType != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.FeatureOfType);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.FeatureOfType, writerContext);
                 stringBuilder.Append(' ');
             }
             stringBuilder.Append("by ");
 
             if (poco.FeaturingType != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.FeaturingType);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.FeaturingType, writerContext);
                 stringBuilder.Append(' ');
             }
-            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, cursorCache, stringBuilder);
+            RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/TypeFeaturingTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/TypeFeaturingTextualNotationBuilder.cs
@@ -46,7 +46,7 @@ namespace SysML2.NET.TextualNotation
 
             if (poco.FeaturingType != null)
             {
-                stringBuilder.Append(poco.FeaturingType.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.FeaturingType);
                 stringBuilder.Append(' ');
             }
 
@@ -73,14 +73,14 @@ namespace SysML2.NET.TextualNotation
 
             if (poco.FeatureOfType != null)
             {
-                stringBuilder.Append(poco.FeatureOfType.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.FeatureOfType);
                 stringBuilder.Append(' ');
             }
             stringBuilder.Append("by ");
 
             if (poco.FeaturingType != null)
             {
-                stringBuilder.Append(poco.FeaturingType.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.FeaturingType);
                 stringBuilder.Append(' ');
             }
             RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, cursorCache, stringBuilder);

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/TypeTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/TypeTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>DefinitionBody:Type=';'|'{'DefinitionBodyItem*'}'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildDefinitionBody(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildDefinitionBody(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            if (cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
+            if (writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
             {
                 stringBuilder.AppendLine(";");
             }
@@ -51,10 +51,10 @@ namespace SysML2.NET.TextualNotation
             {
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
-                var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 while (ownedRelationshipCursor.Current != null)
                 {
-                    BuildDefinitionBodyItem(poco, cursorCache, stringBuilder);
+                    BuildDefinitionBodyItem(poco, writerContext, stringBuilder);
                 }
                 stringBuilder.AppendLine("}");
             }
@@ -66,11 +66,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>DefinitionBodyItem:Type=ownedRelationship+=DefinitionMember|ownedRelationship+=VariantUsageMember|ownedRelationship+=NonOccurrenceUsageMember|(ownedRelationship+=SourceSuccessionMember)?ownedRelationship+=OccurrenceUsageMember|ownedRelationship+=AliasMember|ownedRelationship+=Import</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildDefinitionBodyItem(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildDefinitionBodyItem(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildDefinitionBodyItemHandCoded(poco, cursorCache, stringBuilder);
+            BuildDefinitionBodyItemHandCoded(poco, writerContext, stringBuilder);
         }
 
         /// <summary>
@@ -78,11 +78,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>InterfaceBody:Type=';'|'{'InterfaceBodyItem*'}'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildInterfaceBody(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildInterfaceBody(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            if (cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
+            if (writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
             {
                 stringBuilder.AppendLine(";");
             }
@@ -90,10 +90,10 @@ namespace SysML2.NET.TextualNotation
             {
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
-                var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 while (ownedRelationshipCursor.Current != null)
                 {
-                    BuildInterfaceBodyItem(poco, cursorCache, stringBuilder);
+                    BuildInterfaceBodyItem(poco, writerContext, stringBuilder);
                 }
                 stringBuilder.AppendLine("}");
             }
@@ -105,11 +105,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>InterfaceBodyItem:Type=ownedRelationship+=DefinitionMember|ownedRelationship+=VariantUsageMember|ownedRelationship+=InterfaceNonOccurrenceUsageMember|(ownedRelationship+=SourceSuccessionMember)?ownedRelationship+=InterfaceOccurrenceUsageMember|ownedRelationship+=AliasMember|ownedRelationship+=Import</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildInterfaceBodyItem(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildInterfaceBodyItem(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildInterfaceBodyItemHandCoded(poco, cursorCache, stringBuilder);
+            BuildInterfaceBodyItemHandCoded(poco, writerContext, stringBuilder);
         }
 
         /// <summary>
@@ -117,11 +117,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>ActionBody:Type=';'|'{'ActionBodyItem*'}'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildActionBody(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildActionBody(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            if (cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
+            if (writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
             {
                 stringBuilder.AppendLine(";");
             }
@@ -129,10 +129,10 @@ namespace SysML2.NET.TextualNotation
             {
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
-                var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 while (ownedRelationshipCursor.Current != null)
                 {
-                    BuildActionBodyItem(poco, cursorCache, stringBuilder);
+                    BuildActionBodyItem(poco, writerContext, stringBuilder);
                 }
                 stringBuilder.AppendLine("}");
             }
@@ -144,11 +144,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>ActionBodyItem:Type=NonBehaviorBodyItem|ownedRelationship+=InitialNodeMember(ownedRelationship+=ActionTargetSuccessionMember)*|(ownedRelationship+=SourceSuccessionMember)?ownedRelationship+=ActionBehaviorMember(ownedRelationship+=ActionTargetSuccessionMember)*|ownedRelationship+=GuardedSuccessionMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildActionBodyItem(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildActionBodyItem(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildActionBodyItemHandCoded(poco, cursorCache, stringBuilder);
+            BuildActionBodyItemHandCoded(poco, writerContext, stringBuilder);
         }
 
         /// <summary>
@@ -156,11 +156,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>StateBodyItem:Type=NonBehaviorBodyItem|(ownedRelationship+=SourceSuccessionMember)?ownedRelationship+=BehaviorUsageMember(ownedRelationship+=TargetTransitionUsageMember)*|ownedRelationship+=TransitionUsageMember|ownedRelationship+=EntryActionMember(ownedRelationship+=EntryTransitionMember)*|ownedRelationship+=DoActionMember|ownedRelationship+=ExitActionMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildStateBodyItem(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildStateBodyItem(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildStateBodyItemHandCoded(poco, cursorCache, stringBuilder);
+            BuildStateBodyItemHandCoded(poco, writerContext, stringBuilder);
         }
 
         /// <summary>
@@ -168,11 +168,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>CalculationBody:Type=';'|'{'CalculationBodyPart'}'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildCalculationBody(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildCalculationBody(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            if (cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
+            if (writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
             {
                 stringBuilder.AppendLine(";");
             }
@@ -180,10 +180,10 @@ namespace SysML2.NET.TextualNotation
             {
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
-                var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 if (ownedRelationshipCursor.Current != null)
                 {
-                    BuildCalculationBodyPart(poco, cursorCache, stringBuilder);
+                    BuildCalculationBodyPart(poco, writerContext, stringBuilder);
                 }
                 stringBuilder.AppendLine("}");
             }
@@ -195,14 +195,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>CalculationBodyPart:Type=CalculationBodyItem*(ownedRelationship+=ResultExpressionMember)?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildCalculationBodyPart(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildCalculationBodyPart(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             while (ownedRelationshipCursor.Current is not null and not SysML2.NET.Core.POCO.Kernel.Functions.IResultExpressionMembership)
             {
-                BuildCalculationBodyItem(poco, cursorCache, stringBuilder);
+                BuildCalculationBodyItem(poco, writerContext, stringBuilder);
             }
 
 
@@ -214,11 +214,11 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IResultExpressionMembership elementAsResultExpressionMembership)
                     {
-                        ResultExpressionMembershipTextualNotationBuilder.BuildResultExpressionMember(elementAsResultExpressionMembership, cursorCache, stringBuilder);
+                        ResultExpressionMembershipTextualNotationBuilder.BuildResultExpressionMember(elementAsResultExpressionMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
             }
 
 
@@ -229,19 +229,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>CalculationBodyItem:Type=ActionBodyItem|ownedRelationship+=ReturnParameterMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildCalculationBodyItem(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildCalculationBodyItem(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership returnParameterMembership)
             {
-                ReturnParameterMembershipTextualNotationBuilder.BuildReturnParameterMember(returnParameterMembership, cursorCache, stringBuilder);
+                ReturnParameterMembershipTextualNotationBuilder.BuildReturnParameterMember(returnParameterMembership, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
             }
             else
             {
-                BuildActionBodyItem(poco, cursorCache, stringBuilder);
+                BuildActionBodyItem(poco, writerContext, stringBuilder);
             }
 
         }
@@ -251,11 +251,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>RequirementBody:Type=';'|'{'RequirementBodyItem*'}'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildRequirementBody(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildRequirementBody(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            if (cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
+            if (writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
             {
                 stringBuilder.AppendLine(";");
             }
@@ -263,10 +263,10 @@ namespace SysML2.NET.TextualNotation
             {
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
-                var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 while (ownedRelationshipCursor.Current != null)
                 {
-                    BuildRequirementBodyItem(poco, cursorCache, stringBuilder);
+                    BuildRequirementBodyItem(poco, writerContext, stringBuilder);
                 }
                 stringBuilder.AppendLine("}");
             }
@@ -278,44 +278,44 @@ namespace SysML2.NET.TextualNotation
         /// <para>RequirementBodyItem:Type=DefinitionBodyItem|ownedRelationship+=SubjectMember|ownedRelationship+=RequirementConstraintMember|ownedRelationship+=FramedConcernMember|ownedRelationship+=RequirementVerificationMember|ownedRelationship+=ActorMember|ownedRelationship+=StakeholderMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildRequirementBodyItem(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildRequirementBodyItem(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.Requirements.ISubjectMembership subjectMembership)
             {
-                SubjectMembershipTextualNotationBuilder.BuildSubjectMember(subjectMembership, cursorCache, stringBuilder);
+                SubjectMembershipTextualNotationBuilder.BuildSubjectMember(subjectMembership, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
             }
             else if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.Requirements.IFramedConcernMembership framedConcernMembership)
             {
-                FramedConcernMembershipTextualNotationBuilder.BuildFramedConcernMember(framedConcernMembership, cursorCache, stringBuilder);
+                FramedConcernMembershipTextualNotationBuilder.BuildFramedConcernMember(framedConcernMembership, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
             }
             else if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.VerificationCases.IRequirementVerificationMembership requirementVerificationMembership)
             {
-                RequirementVerificationMembershipTextualNotationBuilder.BuildRequirementVerificationMember(requirementVerificationMembership, cursorCache, stringBuilder);
+                RequirementVerificationMembershipTextualNotationBuilder.BuildRequirementVerificationMember(requirementVerificationMembership, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
             }
             else if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.Requirements.IActorMembership actorMembership)
             {
-                ActorMembershipTextualNotationBuilder.BuildActorMember(actorMembership, cursorCache, stringBuilder);
+                ActorMembershipTextualNotationBuilder.BuildActorMember(actorMembership, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
             }
             else if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.Requirements.IStakeholderMembership stakeholderMembership)
             {
-                StakeholderMembershipTextualNotationBuilder.BuildStakeholderMember(stakeholderMembership, cursorCache, stringBuilder);
+                StakeholderMembershipTextualNotationBuilder.BuildStakeholderMember(stakeholderMembership, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
             }
             else if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.Requirements.IRequirementConstraintMembership requirementConstraintMembership)
             {
-                RequirementConstraintMembershipTextualNotationBuilder.BuildRequirementConstraintMember(requirementConstraintMembership, cursorCache, stringBuilder);
+                RequirementConstraintMembershipTextualNotationBuilder.BuildRequirementConstraintMember(requirementConstraintMembership, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
             }
             else
             {
-                BuildDefinitionBodyItem(poco, cursorCache, stringBuilder);
+                BuildDefinitionBodyItem(poco, writerContext, stringBuilder);
             }
 
         }
@@ -325,22 +325,22 @@ namespace SysML2.NET.TextualNotation
         /// <para>CaseBody:Type=';'|'{'CaseBodyItem*(ownedRelationship+=ResultExpressionMember)?'}'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildCaseBody(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildCaseBody(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            if (cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
+            if (writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
             {
                 stringBuilder.AppendLine(";");
             }
             else
             {
-                var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
                 while (ownedRelationshipCursor.Current != null)
                 {
-                    BuildCaseBodyItem(poco, cursorCache, stringBuilder);
+                    BuildCaseBodyItem(poco, writerContext, stringBuilder);
                 }
 
 
@@ -352,11 +352,11 @@ namespace SysML2.NET.TextualNotation
 
                         if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IResultExpressionMembership elementAsResultExpressionMembership)
                         {
-                            ResultExpressionMembershipTextualNotationBuilder.BuildResultExpressionMember(elementAsResultExpressionMembership, cursorCache, stringBuilder);
+                            ResultExpressionMembershipTextualNotationBuilder.BuildResultExpressionMember(elementAsResultExpressionMembership, writerContext, stringBuilder);
+                            ownedRelationshipCursor.Move();
+
                         }
                     }
-                    ownedRelationshipCursor.Move();
-
                     stringBuilder.Append(' ');
                 }
 
@@ -370,29 +370,29 @@ namespace SysML2.NET.TextualNotation
         /// <para>CaseBodyItem:Type=ActionBodyItem|ownedRelationship+=SubjectMember|ownedRelationship+=ActorMember|ownedRelationship+=ObjectiveMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildCaseBodyItem(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildCaseBodyItem(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.Requirements.ISubjectMembership subjectMembership)
             {
-                SubjectMembershipTextualNotationBuilder.BuildSubjectMember(subjectMembership, cursorCache, stringBuilder);
+                SubjectMembershipTextualNotationBuilder.BuildSubjectMember(subjectMembership, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
             }
             else if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.Requirements.IActorMembership actorMembership)
             {
-                ActorMembershipTextualNotationBuilder.BuildActorMember(actorMembership, cursorCache, stringBuilder);
+                ActorMembershipTextualNotationBuilder.BuildActorMember(actorMembership, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
             }
             else if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.Cases.IObjectiveMembership objectiveMembership)
             {
-                ObjectiveMembershipTextualNotationBuilder.BuildObjectiveMember(objectiveMembership, cursorCache, stringBuilder);
+                ObjectiveMembershipTextualNotationBuilder.BuildObjectiveMember(objectiveMembership, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
             }
             else
             {
-                BuildActionBodyItem(poco, cursorCache, stringBuilder);
+                BuildActionBodyItem(poco, writerContext, stringBuilder);
             }
 
         }
@@ -402,17 +402,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>MetadataBody:Type=';'|'{'(ownedRelationship+=DefinitionMember|ownedRelationship+=MetadataBodyUsageMember|ownedRelationship+=AliasMember|ownedRelationship+=Import)*'}'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildMetadataBody(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildMetadataBody(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            if (cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
+            if (writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
             {
                 stringBuilder.AppendLine(";");
             }
             else
             {
-                var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
                 while (ownedRelationshipCursor.Current != null)
@@ -420,16 +420,16 @@ namespace SysML2.NET.TextualNotation
                     switch (ownedRelationshipCursor.Current)
                     {
                         case SysML2.NET.Core.POCO.Core.Types.IFeatureMembership featureMembership:
-                            FeatureMembershipTextualNotationBuilder.BuildMetadataBodyUsageMember(featureMembership, cursorCache, stringBuilder);
+                            FeatureMembershipTextualNotationBuilder.BuildMetadataBodyUsageMember(featureMembership, writerContext, stringBuilder);
                             break;
                         case SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership owningMembership:
-                            OwningMembershipTextualNotationBuilder.BuildDefinitionMember(owningMembership, cursorCache, stringBuilder);
+                            OwningMembershipTextualNotationBuilder.BuildDefinitionMember(owningMembership, writerContext, stringBuilder);
                             break;
                         case SysML2.NET.Core.POCO.Root.Namespaces.IMembership membership:
-                            MembershipTextualNotationBuilder.BuildAliasMember(membership, cursorCache, stringBuilder);
+                            MembershipTextualNotationBuilder.BuildAliasMember(membership, writerContext, stringBuilder);
                             break;
                         case SysML2.NET.Core.POCO.Root.Namespaces.IImport import:
-                            ImportTextualNotationBuilder.BuildImport(import, cursorCache, stringBuilder);
+                            ImportTextualNotationBuilder.BuildImport(import, writerContext, stringBuilder);
                             break;
                     }
                     ownedRelationshipCursor.Move();
@@ -445,11 +445,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>TypePrefix:Type=(isAbstract?='abstract')?(ownedRelationship+=PrefixMetadataMember)*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTypePrefix(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTypePrefix(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (poco.IsAbstract)
             {
@@ -466,7 +466,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                     {
-                        OwningMembershipTextualNotationBuilder.BuildPrefixMetadataMember(elementAsOwningMembership, cursorCache, stringBuilder);
+                        OwningMembershipTextualNotationBuilder.BuildPrefixMetadataMember(elementAsOwningMembership, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -480,11 +480,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>TypeDeclaration:Type=(isSufficient?='all')?Identification(ownedRelationship+=OwnedMultiplicity)?(SpecializationPart|ConjugationPart)+TypeRelationshipPart*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTypeDeclaration(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTypeDeclaration(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (poco.IsSufficient)
             {
@@ -492,7 +492,7 @@ namespace SysML2.NET.TextualNotation
                 stringBuilder.Append(' ');
             }
 
-            ElementTextualNotationBuilder.BuildIdentification(poco, cursorCache, stringBuilder);
+            ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
 
             if (ownedRelationshipCursor.Current != null)
             {
@@ -502,19 +502,19 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                     {
-                        OwningMembershipTextualNotationBuilder.BuildOwnedMultiplicity(elementAsOwningMembership, cursorCache, stringBuilder);
+                        OwningMembershipTextualNotationBuilder.BuildOwnedMultiplicity(elementAsOwningMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
                 stringBuilder.Append(' ');
             }
 
-            BuildTypeDeclarationHandCoded(poco, cursorCache, stringBuilder);
+            BuildTypeDeclarationHandCoded(poco, writerContext, stringBuilder);
             stringBuilder.Append(' ');
             while (ownedRelationshipCursor.Current != null)
             {
-                BuildTypeRelationshipPart(poco, cursorCache, stringBuilder);
+                BuildTypeRelationshipPart(poco, writerContext, stringBuilder);
             }
 
 
@@ -525,11 +525,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>SpecializationPart:Type=SPECIALIZESownedRelationship+=OwnedSpecialization(','ownedRelationship+=OwnedSpecialization)*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildSpecializationPart(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildSpecializationPart(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append(" :> ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -537,7 +537,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.ISpecialization elementAsSpecialization)
                 {
-                    SpecializationTextualNotationBuilder.BuildOwnedSpecialization(elementAsSpecialization, cursorCache, stringBuilder);
+                    SpecializationTextualNotationBuilder.BuildOwnedSpecialization(elementAsSpecialization, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -552,7 +552,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.ISpecialization elementAsSpecialization)
                     {
-                        SpecializationTextualNotationBuilder.BuildOwnedSpecialization(elementAsSpecialization, cursorCache, stringBuilder);
+                        SpecializationTextualNotationBuilder.BuildOwnedSpecialization(elementAsSpecialization, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -566,11 +566,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>ConjugationPart:Type=CONJUGATESownedRelationship+=OwnedConjugation</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildConjugationPart(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildConjugationPart(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append(" ~");
 
             if (ownedRelationshipCursor.Current != null)
@@ -578,7 +578,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IConjugation elementAsConjugation)
                 {
-                    ConjugationTextualNotationBuilder.BuildOwnedConjugation(elementAsConjugation, cursorCache, stringBuilder);
+                    ConjugationTextualNotationBuilder.BuildOwnedConjugation(elementAsConjugation, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -591,23 +591,23 @@ namespace SysML2.NET.TextualNotation
         /// <para>TypeRelationshipPart:Type=DisjoiningPart|UnioningPart|IntersectingPart|DifferencingPart</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTypeRelationshipPart(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTypeRelationshipPart(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Core.Types.IType pocoTypeDisjoiningPart when pocoTypeDisjoiningPart.IsValidForDisjoiningPart():
-                    BuildDisjoiningPart(pocoTypeDisjoiningPart, cursorCache, stringBuilder);
+                    BuildDisjoiningPart(pocoTypeDisjoiningPart, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Core.Types.IType pocoTypeUnioningPart when pocoTypeUnioningPart.IsValidForUnioningPart():
-                    BuildUnioningPart(pocoTypeUnioningPart, cursorCache, stringBuilder);
+                    BuildUnioningPart(pocoTypeUnioningPart, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Core.Types.IType pocoTypeIntersectingPart when pocoTypeIntersectingPart.IsValidForIntersectingPart():
-                    BuildIntersectingPart(pocoTypeIntersectingPart, cursorCache, stringBuilder);
+                    BuildIntersectingPart(pocoTypeIntersectingPart, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildDifferencingPart(poco, cursorCache, stringBuilder);
+                    BuildDifferencingPart(poco, writerContext, stringBuilder);
                     break;
             }
 
@@ -618,11 +618,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>DisjoiningPart:Type='disjoint''from'ownedRelationship+=OwnedDisjoining(','ownedRelationship+=OwnedDisjoining)*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildDisjoiningPart(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildDisjoiningPart(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append("disjoint ");
             stringBuilder.Append("from ");
 
@@ -631,7 +631,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IDisjoining elementAsDisjoining)
                 {
-                    DisjoiningTextualNotationBuilder.BuildOwnedDisjoining(elementAsDisjoining, cursorCache, stringBuilder);
+                    DisjoiningTextualNotationBuilder.BuildOwnedDisjoining(elementAsDisjoining, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -646,7 +646,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IDisjoining elementAsDisjoining)
                     {
-                        DisjoiningTextualNotationBuilder.BuildOwnedDisjoining(elementAsDisjoining, cursorCache, stringBuilder);
+                        DisjoiningTextualNotationBuilder.BuildOwnedDisjoining(elementAsDisjoining, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -660,11 +660,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>UnioningPart:Type='unions'ownedRelationship+=Unioning(','ownedRelationship+=Unioning)*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildUnioningPart(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildUnioningPart(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append("unions ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -672,7 +672,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IUnioning elementAsUnioning)
                 {
-                    UnioningTextualNotationBuilder.BuildUnioning(elementAsUnioning, cursorCache, stringBuilder);
+                    UnioningTextualNotationBuilder.BuildUnioning(elementAsUnioning, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -687,7 +687,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IUnioning elementAsUnioning)
                     {
-                        UnioningTextualNotationBuilder.BuildUnioning(elementAsUnioning, cursorCache, stringBuilder);
+                        UnioningTextualNotationBuilder.BuildUnioning(elementAsUnioning, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -701,11 +701,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>IntersectingPart:Type='intersects'ownedRelationship+=Intersecting(','ownedRelationship+=Intersecting)*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildIntersectingPart(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildIntersectingPart(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append("intersects ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -713,7 +713,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IIntersecting elementAsIntersecting)
                 {
-                    IntersectingTextualNotationBuilder.BuildIntersecting(elementAsIntersecting, cursorCache, stringBuilder);
+                    IntersectingTextualNotationBuilder.BuildIntersecting(elementAsIntersecting, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -728,7 +728,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IIntersecting elementAsIntersecting)
                     {
-                        IntersectingTextualNotationBuilder.BuildIntersecting(elementAsIntersecting, cursorCache, stringBuilder);
+                        IntersectingTextualNotationBuilder.BuildIntersecting(elementAsIntersecting, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -742,11 +742,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>DifferencingPart:Type='differences'ownedRelationship+=Differencing(','ownedRelationship+=Differencing)*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildDifferencingPart(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildDifferencingPart(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append("differences ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -754,7 +754,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IDifferencing elementAsDifferencing)
                 {
-                    DifferencingTextualNotationBuilder.BuildDifferencing(elementAsDifferencing, cursorCache, stringBuilder);
+                    DifferencingTextualNotationBuilder.BuildDifferencing(elementAsDifferencing, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -769,7 +769,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IDifferencing elementAsDifferencing)
                     {
-                        DifferencingTextualNotationBuilder.BuildDifferencing(elementAsDifferencing, cursorCache, stringBuilder);
+                        DifferencingTextualNotationBuilder.BuildDifferencing(elementAsDifferencing, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -783,11 +783,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>TypeBody:Type=';'|'{'TypeBodyElement*'}'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTypeBody(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTypeBody(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            if (cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
+            if (writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
             {
                 stringBuilder.AppendLine(";");
             }
@@ -795,10 +795,10 @@ namespace SysML2.NET.TextualNotation
             {
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
-                var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 while (ownedRelationshipCursor.Current != null)
                 {
-                    BuildTypeBodyElement(poco, cursorCache, stringBuilder);
+                    BuildTypeBodyElement(poco, writerContext, stringBuilder);
                 }
                 stringBuilder.AppendLine("}");
             }
@@ -810,27 +810,27 @@ namespace SysML2.NET.TextualNotation
         /// <para>TypeBodyElement:Type=ownedRelationship+=NonFeatureMember|ownedRelationship+=FeatureMember|ownedRelationship+=AliasMember|ownedRelationship+=Import</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildTypeBodyElement(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildTypeBodyElement(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             switch (ownedRelationshipCursor.Current)
             {
                 case SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership owningMembership when owningMembership.IsValidForNonFeatureMember():
-                    OwningMembershipTextualNotationBuilder.BuildNonFeatureMember(owningMembership, cursorCache, stringBuilder);
+                    OwningMembershipTextualNotationBuilder.BuildNonFeatureMember(owningMembership, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                     break;
                 case SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership owningMembership when owningMembership.IsValidForFeatureMember():
-                    OwningMembershipTextualNotationBuilder.BuildFeatureMember(owningMembership, cursorCache, stringBuilder);
+                    OwningMembershipTextualNotationBuilder.BuildFeatureMember(owningMembership, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                     break;
                 case SysML2.NET.Core.POCO.Root.Namespaces.IMembership membership:
-                    MembershipTextualNotationBuilder.BuildAliasMember(membership, cursorCache, stringBuilder);
+                    MembershipTextualNotationBuilder.BuildAliasMember(membership, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                     break;
                 case SysML2.NET.Core.POCO.Root.Namespaces.IImport import:
-                    ImportTextualNotationBuilder.BuildImport(import, cursorCache, stringBuilder);
+                    ImportTextualNotationBuilder.BuildImport(import, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                     break;
                 default:
@@ -845,11 +845,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>FunctionBody:Type=';'|'{'FunctionBodyPart'}'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFunctionBody(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFunctionBody(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            if (cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
+            if (writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
             {
                 stringBuilder.AppendLine(";");
             }
@@ -857,10 +857,10 @@ namespace SysML2.NET.TextualNotation
             {
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
-                var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 if (ownedRelationshipCursor.Current != null)
                 {
-                    BuildFunctionBodyPart(poco, cursorCache, stringBuilder);
+                    BuildFunctionBodyPart(poco, writerContext, stringBuilder);
                 }
                 stringBuilder.AppendLine("}");
             }
@@ -872,17 +872,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>FunctionBodyPart:Type=(TypeBodyElement|ownedRelationship+=ReturnFeatureMember)*(ownedRelationship+=ResultExpressionMember)?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildFunctionBodyPart(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildFunctionBodyPart(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             while (ownedRelationshipCursor.Current != null)
             {
                 switch (ownedRelationshipCursor.Current)
                 {
                     case SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership returnParameterMembership:
-                        ReturnParameterMembershipTextualNotationBuilder.BuildReturnFeatureMember(returnParameterMembership, cursorCache, stringBuilder);
+                        ReturnParameterMembershipTextualNotationBuilder.BuildReturnFeatureMember(returnParameterMembership, writerContext, stringBuilder);
                         break;
                 }
                 ownedRelationshipCursor.Move();
@@ -897,11 +897,11 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IResultExpressionMembership elementAsResultExpressionMembership)
                     {
-                        ResultExpressionMembershipTextualNotationBuilder.BuildResultExpressionMember(elementAsResultExpressionMembership, cursorCache, stringBuilder);
+                        ResultExpressionMembershipTextualNotationBuilder.BuildResultExpressionMember(elementAsResultExpressionMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
             }
 
 
@@ -912,11 +912,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>InstantiatedTypeReference:Type=[QualifiedName]</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildInstantiatedTypeReference(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildInstantiatedTypeReference(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco);
+            SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco, writerContext);
             stringBuilder.Append(' ');
 
         }
@@ -926,14 +926,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>Type=TypePrefix'type'TypeDeclarationTypeBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildType(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildType(SysML2.NET.Core.POCO.Core.Types.IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildTypePrefix(poco, cursorCache, stringBuilder);
+            BuildTypePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("type ");
-            BuildTypeDeclaration(poco, cursorCache, stringBuilder);
-            BuildTypeBody(poco, cursorCache, stringBuilder);
+            BuildTypeDeclaration(poco, writerContext, stringBuilder);
+            BuildTypeBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/TypeTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/TypeTextualNotationBuilder.cs
@@ -916,7 +916,7 @@ namespace SysML2.NET.TextualNotation
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         public static void BuildInstantiatedTypeReference(SysML2.NET.Core.POCO.Core.Types.IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
         {
-            stringBuilder.Append(poco.qualifiedName);
+            SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco);
             stringBuilder.Append(' ');
 
         }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/TypeTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/TypeTextualNotationBuilder.cs
@@ -597,13 +597,13 @@ namespace SysML2.NET.TextualNotation
         {
             switch (poco)
             {
-                case SysML2.NET.Core.POCO.Core.Types.IType pocoTypeDisjoiningPart when pocoTypeDisjoiningPart.IsValidForDisjoiningPart():
+                case SysML2.NET.Core.POCO.Core.Types.IType pocoTypeDisjoiningPart when pocoTypeDisjoiningPart.IsValidForDisjoiningPart(writerContext):
                     BuildDisjoiningPart(pocoTypeDisjoiningPart, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Core.Types.IType pocoTypeUnioningPart when pocoTypeUnioningPart.IsValidForUnioningPart():
+                case SysML2.NET.Core.POCO.Core.Types.IType pocoTypeUnioningPart when pocoTypeUnioningPart.IsValidForUnioningPart(writerContext):
                     BuildUnioningPart(pocoTypeUnioningPart, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Core.Types.IType pocoTypeIntersectingPart when pocoTypeIntersectingPart.IsValidForIntersectingPart():
+                case SysML2.NET.Core.POCO.Core.Types.IType pocoTypeIntersectingPart when pocoTypeIntersectingPart.IsValidForIntersectingPart(writerContext):
                     BuildIntersectingPart(pocoTypeIntersectingPart, writerContext, stringBuilder);
                     break;
                 default:
@@ -817,11 +817,11 @@ namespace SysML2.NET.TextualNotation
             var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             switch (ownedRelationshipCursor.Current)
             {
-                case SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership owningMembership when owningMembership.IsValidForNonFeatureMember():
+                case SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership owningMembership when owningMembership.IsValidForNonFeatureMember(writerContext):
                     OwningMembershipTextualNotationBuilder.BuildNonFeatureMember(owningMembership, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                     break;
-                case SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership owningMembership when owningMembership.IsValidForFeatureMember():
+                case SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership owningMembership when owningMembership.IsValidForFeatureMember(writerContext):
                     OwningMembershipTextualNotationBuilder.BuildFeatureMember(owningMembership, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                     break;

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/UnioningTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/UnioningTextualNotationBuilder.cs
@@ -46,7 +46,7 @@ namespace SysML2.NET.TextualNotation
             var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
             if (poco.UnioningType != null)
             {
-                stringBuilder.Append(poco.UnioningType.qualifiedName);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.UnioningType);
                 stringBuilder.Append(' ');
             }
             else

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/UnioningTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/UnioningTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>Unioning=unioningType=[QualifiedName]|ownedRelatedElement+=OwnedFeatureChain</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IUnioning" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildUnioning(SysML2.NET.Core.POCO.Core.Types.IUnioning poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildUnioning(SysML2.NET.Core.POCO.Core.Types.IUnioning poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
             if (poco.UnioningType != null)
             {
-                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.UnioningType);
+                SharedTextualNotationBuilder.AppendQualifiedName(stringBuilder, poco.UnioningType, writerContext);
                 stringBuilder.Append(' ');
             }
             else
@@ -57,7 +57,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                     {
-                        FeatureTextualNotationBuilder.BuildOwnedFeatureChain(elementAsFeature, cursorCache, stringBuilder);
+                        FeatureTextualNotationBuilder.BuildOwnedFeatureChain(elementAsFeature, writerContext, stringBuilder);
                     }
                 }
             }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/UsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/UsageTextualNotationBuilder.cs
@@ -39,17 +39,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>UsageElement:Usage=NonOccurrenceUsageElement|OccurrenceUsageElement</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildUsageElement(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildUsageElement(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage pocoUsageNonOccurrenceUsageElement when pocoUsageNonOccurrenceUsageElement.IsEnd:
-                    BuildNonOccurrenceUsageElement(pocoUsageNonOccurrenceUsageElement, cursorCache, stringBuilder);
+                    BuildNonOccurrenceUsageElement(pocoUsageNonOccurrenceUsageElement, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildOccurrenceUsageElement(poco, cursorCache, stringBuilder);
+                    BuildOccurrenceUsageElement(poco, writerContext, stringBuilder);
                     break;
             }
 
@@ -60,9 +60,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>RefPrefix:Usage=(direction=FeatureDirection)?(isDerived?='derived')?(isAbstract?='abstract'|isVariation?='variation')?(isConstant?='constant')?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildRefPrefix(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildRefPrefix(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.Direction.HasValue)
@@ -102,11 +102,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>BasicUsagePrefix:Usage=RefPrefix(isReference?='ref')?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildBasicUsagePrefix(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildBasicUsagePrefix(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildRefPrefix(poco, cursorCache, stringBuilder);
+            BuildRefPrefix(poco, writerContext, stringBuilder);
 
             if (poco.isReference)
             {
@@ -121,11 +121,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>EndUsagePrefix:Usage=isEnd?='end'(ownedRelationship+=OwnedCrossFeatureMember)?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildEndUsagePrefix(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildEndUsagePrefix(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             if (poco.IsEnd)
             {
                 stringBuilder.Append(" end ");
@@ -139,11 +139,11 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                     {
-                        OwningMembershipTextualNotationBuilder.BuildOwnedCrossFeatureMember(elementAsOwningMembership, cursorCache, stringBuilder);
+                        OwningMembershipTextualNotationBuilder.BuildOwnedCrossFeatureMember(elementAsOwningMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
             }
 
 
@@ -154,18 +154,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>UsageExtensionKeyword:Usage=ownedRelationship+=PrefixMetadataMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildUsageExtensionKeyword(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildUsageExtensionKeyword(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current != null)
             {
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                 {
-                    OwningMembershipTextualNotationBuilder.BuildPrefixMetadataMember(elementAsOwningMembership, cursorCache, stringBuilder);
+                    OwningMembershipTextualNotationBuilder.BuildPrefixMetadataMember(elementAsOwningMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -178,17 +178,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>UnextendedUsagePrefix:Usage=EndUsagePrefix|BasicUsagePrefix</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildUnextendedUsagePrefix(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildUnextendedUsagePrefix(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage pocoUsageBasicUsagePrefix when pocoUsageBasicUsagePrefix.IsDerived:
-                    BuildBasicUsagePrefix(pocoUsageBasicUsagePrefix, cursorCache, stringBuilder);
+                    BuildBasicUsagePrefix(pocoUsageBasicUsagePrefix, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildEndUsagePrefix(poco, cursorCache, stringBuilder);
+                    BuildEndUsagePrefix(poco, writerContext, stringBuilder);
                     break;
             }
 
@@ -199,15 +199,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>UsagePrefix:Usage=UnextendedUsagePrefixUsageExtensionKeyword*</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildUsagePrefix(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildUsagePrefix(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildUnextendedUsagePrefix(poco, cursorCache, stringBuilder);
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            BuildUnextendedUsagePrefix(poco, writerContext, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership owningMembershipGuard && owningMembershipGuard.OwnedRelatedElement.OfType<SysML2.NET.Core.POCO.Systems.Metadata.IMetadataUsage>().Any())
             {
-                BuildUsageExtensionKeyword(poco, cursorCache, stringBuilder);
+                BuildUsageExtensionKeyword(poco, writerContext, stringBuilder);
             }
 
 
@@ -218,15 +218,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>UsageDeclaration:Usage=IdentificationFeatureSpecializationPart?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildUsageDeclaration(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildUsageDeclaration(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            ElementTextualNotationBuilder.BuildIdentification(poco, cursorCache, stringBuilder);
+            ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
 
             if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
             {
-                FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, writerContext, stringBuilder);
             }
 
         }
@@ -236,16 +236,16 @@ namespace SysML2.NET.TextualNotation
         /// <para>UsageCompletion:Usage=ValuePart?UsageBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildUsageCompletion(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildUsageCompletion(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
             if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
-                FeatureTextualNotationBuilder.BuildValuePart(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }
-            BuildUsageBody(poco, cursorCache, stringBuilder);
+            BuildUsageBody(poco, writerContext, stringBuilder);
 
         }
 
@@ -254,11 +254,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>UsageBody:Usage=DefinitionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildUsageBody(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildUsageBody(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            TypeTextualNotationBuilder.BuildDefinitionBody(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildDefinitionBody(poco, writerContext, stringBuilder);
 
         }
 
@@ -267,32 +267,32 @@ namespace SysML2.NET.TextualNotation
         /// <para>NonOccurrenceUsageElement:Usage=DefaultReferenceUsage|ReferenceUsage|AttributeUsage|EnumerationUsage|BindingConnectorAsUsage|SuccessionAsUsage|ExtendedUsage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildNonOccurrenceUsageElement(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildNonOccurrenceUsageElement(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Systems.Connections.IBindingConnectorAsUsage pocoBindingConnectorAsUsage:
-                    BindingConnectorAsUsageTextualNotationBuilder.BuildBindingConnectorAsUsage(pocoBindingConnectorAsUsage, cursorCache, stringBuilder);
+                    BindingConnectorAsUsageTextualNotationBuilder.BuildBindingConnectorAsUsage(pocoBindingConnectorAsUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Connections.ISuccessionAsUsage pocoSuccessionAsUsage:
-                    SuccessionAsUsageTextualNotationBuilder.BuildSuccessionAsUsage(pocoSuccessionAsUsage, cursorCache, stringBuilder);
+                    SuccessionAsUsageTextualNotationBuilder.BuildSuccessionAsUsage(pocoSuccessionAsUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Enumerations.IEnumerationUsage pocoEnumerationUsage:
-                    EnumerationUsageTextualNotationBuilder.BuildEnumerationUsage(pocoEnumerationUsage, cursorCache, stringBuilder);
+                    EnumerationUsageTextualNotationBuilder.BuildEnumerationUsage(pocoEnumerationUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage pocoReferenceUsageReferenceUsage when pocoReferenceUsageReferenceUsage.IsEnd:
-                    ReferenceUsageTextualNotationBuilder.BuildReferenceUsage(pocoReferenceUsageReferenceUsage, cursorCache, stringBuilder);
+                    ReferenceUsageTextualNotationBuilder.BuildReferenceUsage(pocoReferenceUsageReferenceUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage pocoReferenceUsage:
-                    ReferenceUsageTextualNotationBuilder.BuildDefaultReferenceUsage(pocoReferenceUsage, cursorCache, stringBuilder);
+                    ReferenceUsageTextualNotationBuilder.BuildDefaultReferenceUsage(pocoReferenceUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Attributes.IAttributeUsage pocoAttributeUsage:
-                    AttributeUsageTextualNotationBuilder.BuildAttributeUsage(pocoAttributeUsage, cursorCache, stringBuilder);
+                    AttributeUsageTextualNotationBuilder.BuildAttributeUsage(pocoAttributeUsage, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildExtendedUsage(poco, cursorCache, stringBuilder);
+                    BuildExtendedUsage(poco, writerContext, stringBuilder);
                     break;
             }
 
@@ -303,17 +303,17 @@ namespace SysML2.NET.TextualNotation
         /// <para>OccurrenceUsageElement:Usage=StructureUsageElement|BehaviorUsageElement</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildOccurrenceUsageElement(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildOccurrenceUsageElement(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage pocoUsageStructureUsageElement when pocoUsageStructureUsageElement.IsValidForStructureUsageElement():
-                    BuildStructureUsageElement(pocoUsageStructureUsageElement, cursorCache, stringBuilder);
+                    BuildStructureUsageElement(pocoUsageStructureUsageElement, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildBehaviorUsageElement(poco, cursorCache, stringBuilder);
+                    BuildBehaviorUsageElement(poco, writerContext, stringBuilder);
                     break;
             }
 
@@ -324,56 +324,56 @@ namespace SysML2.NET.TextualNotation
         /// <para>StructureUsageElement:Usage=OccurrenceUsage|IndividualUsage|PortionUsage|EventOccurrenceUsage|ItemUsage|PartUsage|ViewUsage|RenderingUsage|PortUsage|ConnectionUsage|InterfaceUsage|AllocationUsage|Message|FlowUsage|SuccessionFlowUsage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildStructureUsageElement(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildStructureUsageElement(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Systems.Flows.ISuccessionFlowUsage pocoSuccessionFlowUsage:
-                    SuccessionFlowUsageTextualNotationBuilder.BuildSuccessionFlowUsage(pocoSuccessionFlowUsage, cursorCache, stringBuilder);
+                    SuccessionFlowUsageTextualNotationBuilder.BuildSuccessionFlowUsage(pocoSuccessionFlowUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceUsage pocoInterfaceUsage:
-                    InterfaceUsageTextualNotationBuilder.BuildInterfaceUsage(pocoInterfaceUsage, cursorCache, stringBuilder);
+                    InterfaceUsageTextualNotationBuilder.BuildInterfaceUsage(pocoInterfaceUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Allocations.IAllocationUsage pocoAllocationUsage:
-                    AllocationUsageTextualNotationBuilder.BuildAllocationUsage(pocoAllocationUsage, cursorCache, stringBuilder);
+                    AllocationUsageTextualNotationBuilder.BuildAllocationUsage(pocoAllocationUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Flows.IFlowUsage pocoFlowUsageMessage when pocoFlowUsageMessage.IsValidForMessage():
-                    FlowUsageTextualNotationBuilder.BuildMessage(pocoFlowUsageMessage, cursorCache, stringBuilder);
+                    FlowUsageTextualNotationBuilder.BuildMessage(pocoFlowUsageMessage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Flows.IFlowUsage pocoFlowUsage:
-                    FlowUsageTextualNotationBuilder.BuildFlowUsage(pocoFlowUsage, cursorCache, stringBuilder);
+                    FlowUsageTextualNotationBuilder.BuildFlowUsage(pocoFlowUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Connections.IConnectionUsage pocoConnectionUsage:
-                    ConnectionUsageTextualNotationBuilder.BuildConnectionUsage(pocoConnectionUsage, cursorCache, stringBuilder);
+                    ConnectionUsageTextualNotationBuilder.BuildConnectionUsage(pocoConnectionUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Views.IViewUsage pocoViewUsage:
-                    ViewUsageTextualNotationBuilder.BuildViewUsage(pocoViewUsage, cursorCache, stringBuilder);
+                    ViewUsageTextualNotationBuilder.BuildViewUsage(pocoViewUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Views.IRenderingUsage pocoRenderingUsage:
-                    RenderingUsageTextualNotationBuilder.BuildRenderingUsage(pocoRenderingUsage, cursorCache, stringBuilder);
+                    RenderingUsageTextualNotationBuilder.BuildRenderingUsage(pocoRenderingUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Parts.IPartUsage pocoPartUsage:
-                    PartUsageTextualNotationBuilder.BuildPartUsage(pocoPartUsage, cursorCache, stringBuilder);
+                    PartUsageTextualNotationBuilder.BuildPartUsage(pocoPartUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Occurrences.IEventOccurrenceUsage pocoEventOccurrenceUsage:
-                    EventOccurrenceUsageTextualNotationBuilder.BuildEventOccurrenceUsage(pocoEventOccurrenceUsage, cursorCache, stringBuilder);
+                    EventOccurrenceUsageTextualNotationBuilder.BuildEventOccurrenceUsage(pocoEventOccurrenceUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Items.IItemUsage pocoItemUsage:
-                    ItemUsageTextualNotationBuilder.BuildItemUsage(pocoItemUsage, cursorCache, stringBuilder);
+                    ItemUsageTextualNotationBuilder.BuildItemUsage(pocoItemUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Ports.IPortUsage pocoPortUsage:
-                    PortUsageTextualNotationBuilder.BuildPortUsage(pocoPortUsage, cursorCache, stringBuilder);
+                    PortUsageTextualNotationBuilder.BuildPortUsage(pocoPortUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage pocoOccurrenceUsageOccurrenceUsage when pocoOccurrenceUsageOccurrenceUsage.IsValidForOccurrenceUsage():
-                    OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsage(pocoOccurrenceUsageOccurrenceUsage, cursorCache, stringBuilder);
+                    OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsage(pocoOccurrenceUsageOccurrenceUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage pocoOccurrenceUsageIndividualUsage when pocoOccurrenceUsageIndividualUsage.IsValidForIndividualUsage():
-                    OccurrenceUsageTextualNotationBuilder.BuildIndividualUsage(pocoOccurrenceUsageIndividualUsage, cursorCache, stringBuilder);
+                    OccurrenceUsageTextualNotationBuilder.BuildIndividualUsage(pocoOccurrenceUsageIndividualUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage pocoOccurrenceUsage:
-                    OccurrenceUsageTextualNotationBuilder.BuildPortionUsage(pocoOccurrenceUsage, cursorCache, stringBuilder);
+                    OccurrenceUsageTextualNotationBuilder.BuildPortionUsage(pocoOccurrenceUsage, writerContext, stringBuilder);
                     break;
             }
 
@@ -384,59 +384,59 @@ namespace SysML2.NET.TextualNotation
         /// <para>BehaviorUsageElement:Usage=ActionUsage|CalculationUsage|StateUsage|ConstraintUsage|RequirementUsage|ConcernUsage|CaseUsage|AnalysisCaseUsage|VerificationCaseUsage|UseCaseUsage|ViewpointUsage|PerformActionUsage|ExhibitStateUsage|IncludeUseCaseUsage|AssertConstraintUsage|SatisfyRequirementUsage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildBehaviorUsageElement(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildBehaviorUsageElement(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Systems.UseCases.IIncludeUseCaseUsage pocoIncludeUseCaseUsage:
-                    IncludeUseCaseUsageTextualNotationBuilder.BuildIncludeUseCaseUsage(pocoIncludeUseCaseUsage, cursorCache, stringBuilder);
+                    IncludeUseCaseUsageTextualNotationBuilder.BuildIncludeUseCaseUsage(pocoIncludeUseCaseUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Requirements.ISatisfyRequirementUsage pocoSatisfyRequirementUsage:
-                    SatisfyRequirementUsageTextualNotationBuilder.BuildSatisfyRequirementUsage(pocoSatisfyRequirementUsage, cursorCache, stringBuilder);
+                    SatisfyRequirementUsageTextualNotationBuilder.BuildSatisfyRequirementUsage(pocoSatisfyRequirementUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Requirements.IConcernUsage pocoConcernUsage:
-                    ConcernUsageTextualNotationBuilder.BuildConcernUsage(pocoConcernUsage, cursorCache, stringBuilder);
+                    ConcernUsageTextualNotationBuilder.BuildConcernUsage(pocoConcernUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.AnalysisCases.IAnalysisCaseUsage pocoAnalysisCaseUsage:
-                    AnalysisCaseUsageTextualNotationBuilder.BuildAnalysisCaseUsage(pocoAnalysisCaseUsage, cursorCache, stringBuilder);
+                    AnalysisCaseUsageTextualNotationBuilder.BuildAnalysisCaseUsage(pocoAnalysisCaseUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.VerificationCases.IVerificationCaseUsage pocoVerificationCaseUsage:
-                    VerificationCaseUsageTextualNotationBuilder.BuildVerificationCaseUsage(pocoVerificationCaseUsage, cursorCache, stringBuilder);
+                    VerificationCaseUsageTextualNotationBuilder.BuildVerificationCaseUsage(pocoVerificationCaseUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.UseCases.IUseCaseUsage pocoUseCaseUsage:
-                    UseCaseUsageTextualNotationBuilder.BuildUseCaseUsage(pocoUseCaseUsage, cursorCache, stringBuilder);
+                    UseCaseUsageTextualNotationBuilder.BuildUseCaseUsage(pocoUseCaseUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Views.IViewpointUsage pocoViewpointUsage:
-                    ViewpointUsageTextualNotationBuilder.BuildViewpointUsage(pocoViewpointUsage, cursorCache, stringBuilder);
+                    ViewpointUsageTextualNotationBuilder.BuildViewpointUsage(pocoViewpointUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.States.IExhibitStateUsage pocoExhibitStateUsage:
-                    ExhibitStateUsageTextualNotationBuilder.BuildExhibitStateUsage(pocoExhibitStateUsage, cursorCache, stringBuilder);
+                    ExhibitStateUsageTextualNotationBuilder.BuildExhibitStateUsage(pocoExhibitStateUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Constraints.IAssertConstraintUsage pocoAssertConstraintUsage:
-                    AssertConstraintUsageTextualNotationBuilder.BuildAssertConstraintUsage(pocoAssertConstraintUsage, cursorCache, stringBuilder);
+                    AssertConstraintUsageTextualNotationBuilder.BuildAssertConstraintUsage(pocoAssertConstraintUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Requirements.IRequirementUsage pocoRequirementUsage:
-                    RequirementUsageTextualNotationBuilder.BuildRequirementUsage(pocoRequirementUsage, cursorCache, stringBuilder);
+                    RequirementUsageTextualNotationBuilder.BuildRequirementUsage(pocoRequirementUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Cases.ICaseUsage pocoCaseUsage:
-                    CaseUsageTextualNotationBuilder.BuildCaseUsage(pocoCaseUsage, cursorCache, stringBuilder);
+                    CaseUsageTextualNotationBuilder.BuildCaseUsage(pocoCaseUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Calculations.ICalculationUsage pocoCalculationUsage:
-                    CalculationUsageTextualNotationBuilder.BuildCalculationUsage(pocoCalculationUsage, cursorCache, stringBuilder);
+                    CalculationUsageTextualNotationBuilder.BuildCalculationUsage(pocoCalculationUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Constraints.IConstraintUsage pocoConstraintUsage:
-                    ConstraintUsageTextualNotationBuilder.BuildConstraintUsage(pocoConstraintUsage, cursorCache, stringBuilder);
+                    ConstraintUsageTextualNotationBuilder.BuildConstraintUsage(pocoConstraintUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Actions.IPerformActionUsage pocoPerformActionUsage:
-                    PerformActionUsageTextualNotationBuilder.BuildPerformActionUsage(pocoPerformActionUsage, cursorCache, stringBuilder);
+                    PerformActionUsageTextualNotationBuilder.BuildPerformActionUsage(pocoPerformActionUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.States.IStateUsage pocoStateUsage:
-                    StateUsageTextualNotationBuilder.BuildStateUsage(pocoStateUsage, cursorCache, stringBuilder);
+                    StateUsageTextualNotationBuilder.BuildStateUsage(pocoStateUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Actions.IActionUsage pocoActionUsage:
-                    ActionUsageTextualNotationBuilder.BuildActionUsage(pocoActionUsage, cursorCache, stringBuilder);
+                    ActionUsageTextualNotationBuilder.BuildActionUsage(pocoActionUsage, writerContext, stringBuilder);
                     break;
             }
 
@@ -447,74 +447,74 @@ namespace SysML2.NET.TextualNotation
         /// <para>VariantUsageElement:Usage=VariantReference|ReferenceUsage|AttributeUsage|BindingConnectorAsUsage|SuccessionAsUsage|OccurrenceUsage|IndividualUsage|PortionUsage|EventOccurrenceUsage|ItemUsage|PartUsage|ViewUsage|RenderingUsage|PortUsage|ConnectionUsage|InterfaceUsage|AllocationUsage|Message|FlowUsage|SuccessionFlowUsage|BehaviorUsageElement</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildVariantUsageElement(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildVariantUsageElement(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Systems.Flows.ISuccessionFlowUsage pocoSuccessionFlowUsage:
-                    SuccessionFlowUsageTextualNotationBuilder.BuildSuccessionFlowUsage(pocoSuccessionFlowUsage, cursorCache, stringBuilder);
+                    SuccessionFlowUsageTextualNotationBuilder.BuildSuccessionFlowUsage(pocoSuccessionFlowUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceUsage pocoInterfaceUsage:
-                    InterfaceUsageTextualNotationBuilder.BuildInterfaceUsage(pocoInterfaceUsage, cursorCache, stringBuilder);
+                    InterfaceUsageTextualNotationBuilder.BuildInterfaceUsage(pocoInterfaceUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Allocations.IAllocationUsage pocoAllocationUsage:
-                    AllocationUsageTextualNotationBuilder.BuildAllocationUsage(pocoAllocationUsage, cursorCache, stringBuilder);
+                    AllocationUsageTextualNotationBuilder.BuildAllocationUsage(pocoAllocationUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Flows.IFlowUsage pocoFlowUsageFlowUsage when pocoFlowUsageFlowUsage.IsValidForFlowUsage():
-                    FlowUsageTextualNotationBuilder.BuildFlowUsage(pocoFlowUsageFlowUsage, cursorCache, stringBuilder);
+                    FlowUsageTextualNotationBuilder.BuildFlowUsage(pocoFlowUsageFlowUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Flows.IFlowUsage pocoFlowUsage:
-                    FlowUsageTextualNotationBuilder.BuildMessage(pocoFlowUsage, cursorCache, stringBuilder);
+                    FlowUsageTextualNotationBuilder.BuildMessage(pocoFlowUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Connections.IConnectionUsage pocoConnectionUsage:
-                    ConnectionUsageTextualNotationBuilder.BuildConnectionUsage(pocoConnectionUsage, cursorCache, stringBuilder);
+                    ConnectionUsageTextualNotationBuilder.BuildConnectionUsage(pocoConnectionUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Connections.IBindingConnectorAsUsage pocoBindingConnectorAsUsage:
-                    BindingConnectorAsUsageTextualNotationBuilder.BuildBindingConnectorAsUsage(pocoBindingConnectorAsUsage, cursorCache, stringBuilder);
+                    BindingConnectorAsUsageTextualNotationBuilder.BuildBindingConnectorAsUsage(pocoBindingConnectorAsUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Connections.ISuccessionAsUsage pocoSuccessionAsUsage:
-                    SuccessionAsUsageTextualNotationBuilder.BuildSuccessionAsUsage(pocoSuccessionAsUsage, cursorCache, stringBuilder);
+                    SuccessionAsUsageTextualNotationBuilder.BuildSuccessionAsUsage(pocoSuccessionAsUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Views.IViewUsage pocoViewUsage:
-                    ViewUsageTextualNotationBuilder.BuildViewUsage(pocoViewUsage, cursorCache, stringBuilder);
+                    ViewUsageTextualNotationBuilder.BuildViewUsage(pocoViewUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Views.IRenderingUsage pocoRenderingUsage:
-                    RenderingUsageTextualNotationBuilder.BuildRenderingUsage(pocoRenderingUsage, cursorCache, stringBuilder);
+                    RenderingUsageTextualNotationBuilder.BuildRenderingUsage(pocoRenderingUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Parts.IPartUsage pocoPartUsage:
-                    PartUsageTextualNotationBuilder.BuildPartUsage(pocoPartUsage, cursorCache, stringBuilder);
+                    PartUsageTextualNotationBuilder.BuildPartUsage(pocoPartUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Occurrences.IEventOccurrenceUsage pocoEventOccurrenceUsage:
-                    EventOccurrenceUsageTextualNotationBuilder.BuildEventOccurrenceUsage(pocoEventOccurrenceUsage, cursorCache, stringBuilder);
+                    EventOccurrenceUsageTextualNotationBuilder.BuildEventOccurrenceUsage(pocoEventOccurrenceUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Items.IItemUsage pocoItemUsage:
-                    ItemUsageTextualNotationBuilder.BuildItemUsage(pocoItemUsage, cursorCache, stringBuilder);
+                    ItemUsageTextualNotationBuilder.BuildItemUsage(pocoItemUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Ports.IPortUsage pocoPortUsage:
-                    PortUsageTextualNotationBuilder.BuildPortUsage(pocoPortUsage, cursorCache, stringBuilder);
+                    PortUsageTextualNotationBuilder.BuildPortUsage(pocoPortUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage pocoReferenceUsageReferenceUsage when pocoReferenceUsageReferenceUsage.IsEnd:
-                    ReferenceUsageTextualNotationBuilder.BuildReferenceUsage(pocoReferenceUsageReferenceUsage, cursorCache, stringBuilder);
+                    ReferenceUsageTextualNotationBuilder.BuildReferenceUsage(pocoReferenceUsageReferenceUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage pocoReferenceUsage:
-                    ReferenceUsageTextualNotationBuilder.BuildVariantReference(pocoReferenceUsage, cursorCache, stringBuilder);
+                    ReferenceUsageTextualNotationBuilder.BuildVariantReference(pocoReferenceUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Attributes.IAttributeUsage pocoAttributeUsage:
-                    AttributeUsageTextualNotationBuilder.BuildAttributeUsage(pocoAttributeUsage, cursorCache, stringBuilder);
+                    AttributeUsageTextualNotationBuilder.BuildAttributeUsage(pocoAttributeUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage pocoOccurrenceUsageIndividualUsage when pocoOccurrenceUsageIndividualUsage.IsValidForIndividualUsage():
-                    OccurrenceUsageTextualNotationBuilder.BuildIndividualUsage(pocoOccurrenceUsageIndividualUsage, cursorCache, stringBuilder);
+                    OccurrenceUsageTextualNotationBuilder.BuildIndividualUsage(pocoOccurrenceUsageIndividualUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage pocoOccurrenceUsageOccurrenceUsage when pocoOccurrenceUsageOccurrenceUsage.IsValidForOccurrenceUsage():
-                    OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsage(pocoOccurrenceUsageOccurrenceUsage, cursorCache, stringBuilder);
+                    OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsage(pocoOccurrenceUsageOccurrenceUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage pocoOccurrenceUsage:
-                    OccurrenceUsageTextualNotationBuilder.BuildPortionUsage(pocoOccurrenceUsage, cursorCache, stringBuilder);
+                    OccurrenceUsageTextualNotationBuilder.BuildPortionUsage(pocoOccurrenceUsage, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildBehaviorUsageElement(poco, cursorCache, stringBuilder);
+                    BuildBehaviorUsageElement(poco, writerContext, stringBuilder);
                     break;
             }
 
@@ -525,26 +525,26 @@ namespace SysML2.NET.TextualNotation
         /// <para>InterfaceNonOccurrenceUsageElement:Usage=ReferenceUsage|AttributeUsage|EnumerationUsage|BindingConnectorAsUsage|SuccessionAsUsage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildInterfaceNonOccurrenceUsageElement(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildInterfaceNonOccurrenceUsageElement(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Systems.Connections.IBindingConnectorAsUsage pocoBindingConnectorAsUsage:
-                    BindingConnectorAsUsageTextualNotationBuilder.BuildBindingConnectorAsUsage(pocoBindingConnectorAsUsage, cursorCache, stringBuilder);
+                    BindingConnectorAsUsageTextualNotationBuilder.BuildBindingConnectorAsUsage(pocoBindingConnectorAsUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Connections.ISuccessionAsUsage pocoSuccessionAsUsage:
-                    SuccessionAsUsageTextualNotationBuilder.BuildSuccessionAsUsage(pocoSuccessionAsUsage, cursorCache, stringBuilder);
+                    SuccessionAsUsageTextualNotationBuilder.BuildSuccessionAsUsage(pocoSuccessionAsUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Enumerations.IEnumerationUsage pocoEnumerationUsage:
-                    EnumerationUsageTextualNotationBuilder.BuildEnumerationUsage(pocoEnumerationUsage, cursorCache, stringBuilder);
+                    EnumerationUsageTextualNotationBuilder.BuildEnumerationUsage(pocoEnumerationUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage pocoReferenceUsage:
-                    ReferenceUsageTextualNotationBuilder.BuildReferenceUsage(pocoReferenceUsage, cursorCache, stringBuilder);
+                    ReferenceUsageTextualNotationBuilder.BuildReferenceUsage(pocoReferenceUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Attributes.IAttributeUsage pocoAttributeUsage:
-                    AttributeUsageTextualNotationBuilder.BuildAttributeUsage(pocoAttributeUsage, cursorCache, stringBuilder);
+                    AttributeUsageTextualNotationBuilder.BuildAttributeUsage(pocoAttributeUsage, writerContext, stringBuilder);
                     break;
             }
 
@@ -555,20 +555,20 @@ namespace SysML2.NET.TextualNotation
         /// <para>InterfaceOccurrenceUsageElement:Usage=DefaultInterfaceEnd|StructureUsageElement|BehaviorUsageElement</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildInterfaceOccurrenceUsageElement(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildInterfaceOccurrenceUsageElement(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Systems.Ports.IPortUsage pocoPortUsage:
-                    PortUsageTextualNotationBuilder.BuildDefaultInterfaceEnd(pocoPortUsage, cursorCache, stringBuilder);
+                    PortUsageTextualNotationBuilder.BuildDefaultInterfaceEnd(pocoPortUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage pocoUsageStructureUsageElement when pocoUsageStructureUsageElement.IsValidForStructureUsageElement():
-                    BuildStructureUsageElement(pocoUsageStructureUsageElement, cursorCache, stringBuilder);
+                    BuildStructureUsageElement(pocoUsageStructureUsageElement, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildBehaviorUsageElement(poco, cursorCache, stringBuilder);
+                    BuildBehaviorUsageElement(poco, writerContext, stringBuilder);
                     break;
             }
 
@@ -579,25 +579,25 @@ namespace SysML2.NET.TextualNotation
         /// <para>ActionTargetSuccession:Usage=(TargetSuccession|GuardedTargetSuccession|DefaultTargetSuccession)UsageBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildActionTargetSuccession(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildActionTargetSuccession(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Systems.Connections.ISuccessionAsUsage pocoSuccessionAsUsage:
-                    SuccessionAsUsageTextualNotationBuilder.BuildTargetSuccession(pocoSuccessionAsUsage, cursorCache, stringBuilder);
+                    SuccessionAsUsageTextualNotationBuilder.BuildTargetSuccession(pocoSuccessionAsUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.States.ITransitionUsage pocoTransitionUsageGuardedTargetSuccession when pocoTransitionUsageGuardedTargetSuccession.IsValidForGuardedTargetSuccession():
-                    TransitionUsageTextualNotationBuilder.BuildGuardedTargetSuccession(pocoTransitionUsageGuardedTargetSuccession, cursorCache, stringBuilder);
+                    TransitionUsageTextualNotationBuilder.BuildGuardedTargetSuccession(pocoTransitionUsageGuardedTargetSuccession, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.States.ITransitionUsage pocoTransitionUsage:
-                    TransitionUsageTextualNotationBuilder.BuildDefaultTargetSuccession(pocoTransitionUsage, cursorCache, stringBuilder);
+                    TransitionUsageTextualNotationBuilder.BuildDefaultTargetSuccession(pocoTransitionUsage, writerContext, stringBuilder);
                     break;
             }
 
             stringBuilder.Append(' ');
-            BuildUsageBody(poco, cursorCache, stringBuilder);
+            BuildUsageBody(poco, writerContext, stringBuilder);
 
         }
 
@@ -606,18 +606,18 @@ namespace SysML2.NET.TextualNotation
         /// <para>ExtendedUsage:Usage=UnextendedUsagePrefixUsageExtensionKeyword+Usage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildExtendedUsage(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildExtendedUsage(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildUnextendedUsagePrefix(poco, cursorCache, stringBuilder);
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            BuildUnextendedUsagePrefix(poco, writerContext, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership)
             {
-                BuildUsageExtensionKeyword(poco, cursorCache, stringBuilder);
+                BuildUsageExtensionKeyword(poco, writerContext, stringBuilder);
             }
 
-            BuildUsage(poco, cursorCache, stringBuilder);
+            BuildUsage(poco, writerContext, stringBuilder);
 
         }
 
@@ -626,12 +626,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>Usage=UsageDeclarationUsageCompletion</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildUsage(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildUsage(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildUsageDeclaration(poco, cursorCache, stringBuilder);
-            BuildUsageCompletion(poco, cursorCache, stringBuilder);
+            BuildUsageDeclaration(poco, writerContext, stringBuilder);
+            BuildUsageCompletion(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/UsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/UsageTextualNotationBuilder.cs
@@ -309,7 +309,7 @@ namespace SysML2.NET.TextualNotation
         {
             switch (poco)
             {
-                case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage pocoUsageStructureUsageElement when pocoUsageStructureUsageElement.IsValidForStructureUsageElement():
+                case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage pocoUsageStructureUsageElement when pocoUsageStructureUsageElement.IsValidForStructureUsageElement(writerContext):
                     BuildStructureUsageElement(pocoUsageStructureUsageElement, writerContext, stringBuilder);
                     break;
                 default:
@@ -339,7 +339,7 @@ namespace SysML2.NET.TextualNotation
                 case SysML2.NET.Core.POCO.Systems.Allocations.IAllocationUsage pocoAllocationUsage:
                     AllocationUsageTextualNotationBuilder.BuildAllocationUsage(pocoAllocationUsage, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Systems.Flows.IFlowUsage pocoFlowUsageMessage when pocoFlowUsageMessage.IsValidForMessage():
+                case SysML2.NET.Core.POCO.Systems.Flows.IFlowUsage pocoFlowUsageMessage when pocoFlowUsageMessage.IsValidForMessage(writerContext):
                     FlowUsageTextualNotationBuilder.BuildMessage(pocoFlowUsageMessage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Flows.IFlowUsage pocoFlowUsage:
@@ -366,10 +366,10 @@ namespace SysML2.NET.TextualNotation
                 case SysML2.NET.Core.POCO.Systems.Ports.IPortUsage pocoPortUsage:
                     PortUsageTextualNotationBuilder.BuildPortUsage(pocoPortUsage, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage pocoOccurrenceUsageOccurrenceUsage when pocoOccurrenceUsageOccurrenceUsage.IsValidForOccurrenceUsage():
+                case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage pocoOccurrenceUsageOccurrenceUsage when pocoOccurrenceUsageOccurrenceUsage.IsValidForOccurrenceUsage(writerContext):
                     OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsage(pocoOccurrenceUsageOccurrenceUsage, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage pocoOccurrenceUsageIndividualUsage when pocoOccurrenceUsageIndividualUsage.IsValidForIndividualUsage():
+                case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage pocoOccurrenceUsageIndividualUsage when pocoOccurrenceUsageIndividualUsage.IsValidForIndividualUsage(writerContext):
                     OccurrenceUsageTextualNotationBuilder.BuildIndividualUsage(pocoOccurrenceUsageIndividualUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage pocoOccurrenceUsage:
@@ -462,7 +462,7 @@ namespace SysML2.NET.TextualNotation
                 case SysML2.NET.Core.POCO.Systems.Allocations.IAllocationUsage pocoAllocationUsage:
                     AllocationUsageTextualNotationBuilder.BuildAllocationUsage(pocoAllocationUsage, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Systems.Flows.IFlowUsage pocoFlowUsageFlowUsage when pocoFlowUsageFlowUsage.IsValidForFlowUsage():
+                case SysML2.NET.Core.POCO.Systems.Flows.IFlowUsage pocoFlowUsageFlowUsage when pocoFlowUsageFlowUsage.IsValidForFlowUsage(writerContext):
                     FlowUsageTextualNotationBuilder.BuildFlowUsage(pocoFlowUsageFlowUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Flows.IFlowUsage pocoFlowUsage:
@@ -504,10 +504,10 @@ namespace SysML2.NET.TextualNotation
                 case SysML2.NET.Core.POCO.Systems.Attributes.IAttributeUsage pocoAttributeUsage:
                     AttributeUsageTextualNotationBuilder.BuildAttributeUsage(pocoAttributeUsage, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage pocoOccurrenceUsageIndividualUsage when pocoOccurrenceUsageIndividualUsage.IsValidForIndividualUsage():
+                case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage pocoOccurrenceUsageIndividualUsage when pocoOccurrenceUsageIndividualUsage.IsValidForIndividualUsage(writerContext):
                     OccurrenceUsageTextualNotationBuilder.BuildIndividualUsage(pocoOccurrenceUsageIndividualUsage, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage pocoOccurrenceUsageOccurrenceUsage when pocoOccurrenceUsageOccurrenceUsage.IsValidForOccurrenceUsage():
+                case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage pocoOccurrenceUsageOccurrenceUsage when pocoOccurrenceUsageOccurrenceUsage.IsValidForOccurrenceUsage(writerContext):
                     OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsage(pocoOccurrenceUsageOccurrenceUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage pocoOccurrenceUsage:
@@ -564,7 +564,7 @@ namespace SysML2.NET.TextualNotation
                 case SysML2.NET.Core.POCO.Systems.Ports.IPortUsage pocoPortUsage:
                     PortUsageTextualNotationBuilder.BuildDefaultInterfaceEnd(pocoPortUsage, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage pocoUsageStructureUsageElement when pocoUsageStructureUsageElement.IsValidForStructureUsageElement():
+                case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage pocoUsageStructureUsageElement when pocoUsageStructureUsageElement.IsValidForStructureUsageElement(writerContext):
                     BuildStructureUsageElement(pocoUsageStructureUsageElement, writerContext, stringBuilder);
                     break;
                 default:
@@ -588,7 +588,7 @@ namespace SysML2.NET.TextualNotation
                 case SysML2.NET.Core.POCO.Systems.Connections.ISuccessionAsUsage pocoSuccessionAsUsage:
                     SuccessionAsUsageTextualNotationBuilder.BuildTargetSuccession(pocoSuccessionAsUsage, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Systems.States.ITransitionUsage pocoTransitionUsageGuardedTargetSuccession when pocoTransitionUsageGuardedTargetSuccession.IsValidForGuardedTargetSuccession():
+                case SysML2.NET.Core.POCO.Systems.States.ITransitionUsage pocoTransitionUsageGuardedTargetSuccession when pocoTransitionUsageGuardedTargetSuccession.IsValidForGuardedTargetSuccession(writerContext):
                     TransitionUsageTextualNotationBuilder.BuildGuardedTargetSuccession(pocoTransitionUsageGuardedTargetSuccession, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.States.ITransitionUsage pocoTransitionUsage:

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/UseCaseDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/UseCaseDefinitionTextualNotationBuilder.cs
@@ -39,16 +39,16 @@ namespace SysML2.NET.TextualNotation
         /// <para>UseCaseDefinition=OccurrenceDefinitionPrefix'use''case''def'DefinitionDeclarationCaseBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.UseCases.IUseCaseDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildUseCaseDefinition(SysML2.NET.Core.POCO.Systems.UseCases.IUseCaseDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildUseCaseDefinition(SysML2.NET.Core.POCO.Systems.UseCases.IUseCaseDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, cursorCache, stringBuilder);
+            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("use ");
             stringBuilder.Append("case ");
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildCaseBody(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildCaseBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/UseCaseUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/UseCaseUsageTextualNotationBuilder.cs
@@ -39,21 +39,21 @@ namespace SysML2.NET.TextualNotation
         /// <para>UseCaseUsage=OccurrenceUsagePrefix'use''case'ConstraintUsageDeclarationCaseBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.UseCases.IUseCaseUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildUseCaseUsage(SysML2.NET.Core.POCO.Systems.UseCases.IUseCaseUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildUseCaseUsage(SysML2.NET.Core.POCO.Systems.UseCases.IUseCaseUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("use ");
             stringBuilder.Append("case ");
-            UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
 
             if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
-                FeatureTextualNotationBuilder.BuildValuePart(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }
 
-            TypeTextualNotationBuilder.BuildCaseBody(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildCaseBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/VariantMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/VariantMembershipTextualNotationBuilder.cs
@@ -39,16 +39,16 @@ namespace SysML2.NET.TextualNotation
         /// <para>VariantUsageMember:VariantMembership=MemberPrefix'variant'ownedVariantUsage=VariantUsageElement</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IVariantMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildVariantUsageMember(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IVariantMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildVariantUsageMember(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IVariantMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("variant ");
 
             if (poco.ownedVariantUsage != null)
             {
-                UsageTextualNotationBuilder.BuildVariantUsageElement(poco.ownedVariantUsage, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildVariantUsageElement(poco.ownedVariantUsage, writerContext, stringBuilder);
             }
 
         }
@@ -58,19 +58,19 @@ namespace SysML2.NET.TextualNotation
         /// <para>EnumerationUsageMember:VariantMembership=MemberPrefixownedRelatedElement+=EnumeratedValue</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IVariantMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildEnumerationUsageMember(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IVariantMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildEnumerationUsageMember(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IVariantMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
 
             if (ownedRelatedElementCursor.Current != null)
             {
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Enumerations.IEnumerationUsage elementAsEnumerationUsage)
                 {
-                    EnumerationUsageTextualNotationBuilder.BuildEnumeratedValue(elementAsEnumerationUsage, cursorCache, stringBuilder);
+                    EnumerationUsageTextualNotationBuilder.BuildEnumeratedValue(elementAsEnumerationUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/VerificationCaseDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/VerificationCaseDefinitionTextualNotationBuilder.cs
@@ -39,15 +39,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>VerificationCaseDefinition=OccurrenceDefinitionPrefix'verification''def'DefinitionDeclarationCaseBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.VerificationCases.IVerificationCaseDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildVerificationCaseDefinition(SysML2.NET.Core.POCO.Systems.VerificationCases.IVerificationCaseDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildVerificationCaseDefinition(SysML2.NET.Core.POCO.Systems.VerificationCases.IVerificationCaseDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, cursorCache, stringBuilder);
+            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("verification ");
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildCaseBody(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildCaseBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/VerificationCaseUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/VerificationCaseUsageTextualNotationBuilder.cs
@@ -39,20 +39,20 @@ namespace SysML2.NET.TextualNotation
         /// <para>VerificationCaseUsage=OccurrenceUsagePrefix'verification'ConstraintUsageDeclarationCaseBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.VerificationCases.IVerificationCaseUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildVerificationCaseUsage(SysML2.NET.Core.POCO.Systems.VerificationCases.IVerificationCaseUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildVerificationCaseUsage(SysML2.NET.Core.POCO.Systems.VerificationCases.IVerificationCaseUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("verification ");
-            UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
+            UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
 
             if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
-                FeatureTextualNotationBuilder.BuildValuePart(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }
 
-            TypeTextualNotationBuilder.BuildCaseBody(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildCaseBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ViewDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ViewDefinitionTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>ViewDefinitionBody:ViewDefinition=';'|'{'ViewDefinitionBodyItem*'}'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.IViewDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildViewDefinitionBody(SysML2.NET.Core.POCO.Systems.Views.IViewDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildViewDefinitionBody(SysML2.NET.Core.POCO.Systems.Views.IViewDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            if (cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
+            if (writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
             {
                 stringBuilder.AppendLine(";");
             }
@@ -51,10 +51,10 @@ namespace SysML2.NET.TextualNotation
             {
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
-                var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 while (ownedRelationshipCursor.Current != null)
                 {
-                    BuildViewDefinitionBodyItem(poco, cursorCache, stringBuilder);
+                    BuildViewDefinitionBodyItem(poco, writerContext, stringBuilder);
                 }
                 stringBuilder.AppendLine("}");
             }
@@ -66,24 +66,24 @@ namespace SysML2.NET.TextualNotation
         /// <para>ViewDefinitionBodyItem:ViewDefinition=DefinitionBodyItem|ownedRelationship+=ElementFilterMember|ownedRelationship+=ViewRenderingMember</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.IViewDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildViewDefinitionBodyItem(SysML2.NET.Core.POCO.Systems.Views.IViewDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildViewDefinitionBodyItem(SysML2.NET.Core.POCO.Systems.Views.IViewDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.Views.IViewRenderingMembership viewRenderingMembership)
             {
-                ViewRenderingMembershipTextualNotationBuilder.BuildViewRenderingMember(viewRenderingMembership, cursorCache, stringBuilder);
+                ViewRenderingMembershipTextualNotationBuilder.BuildViewRenderingMember(viewRenderingMembership, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
             }
             else if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Packages.IElementFilterMembership elementFilterMembership)
             {
-                ElementFilterMembershipTextualNotationBuilder.BuildElementFilterMember(elementFilterMembership, cursorCache, stringBuilder);
+                ElementFilterMembershipTextualNotationBuilder.BuildElementFilterMember(elementFilterMembership, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
             }
             else
             {
-                TypeTextualNotationBuilder.BuildDefinitionBodyItem(poco, cursorCache, stringBuilder);
+                TypeTextualNotationBuilder.BuildDefinitionBodyItem(poco, writerContext, stringBuilder);
             }
 
         }
@@ -93,15 +93,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>ViewDefinition=OccurrenceDefinitionPrefix'view''def'DefinitionDeclarationViewDefinitionBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.IViewDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildViewDefinition(SysML2.NET.Core.POCO.Systems.Views.IViewDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildViewDefinition(SysML2.NET.Core.POCO.Systems.Views.IViewDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, cursorCache, stringBuilder);
+            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("view ");
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, cursorCache, stringBuilder);
-            BuildViewDefinitionBody(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, writerContext, stringBuilder);
+            BuildViewDefinitionBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ViewRenderingMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ViewRenderingMembershipTextualNotationBuilder.cs
@@ -39,12 +39,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>ViewRenderingMember:ViewRenderingMembership=MemberPrefix'render'ownedRelatedElement+=ViewRenderingUsage</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.IViewRenderingMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildViewRenderingMember(SysML2.NET.Core.POCO.Systems.Views.IViewRenderingMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildViewRenderingMember(SysML2.NET.Core.POCO.Systems.Views.IViewRenderingMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
-            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, cursorCache, stringBuilder);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("render ");
 
             if (ownedRelatedElementCursor.Current != null)
@@ -52,7 +52,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Views.IRenderingUsage elementAsRenderingUsage)
                 {
-                    RenderingUsageTextualNotationBuilder.BuildViewRenderingUsage(elementAsRenderingUsage, cursorCache, stringBuilder);
+                    RenderingUsageTextualNotationBuilder.BuildViewRenderingUsage(elementAsRenderingUsage, writerContext, stringBuilder);
                 }
             }
             ownedRelatedElementCursor.Move();

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ViewUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ViewUsageTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <para>ViewBody:ViewUsage=';'|'{'ViewBodyItem*'}'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.IViewUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildViewBody(SysML2.NET.Core.POCO.Systems.Views.IViewUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildViewBody(SysML2.NET.Core.POCO.Systems.Views.IViewUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            if (cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
+            if (writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship).Current == null)
             {
                 stringBuilder.AppendLine(";");
             }
@@ -51,10 +51,10 @@ namespace SysML2.NET.TextualNotation
             {
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
-                var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 while (ownedRelationshipCursor.Current != null)
                 {
-                    BuildViewBodyItem(poco, cursorCache, stringBuilder);
+                    BuildViewBodyItem(poco, writerContext, stringBuilder);
                 }
                 stringBuilder.AppendLine("}");
             }
@@ -66,29 +66,29 @@ namespace SysML2.NET.TextualNotation
         /// <para>ViewBodyItem:ViewUsage=DefinitionBodyItem|ownedRelationship+=ElementFilterMember|ownedRelationship+=ViewRenderingMember|ownedRelationship+=Expose</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.IViewUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildViewBodyItem(SysML2.NET.Core.POCO.Systems.Views.IViewUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildViewBodyItem(SysML2.NET.Core.POCO.Systems.Views.IViewUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.Views.IViewRenderingMembership viewRenderingMembership)
             {
-                ViewRenderingMembershipTextualNotationBuilder.BuildViewRenderingMember(viewRenderingMembership, cursorCache, stringBuilder);
+                ViewRenderingMembershipTextualNotationBuilder.BuildViewRenderingMember(viewRenderingMembership, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
             }
             else if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Packages.IElementFilterMembership elementFilterMembership)
             {
-                ElementFilterMembershipTextualNotationBuilder.BuildElementFilterMember(elementFilterMembership, cursorCache, stringBuilder);
+                ElementFilterMembershipTextualNotationBuilder.BuildElementFilterMember(elementFilterMembership, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
             }
             else if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.Views.IExpose expose)
             {
-                ExposeTextualNotationBuilder.BuildExpose(expose, cursorCache, stringBuilder);
+                ExposeTextualNotationBuilder.BuildExpose(expose, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
             }
             else
             {
-                TypeTextualNotationBuilder.BuildDefinitionBodyItem(poco, cursorCache, stringBuilder);
+                TypeTextualNotationBuilder.BuildDefinitionBodyItem(poco, writerContext, stringBuilder);
             }
 
         }
@@ -98,23 +98,23 @@ namespace SysML2.NET.TextualNotation
         /// <para>ViewUsage=OccurrenceUsagePrefix'view'UsageDeclaration?ValuePart?ViewBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.IViewUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildViewUsage(SysML2.NET.Core.POCO.Systems.Views.IViewUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildViewUsage(SysML2.NET.Core.POCO.Systems.Views.IViewUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("view ");
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
             {
-                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
             }
 
             if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
             {
-                FeatureTextualNotationBuilder.BuildValuePart(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }
-            BuildViewBody(poco, cursorCache, stringBuilder);
+            BuildViewBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ViewpointDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ViewpointDefinitionTextualNotationBuilder.cs
@@ -39,15 +39,15 @@ namespace SysML2.NET.TextualNotation
         /// <para>ViewpointDefinition=OccurrenceDefinitionPrefix'viewpoint''def'DefinitionDeclarationRequirementBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.IViewpointDefinition" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildViewpointDefinition(SysML2.NET.Core.POCO.Systems.Views.IViewpointDefinition poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildViewpointDefinition(SysML2.NET.Core.POCO.Systems.Views.IViewpointDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, cursorCache, stringBuilder);
+            OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinitionPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("viewpoint ");
             stringBuilder.Append("def ");
-            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildRequirementBody(poco, cursorCache, stringBuilder);
+            DefinitionTextualNotationBuilder.BuildDefinitionDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildRequirementBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ViewpointUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/ViewpointUsageTextualNotationBuilder.cs
@@ -39,14 +39,14 @@ namespace SysML2.NET.TextualNotation
         /// <para>ViewpointUsage=OccurrenceUsagePrefix'viewpoint'ConstraintUsageDeclarationRequirementBody</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Views.IViewpointUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildViewpointUsage(SysML2.NET.Core.POCO.Systems.Views.IViewpointUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildViewpointUsage(SysML2.NET.Core.POCO.Systems.Views.IViewpointUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, cursorCache, stringBuilder);
+            OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("viewpoint ");
-            ConstraintUsageTextualNotationBuilder.BuildConstraintUsageDeclaration(poco, cursorCache, stringBuilder);
-            TypeTextualNotationBuilder.BuildRequirementBody(poco, cursorCache, stringBuilder);
+            ConstraintUsageTextualNotationBuilder.BuildConstraintUsageDeclaration(poco, writerContext, stringBuilder);
+            TypeTextualNotationBuilder.BuildRequirementBody(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/VisibilityKindTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/VisibilityKindTextualNotationBuilder.cs
@@ -39,9 +39,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>VisibilityIndicator:VisibilityKind='public'|'private'|'protected'</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.Root.Namespaces.VisibilityKind" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildVisibilityIndicator(SysML2.NET.Core.Root.Namespaces.VisibilityKind poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildVisibilityIndicator(SysML2.NET.Core.Root.Namespaces.VisibilityKind poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
 
         }

--- a/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/WhileLoopActionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/AutoGenTextualNotationBuilder/WhileLoopActionUsageTextualNotationBuilder.cs
@@ -39,12 +39,12 @@ namespace SysML2.NET.TextualNotation
         /// <para>WhileLoopNode:WhileLoopActionUsage=ActionNodePrefix('while'ownedRelationship+=ExpressionParameterMember|'loop'ownedRelationship+=EmptyParameterMember)ownedRelationship+=ActionBodyParameterMember('until'ownedRelationship+=ExpressionParameterMember';')?</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Actions.IWhileLoopActionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        public static void BuildWhileLoopNode(SysML2.NET.Core.POCO.Systems.Actions.IWhileLoopActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        public static void BuildWhileLoopNode(SysML2.NET.Core.POCO.Systems.Actions.IWhileLoopActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-            ActionUsageTextualNotationBuilder.BuildActionNodePrefix(poco, cursorCache, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            ActionUsageTextualNotationBuilder.BuildActionNodePrefix(poco, writerContext, stringBuilder);
             if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership { OwnedRelatedElement.Count: 0 })
             {
                 stringBuilder.Append("loop ");
@@ -54,7 +54,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                     {
-                        ParameterMembershipTextualNotationBuilder.BuildEmptyParameterMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                        ParameterMembershipTextualNotationBuilder.BuildEmptyParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -69,7 +69,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                     {
-                        ParameterMembershipTextualNotationBuilder.BuildExpressionParameterMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                        ParameterMembershipTextualNotationBuilder.BuildExpressionParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
                     }
                 }
                 ownedRelationshipCursor.Move();
@@ -83,7 +83,7 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildActionBodyParameterMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildActionBodyParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
                 }
             }
             ownedRelationshipCursor.Move();
@@ -98,11 +98,11 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                     {
-                        ParameterMembershipTextualNotationBuilder.BuildExpressionParameterMember(elementAsParameterMembership, cursorCache, stringBuilder);
+                        ParameterMembershipTextualNotationBuilder.BuildExpressionParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
                 stringBuilder.AppendLine(";");
             }
 

--- a/SysML2.NET/TextualNotation/BindingConnectorTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/BindingConnectorTextualNotationBuilder.cs
@@ -35,7 +35,7 @@ namespace SysML2.NET.TextualNotation
         /// Builds the Textual Notation string for the rule BindingConnectorDeclaration
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Connectors.IBindingConnector" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         /// <remarks>
         /// BindingConnectorDeclaration : BindingConnector =
@@ -44,9 +44,9 @@ namespace SysML2.NET.TextualNotation
         ///
         /// Auto-gen delegates entirely to this method.
         /// </remarks>
-        private static void BuildBindingConnectorDeclarationHandCoded(IBindingConnector poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildBindingConnectorDeclarationHandCoded(IBindingConnector poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             var hasDeclaration = !string.IsNullOrWhiteSpace(poco.DeclaredShortName)
                                  || !string.IsNullOrWhiteSpace(poco.DeclaredName)
@@ -56,19 +56,19 @@ namespace SysML2.NET.TextualNotation
             if (hasDeclaration)
             {
                 // Alt 1: FeatureDeclaration ('of' ConnectorEndMember '=' ConnectorEndMember)?
-                FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, writerContext, stringBuilder);
 
                 if (ownedRelationshipCursor.Current is IEndFeatureMembership firstEnd)
                 {
                     stringBuilder.Append("of ");
-                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(firstEnd, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(firstEnd, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
 
                     stringBuilder.Append("= ");
 
                     if (ownedRelationshipCursor.Current is IEndFeatureMembership secondEnd)
                     {
-                        EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(secondEnd, cursorCache, stringBuilder);
+                        EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(secondEnd, writerContext, stringBuilder);
                     }
 
                     ownedRelationshipCursor.Move();
@@ -85,14 +85,14 @@ namespace SysML2.NET.TextualNotation
                 if (ownedRelationshipCursor.Current is IEndFeatureMembership firstEnd)
                 {
                     stringBuilder.Append("of ");
-                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(firstEnd, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(firstEnd, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
 
                     stringBuilder.Append("= ");
 
                     if (ownedRelationshipCursor.Current is IEndFeatureMembership secondEnd)
                     {
-                        EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(secondEnd, cursorCache, stringBuilder);
+                        EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(secondEnd, writerContext, stringBuilder);
                     }
 
                     ownedRelationshipCursor.Move();

--- a/SysML2.NET/TextualNotation/ClassifierTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/ClassifierTextualNotationBuilder.cs
@@ -41,7 +41,7 @@ namespace SysML2.NET.TextualNotation
         /// <c>IConjugation</c> → ConjugationPart.</para>
         /// </summary>
         /// <param name="poco">The <see cref="IClassifier" /> from which the rule should be built</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         /// <remarks>
         /// ClassifierDeclaration : Classifier =
@@ -51,27 +51,27 @@ namespace SysML2.NET.TextualNotation
         /// The auto-gen handles isSufficient, Identification, and OwnedMultiplicity.
         /// This HandCoded method handles: (SuperclassingPart | ConjugationPart)+ TypeRelationshipPart*
         /// </remarks>
-        private static void BuildClassifierDeclarationHandCoded(IClassifier poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildClassifierDeclarationHandCoded(IClassifier poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             // (SuperclassingPart | ConjugationPart)+ — dispatch on cursor element type
             while (ownedRelationshipCursor.Current is ISubclassification or IConjugation)
             {
                 if (ownedRelationshipCursor.Current is ISubclassification)
                 {
-                    BuildSuperclassingPart(poco, cursorCache, stringBuilder);
+                    BuildSuperclassingPart(poco, writerContext, stringBuilder);
                 }
                 else
                 {
-                    TypeTextualNotationBuilder.BuildConjugationPart(poco, cursorCache, stringBuilder);
+                    TypeTextualNotationBuilder.BuildConjugationPart(poco, writerContext, stringBuilder);
                 }
             }
 
             // TypeRelationshipPart* — zero or more
             while (ownedRelationshipCursor.Current is IDisjoining or IUnioning or IIntersecting or IDifferencing)
             {
-                TypeTextualNotationBuilder.BuildTypeRelationshipPart(poco, cursorCache, stringBuilder);
+                TypeTextualNotationBuilder.BuildTypeRelationshipPart(poco, writerContext, stringBuilder);
             }
         }
     }

--- a/SysML2.NET/TextualNotation/ConcernUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/ConcernUsageTextualNotationBuilder.cs
@@ -48,24 +48,24 @@ namespace SysML2.NET.TextualNotation
         /// not separately defined — the reusable <c>UsageDeclaration</c> rule covers it).</para>
         /// </summary>
         /// <param name="poco">The <see cref="IConcernUsage"/> being serialised</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache"/> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache"/> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder"/> that contains the entire textual notation</param>
-        private static void BuildFramedConcernUsageHandCoded(IConcernUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildFramedConcernUsageHandCoded(IConcernUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (poco.OwnedRelationship.OfType<IReferenceSubsetting>().Any())
             {
                 // Alt 1: OwnedReferenceSubsetting FeatureSpecializationPart?
                 if (ownedRelationshipCursor.Current is IReferenceSubsetting referenceSubsetting)
                 {
-                    ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(referenceSubsetting, cursorCache, stringBuilder);
+                    ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(referenceSubsetting, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                 }
 
                 if (ownedRelationshipCursor.Current is ISpecialization)
                 {
-                    FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, cursorCache, stringBuilder);
+                    FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, writerContext, stringBuilder);
                 }
             }
             else
@@ -74,14 +74,14 @@ namespace SysML2.NET.TextualNotation
                 while (ownedRelationshipCursor.Current is IOwningMembership membership
                        && membership.OwnedRelatedElement.OfType<IMetadataUsage>().Any())
                 {
-                    UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, cursorCache, stringBuilder);
+                    UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, writerContext, stringBuilder);
                 }
 
                 stringBuilder.Append("concern ");
-                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
             }
 
-            TypeTextualNotationBuilder.BuildCalculationBody(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildCalculationBody(poco, writerContext, stringBuilder);
         }
     }
 }

--- a/SysML2.NET/TextualNotation/ConjugatedPortTypingTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/ConjugatedPortTypingTextualNotationBuilder.cs
@@ -33,9 +33,9 @@ namespace SysML2.NET.TextualNotation
         /// Build the originalPortDefinition=~[QualifiedName] rule part
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Ports.IConjugatedPortTyping" /> from which the rule should be build</param>
-        /// <param name="cursorCache"> The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext"> The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        private static void BuildOriginalPortDefinition(IConjugatedPortTyping poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildOriginalPortDefinition(IConjugatedPortTyping poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
         }
     }

--- a/SysML2.NET/TextualNotation/ConnectionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/ConnectionUsageTextualNotationBuilder.cs
@@ -36,7 +36,7 @@ namespace SysML2.NET.TextualNotation
         /// Builds the Textual Notation string for the rule ConnectionUsage
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Connections.IConnectionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         /// <remarks>
         /// ConnectionUsage =
@@ -48,9 +48,9 @@ namespace SysML2.NET.TextualNotation
         ///
         /// Auto-gen emits OccurrenceUsagePrefix before and UsageBody after.
         /// </remarks>
-        private static void BuildConnectionUsageHandCoded(IConnectionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildConnectionUsageHandCoded(IConnectionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             var hasDeclaration = !string.IsNullOrWhiteSpace(poco.DeclaredShortName)
                                  || !string.IsNullOrWhiteSpace(poco.DeclaredName)
@@ -61,20 +61,20 @@ namespace SysML2.NET.TextualNotation
             {
                 // Alt 1: 'connection' UsageDeclaration ValuePart? ('connect' ConnectorPart)?
                 stringBuilder.Append("connection ");
-                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
-                FeatureTextualNotationBuilder.BuildValuePart(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
+                FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
 
                 if (poco.OwnedRelationship.OfType<IEndFeatureMembership>().Any())
                 {
                     stringBuilder.Append("connect ");
-                    BuildConnectorPart(poco, cursorCache, stringBuilder);
+                    BuildConnectorPart(poco, writerContext, stringBuilder);
                 }
             }
             else
             {
                 // Alt 2: 'connect' ConnectorPart
                 stringBuilder.Append("connect ");
-                BuildConnectorPart(poco, cursorCache, stringBuilder);
+                BuildConnectorPart(poco, writerContext, stringBuilder);
             }
         }
 

--- a/SysML2.NET/TextualNotation/ConnectorTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/ConnectorTextualNotationBuilder.cs
@@ -36,7 +36,7 @@ namespace SysML2.NET.TextualNotation
         /// Builds the Textual Notation string for the rule BinaryConnectorDeclaration
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Connectors.IConnector" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         /// <remarks>
         /// BinaryConnectorDeclaration : Connector =
@@ -46,9 +46,9 @@ namespace SysML2.NET.TextualNotation
         /// Auto-gen emits the two ConnectorEndMember + 'to' AFTER this method.
         /// This method handles only the optional preamble: FeatureDeclaration? + 'from' or 'all' + 'from'?.
         /// </remarks>
-        private static void BuildBinaryConnectorDeclarationHandCoded(IConnector poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildBinaryConnectorDeclarationHandCoded(IConnector poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             var hasDeclaration = !string.IsNullOrWhiteSpace(poco.DeclaredShortName)
                                  || !string.IsNullOrWhiteSpace(poco.DeclaredName)
@@ -57,7 +57,7 @@ namespace SysML2.NET.TextualNotation
 
             if (hasDeclaration)
             {
-                FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, writerContext, stringBuilder);
                 stringBuilder.Append("from ");
             }
             else if (poco.IsSufficient)
@@ -71,7 +71,7 @@ namespace SysML2.NET.TextualNotation
         /// Builds the Textual Notation string for the rule Connector
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Connectors.IConnector" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         /// <remarks>
         /// Connector = FeaturePrefix 'connector' ( FeatureDeclaration? ValuePart? | ConnectorDeclaration ) TypeBody
@@ -79,18 +79,18 @@ namespace SysML2.NET.TextualNotation
         /// Auto-gen emits FeaturePrefix + 'connector ' before and TypeBody after this method.
         /// This method handles: ( FeatureDeclaration? ValuePart? | ConnectorDeclaration )
         /// </remarks>
-        private static void BuildConnectorHandCoded(IConnector poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildConnectorHandCoded(IConnector poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             if (poco.OwnedRelationship.OfType<IEndFeatureMembership>().Any())
             {
                 // ConnectorDeclaration — dispatches to BinaryConnectorDeclaration or NaryConnectorDeclaration
-                BuildConnectorDeclaration(poco, cursorCache, stringBuilder);
+                BuildConnectorDeclaration(poco, writerContext, stringBuilder);
             }
             else
             {
                 // FeatureDeclaration? ValuePart?
-                FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, cursorCache, stringBuilder);
-                FeatureTextualNotationBuilder.BuildValuePart(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, writerContext, stringBuilder);
+                FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }
         }
     }

--- a/SysML2.NET/TextualNotation/ConstraintUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/ConstraintUsageTextualNotationBuilder.cs
@@ -50,27 +50,27 @@ namespace SysML2.NET.TextualNotation
         /// own body.</para>
         /// </summary>
         /// <param name="poco">The <see cref="IConstraintUsage"/> being serialised</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache"/> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache"/> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder"/> that contains the entire textual notation</param>
-        private static void BuildRequirementConstraintUsageHandCoded(IConstraintUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildRequirementConstraintUsageHandCoded(IConstraintUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (poco.OwnedRelationship.OfType<IReferenceSubsetting>().Any())
             {
                 // Alt 1: OwnedReferenceSubsetting FeatureSpecializationPart? RequirementBody
                 if (ownedRelationshipCursor.Current is IReferenceSubsetting referenceSubsetting)
                 {
-                    ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(referenceSubsetting, cursorCache, stringBuilder);
+                    ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(referenceSubsetting, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                 }
 
                 if (ownedRelationshipCursor.Current is ISpecialization)
                 {
-                    FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, cursorCache, stringBuilder);
+                    FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, writerContext, stringBuilder);
                 }
 
-                TypeTextualNotationBuilder.BuildRequirementBody(poco, cursorCache, stringBuilder);
+                TypeTextualNotationBuilder.BuildRequirementBody(poco, writerContext, stringBuilder);
             }
             else
             {
@@ -78,12 +78,12 @@ namespace SysML2.NET.TextualNotation
                 while (ownedRelationshipCursor.Current is IOwningMembership membership
                        && membership.OwnedRelatedElement.OfType<IMetadataUsage>().Any())
                 {
-                    UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, cursorCache, stringBuilder);
+                    UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, writerContext, stringBuilder);
                 }
 
                 stringBuilder.Append("constraint ");
-                BuildConstraintUsageDeclaration(poco, cursorCache, stringBuilder);
-                TypeTextualNotationBuilder.BuildCalculationBody(poco, cursorCache, stringBuilder);
+                BuildConstraintUsageDeclaration(poco, writerContext, stringBuilder);
+                TypeTextualNotationBuilder.BuildCalculationBody(poco, writerContext, stringBuilder);
             }
         }
     }

--- a/SysML2.NET/TextualNotation/ExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/ExpressionTextualNotationBuilder.cs
@@ -34,19 +34,19 @@ namespace SysML2.NET.TextualNotation
         /// <remarks>SequenceExpressionList:Expression=OwnedExpression','?|SequenceOperatorExpression. SequenceOperatorExpression is an OperatorExpression with operator=','.</remarks>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Functions.IExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        private static void BuildSequenceExpressionListHandCoded(IExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildSequenceExpressionListHandCoded(IExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             // Dispatch: if the poco is an OperatorExpression with operator=',', emit as SequenceOperatorExpression;
             // otherwise emit as OwnedExpression (the optional trailing comma in the grammar is not emitted)
             if (poco is SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression { Operator: "," } operatorExpression)
             {
-                OperatorExpressionTextualNotationBuilder.BuildSequenceOperatorExpression(operatorExpression, cursorCache, stringBuilder);
+                OperatorExpressionTextualNotationBuilder.BuildSequenceOperatorExpression(operatorExpression, writerContext, stringBuilder);
             }
             else
             {
-                BuildOwnedExpression(poco, cursorCache, stringBuilder);
+                BuildOwnedExpression(poco, writerContext, stringBuilder);
             }
         }
     }

--- a/SysML2.NET/TextualNotation/FeatureMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/FeatureMembershipTextualNotationBuilder.cs
@@ -34,9 +34,9 @@ namespace SysML2.NET.TextualNotation
         /// Build the memberFeature=[QualifiedName] of the rule
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        private static void BuildMemberFeature(IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildMemberFeature(IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
         }
 
@@ -45,24 +45,24 @@ namespace SysML2.NET.TextualNotation
         /// <remarks>EntryTransitionMember:FeatureMembership=MemberPrefix(ownedRelatedElement+=GuardedTargetSuccession|'then'ownedRelatedElement+=TargetSuccession)';'</remarks>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        private static void BuildEntryTransitionMemberHandCoded(IFeatureMembership poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildEntryTransitionMemberHandCoded(IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             // Dispatch on cursor element type:
             //   - ITransitionUsage → GuardedTargetSuccession (no 'then' keyword)
             //   - ISuccessionAsUsage → TargetSuccession (emit 'then' first)
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.States.ITransitionUsage guardedTarget)
             {
-                TransitionUsageTextualNotationBuilder.BuildGuardedTargetSuccession(guardedTarget, cursorCache, stringBuilder);
+                TransitionUsageTextualNotationBuilder.BuildGuardedTargetSuccession(guardedTarget, writerContext, stringBuilder);
                 ownedRelatedElementCursor.Move();
             }
             else if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Connections.ISuccessionAsUsage targetSuccession)
             {
                 stringBuilder.Append("then ");
-                SuccessionAsUsageTextualNotationBuilder.BuildTargetSuccession(targetSuccession, cursorCache, stringBuilder);
+                SuccessionAsUsageTextualNotationBuilder.BuildTargetSuccession(targetSuccession, writerContext, stringBuilder);
                 ownedRelatedElementCursor.Move();
             }
         }

--- a/SysML2.NET/TextualNotation/FeatureTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/FeatureTextualNotationBuilder.cs
@@ -37,10 +37,10 @@ namespace SysML2.NET.TextualNotation
         /// Builds the Textual Notation string for the rule BasicFeaturePrefix
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         /// <remarks>Trailing alternative of BasicFeaturePrefix: (isVariable?='var'|isConstant?='const'{isVariable=true})?. Note: 'const' implies isVariable=true, so check isConstant first.</remarks>
-        private static void BuildBasicFeaturePrefixHandCoded(IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildBasicFeaturePrefixHandCoded(IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             if (poco.IsConstant)
             {
@@ -56,7 +56,7 @@ namespace SysML2.NET.TextualNotation
         /// Builds the Textual Notation string for the rule FeatureDeclaration
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         /// <remarks>
         /// FeatureDeclaration : Feature =
@@ -68,32 +68,32 @@ namespace SysML2.NET.TextualNotation
         ///     FeatureRelationshipPart*
         ///
         /// </remarks>
-        private static void BuildFeatureDeclarationHandCoded(IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildFeatureDeclarationHandCoded(IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             var hasIdentification = !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName);
 
             if (hasIdentification)
             {
-                BuildFeatureIdentification(poco, cursorCache, stringBuilder);
+                BuildFeatureIdentification(poco, writerContext, stringBuilder);
 
                 if (ownedRelationshipCursor.Current is ISpecialization)
                 {
-                    BuildFeatureSpecializationPart(poco, cursorCache, stringBuilder);
+                    BuildFeatureSpecializationPart(poco, writerContext, stringBuilder);
                 }
                 else if (ownedRelationshipCursor.Current is IConjugation)
                 {
-                    TypeTextualNotationBuilder.BuildConjugationPart(poco, cursorCache, stringBuilder);
+                    TypeTextualNotationBuilder.BuildConjugationPart(poco, writerContext, stringBuilder);
                 }
             }
             else if (ownedRelationshipCursor.Current is ISpecialization)
             {
-                BuildFeatureSpecializationPart(poco, cursorCache, stringBuilder);
+                BuildFeatureSpecializationPart(poco, writerContext, stringBuilder);
             }
             else if (ownedRelationshipCursor.Current is IConjugation)
             {
-                TypeTextualNotationBuilder.BuildConjugationPart(poco, cursorCache, stringBuilder);
+                TypeTextualNotationBuilder.BuildConjugationPart(poco, writerContext, stringBuilder);
             }
 
             // FeatureRelationshipPart* — zero or more, dispatched by cursor type.
@@ -109,16 +109,16 @@ namespace SysML2.NET.TextualNotation
                 switch (ownedRelationshipCursor.Current)
                 {
                     case IFeatureChaining:
-                        BuildChainingPart(poco, cursorCache, stringBuilder);
+                        BuildChainingPart(poco, writerContext, stringBuilder);
                         break;
                     case IFeatureInverting:
-                        BuildInvertingPart(poco, cursorCache, stringBuilder);
+                        BuildInvertingPart(poco, writerContext, stringBuilder);
                         break;
                     case ITypeFeaturing:
-                        BuildTypeFeaturingPart(poco, cursorCache, stringBuilder);
+                        BuildTypeFeaturingPart(poco, writerContext, stringBuilder);
                         break;
                     default:
-                        TypeTextualNotationBuilder.BuildTypeRelationshipPart(poco, cursorCache, stringBuilder);
+                        TypeTextualNotationBuilder.BuildTypeRelationshipPart(poco, writerContext, stringBuilder);
                         break;
                 }
             }
@@ -128,7 +128,7 @@ namespace SysML2.NET.TextualNotation
         /// Builds the Textual Notation string for the rule Feature
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         /// <remarks>
         /// Feature =
@@ -144,7 +144,7 @@ namespace SysML2.NET.TextualNotation
         /// BuildFeatureDeclaration is then called to emit the identification, specialization,
         /// conjugation, and relationship parts.
         /// </remarks>
-        private static void BuildFeatureHandCoded(IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildFeatureHandCoded(IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             // Alt 1 uses FeaturePrefix (which handles abstract/variation/readonly/derived/end
             // and PrefixMetadataMember*). It applies when the feature carries modifiers that
@@ -157,15 +157,15 @@ namespace SysML2.NET.TextualNotation
             if (!poco.IsEnd && (poco.IsAbstract || poco.IsDerived || hasPrefixMetadata))
             {
                 // Alt 1: FeaturePrefix ('feature' | ownedRelationship += PrefixMetadataMember) FeatureDeclaration?
-                SharedTextualNotationBuilder.BuildFeaturePrefix(poco, cursorCache, stringBuilder);
+                SharedTextualNotationBuilder.BuildFeaturePrefix(poco, writerContext, stringBuilder);
 
-                var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
                 if (ownedRelationshipCursor.Current is IOwningMembership prefixMetadata
                     && prefixMetadata.OwnedRelatedElement.OfType<IMetadataUsage>().Any())
                 {
                     // PrefixMetadataMember alternative — consume a single metadata annotation
-                    OwningMembershipTextualNotationBuilder.BuildPrefixMetadataMember(prefixMetadata, cursorCache, stringBuilder);
+                    OwningMembershipTextualNotationBuilder.BuildPrefixMetadataMember(prefixMetadata, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                 }
                 else
@@ -175,13 +175,13 @@ namespace SysML2.NET.TextualNotation
                 }
 
                 // FeatureDeclaration is optional in Alt 1
-                BuildFeatureDeclaration(poco, cursorCache, stringBuilder);
+                BuildFeatureDeclaration(poco, writerContext, stringBuilder);
             }
             else
             {
                 // Alt 2: (EndFeaturePrefix | BasicFeaturePrefix) FeatureDeclaration
-                SharedTextualNotationBuilder.BuildFeaturePrefix(poco, cursorCache, stringBuilder);
-                BuildFeatureDeclaration(poco, cursorCache, stringBuilder);
+                SharedTextualNotationBuilder.BuildFeaturePrefix(poco, writerContext, stringBuilder);
+                BuildFeatureDeclaration(poco, writerContext, stringBuilder);
             }
         }
 
@@ -189,10 +189,10 @@ namespace SysML2.NET.TextualNotation
         /// Builds the Textual Notation string for the rule FeatureIdentification
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         /// <remarks>FeatureIdentification:Feature='&lt;'declaredShortName=NAME'&gt;'(declaredName=NAME)?|declaredName=NAME</remarks>
-        private static void BuildFeatureIdentificationHandCoded(IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildFeatureIdentificationHandCoded(IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName))
             {
@@ -229,18 +229,18 @@ namespace SysML2.NET.TextualNotation
         /// is present — see the rule's own grammar in <c>BuildMultiplicityPartHandCoded</c>'s remarks.</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        private static void BuildFeatureSpecializationPartHandCoded(IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildFeatureSpecializationPartHandCoded(IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current is ISpecialization)
             {
                 // Alt 1: FeatureSpecialization+ MultiplicityPart? FeatureSpecialization*
                 while (ownedRelationshipCursor.Current is ISpecialization)
                 {
-                    BuildFeatureSpecialization(poco, cursorCache, stringBuilder);
+                    BuildFeatureSpecialization(poco, writerContext, stringBuilder);
                 }
 
                 var multiplicityElementPresent = ownedRelationshipCursor.Current is IOwningMembership owningMembership
@@ -248,24 +248,24 @@ namespace SysML2.NET.TextualNotation
 
                 if (multiplicityElementPresent || poco.IsOrdered || !poco.IsUnique)
                 {
-                    BuildMultiplicityPart(poco, cursorCache, stringBuilder);
+                    BuildMultiplicityPart(poco, writerContext, stringBuilder);
                 }
 
                 // Trailing FeatureSpecialization* — runs regardless of whether MultiplicityPart fired,
                 // per the grammar's three-segment shape `FeatureSpecialization+ MultiplicityPart? FeatureSpecialization*`.
                 while (ownedRelationshipCursor.Current is ISpecialization)
                 {
-                    BuildFeatureSpecialization(poco, cursorCache, stringBuilder);
+                    BuildFeatureSpecialization(poco, writerContext, stringBuilder);
                 }
             }
             else
             {
                 // Alt 2: MultiplicityPart FeatureSpecialization*
-                BuildMultiplicityPart(poco, cursorCache, stringBuilder);
+                BuildMultiplicityPart(poco, writerContext, stringBuilder);
 
                 while (ownedRelationshipCursor.Current is ISpecialization)
                 {
-                    BuildFeatureSpecialization(poco, cursorCache, stringBuilder);
+                    BuildFeatureSpecialization(poco, writerContext, stringBuilder);
                 }
             }
         }
@@ -275,17 +275,17 @@ namespace SysML2.NET.TextualNotation
         /// <remarks>MultiplicityPart:Feature=ownedRelationship+=OwnedMultiplicity|(ownedRelationship+=OwnedMultiplicity)?(isOrdered?='ordered'({isUnique=false}'nonunique')?|{isUnique=false}'nonunique'(isOrdered?='ordered')?)</remarks>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        private static void BuildMultiplicityPartHandCoded(IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildMultiplicityPartHandCoded(IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             // Emit the OwnedMultiplicity if present (cursor advances on += processing)
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership multiplicityMember
                 && multiplicityMember.OwnedRelatedElement.OfType<SysML2.NET.Core.POCO.Core.Types.IMultiplicity>().Any())
             {
-                OwningMembershipTextualNotationBuilder.BuildOwnedMultiplicity(multiplicityMember, cursorCache, stringBuilder);
+                OwningMembershipTextualNotationBuilder.BuildOwnedMultiplicity(multiplicityMember, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
             }
 
@@ -306,7 +306,7 @@ namespace SysML2.NET.TextualNotation
         /// Builds the Textual Notation string for the rule PayloadFeature
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         /// <remarks>
         /// PayloadFeature : Feature =
@@ -314,9 +314,9 @@ namespace SysML2.NET.TextualNotation
         ///   | ownedRelationship += OwnedFeatureTyping ( ownedRelationship += OwnedMultiplicity )?
         ///   | ownedRelationship += OwnedMultiplicity ownedRelationship += OwnedFeatureTyping
         /// </remarks>
-        private static void BuildPayloadFeatureHandCoded(IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildPayloadFeatureHandCoded(IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             var hasIdentification = !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName);
 
@@ -325,28 +325,28 @@ namespace SysML2.NET.TextualNotation
                 // Alt 1: Identification? PayloadFeatureSpecializationPart ValuePart?
                 if (hasIdentification)
                 {
-                    ElementTextualNotationBuilder.BuildIdentification(poco, cursorCache, stringBuilder);
+                    ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
                 }
 
                 if (ownedRelationshipCursor.Current is ISpecialization
                     || ownedRelationshipCursor.Current is IOwningMembership multiplicityCheck
                        && multiplicityCheck.OwnedRelatedElement.OfType<IMultiplicity>().Any())
                 {
-                    BuildPayloadFeatureSpecializationPart(poco, cursorCache, stringBuilder);
+                    BuildPayloadFeatureSpecializationPart(poco, writerContext, stringBuilder);
                 }
 
-                BuildValuePart(poco, cursorCache, stringBuilder);
+                BuildValuePart(poco, writerContext, stringBuilder);
             }
             else if (ownedRelationshipCursor.Current is IFeatureTyping featureTyping)
             {
                 // Alt 2: OwnedFeatureTyping (OwnedMultiplicity)?
-                FeatureTypingTextualNotationBuilder.BuildOwnedFeatureTyping(featureTyping, cursorCache, stringBuilder);
+                FeatureTypingTextualNotationBuilder.BuildOwnedFeatureTyping(featureTyping, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
 
                 if (ownedRelationshipCursor.Current is IOwningMembership owningMembership
                     && owningMembership.OwnedRelatedElement.OfType<IMultiplicity>().Any())
                 {
-                    OwningMembershipTextualNotationBuilder.BuildOwnedMultiplicity(owningMembership, cursorCache, stringBuilder);
+                    OwningMembershipTextualNotationBuilder.BuildOwnedMultiplicity(owningMembership, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                 }
             }
@@ -354,12 +354,12 @@ namespace SysML2.NET.TextualNotation
                      && multiplicityMember.OwnedRelatedElement.OfType<IMultiplicity>().Any())
             {
                 // Alt 3: OwnedMultiplicity OwnedFeatureTyping
-                OwningMembershipTextualNotationBuilder.BuildOwnedMultiplicity(multiplicityMember, cursorCache, stringBuilder);
+                OwningMembershipTextualNotationBuilder.BuildOwnedMultiplicity(multiplicityMember, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
 
                 if (ownedRelationshipCursor.Current is IFeatureTyping featureTypingAfterMult)
                 {
-                    FeatureTypingTextualNotationBuilder.BuildOwnedFeatureTyping(featureTypingAfterMult, cursorCache, stringBuilder);
+                    FeatureTypingTextualNotationBuilder.BuildOwnedFeatureTyping(featureTypingAfterMult, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                 }
             }
@@ -369,7 +369,7 @@ namespace SysML2.NET.TextualNotation
         /// Builds the Textual Notation string for the rule PayloadFeatureSpecializationPart
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Features.IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         /// <remarks>
         /// PayloadFeatureSpecializationPart : Feature =
@@ -380,16 +380,16 @@ namespace SysML2.NET.TextualNotation
         /// (Alt 2 uses '+' instead of '*') is a parse-time validation concern, not a
         /// serialization difference.
         /// </remarks>
-        private static void BuildPayloadFeatureSpecializationPartHandCoded(IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildPayloadFeatureSpecializationPartHandCoded(IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current is ISpecialization)
             {
                 // Alt 1: FeatureSpecialization+ MultiplicityPart? FeatureSpecialization*
                 while (ownedRelationshipCursor.Current is ISpecialization)
                 {
-                    BuildFeatureSpecialization(poco, cursorCache, stringBuilder);
+                    BuildFeatureSpecialization(poco, writerContext, stringBuilder);
                 }
 
                 var multiplicityElementPresent = ownedRelationshipCursor.Current is IOwningMembership owningMembership
@@ -397,22 +397,22 @@ namespace SysML2.NET.TextualNotation
 
                 if (multiplicityElementPresent || poco.IsOrdered || !poco.IsUnique)
                 {
-                    BuildMultiplicityPart(poco, cursorCache, stringBuilder);
+                    BuildMultiplicityPart(poco, writerContext, stringBuilder);
                 }
 
                 while (ownedRelationshipCursor.Current is ISpecialization)
                 {
-                    BuildFeatureSpecialization(poco, cursorCache, stringBuilder);
+                    BuildFeatureSpecialization(poco, writerContext, stringBuilder);
                 }
             }
             else
             {
                 // Alt 2: MultiplicityPart FeatureSpecialization+
-                BuildMultiplicityPart(poco, cursorCache, stringBuilder);
+                BuildMultiplicityPart(poco, writerContext, stringBuilder);
 
                 while (ownedRelationshipCursor.Current is ISpecialization)
                 {
-                    BuildFeatureSpecialization(poco, cursorCache, stringBuilder);
+                    BuildFeatureSpecialization(poco, writerContext, stringBuilder);
                 }
             }
         }

--- a/SysML2.NET/TextualNotation/FeatureValueTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/FeatureValueTextualNotationBuilder.cs
@@ -35,9 +35,9 @@ namespace SysML2.NET.TextualNotation
         /// <remarks>FeatureValue=('='|isInitial?=':='|isDefault?='default'('='|isInitial?=':=')?)ownedRelatedElement+=OwnedExpression</remarks>
         /// </summary>
         /// <param name="poco">The <see cref="IFeatureValue" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        private static void BuildFeatureValueHandCoded(IFeatureValue poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildFeatureValueHandCoded(IFeatureValue poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             if (poco.IsDefault)
             {

--- a/SysML2.NET/TextualNotation/FlowTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/FlowTextualNotationBuilder.cs
@@ -35,7 +35,7 @@ namespace SysML2.NET.TextualNotation
         /// Builds the Textual Notation string for the rule FlowDeclaration
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Interactions.IFlow" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         /// <remarks>
         /// FlowDeclaration : Flow =
@@ -47,9 +47,9 @@ namespace SysML2.NET.TextualNotation
         ///
         /// Auto-gen emits FeaturePrefix + 'flow ' before and TypeBody after this method.
         /// </remarks>
-        private static void BuildFlowDeclarationHandCoded(IFlow poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildFlowDeclarationHandCoded(IFlow poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             var hasDeclaration = !string.IsNullOrWhiteSpace(poco.DeclaredShortName)
                                  || !string.IsNullOrWhiteSpace(poco.DeclaredName);
@@ -57,15 +57,15 @@ namespace SysML2.NET.TextualNotation
             if (hasDeclaration || ownedRelationshipCursor.Current is not IEndFeatureMembership)
             {
                 // Alt 1: FeatureDeclaration ValuePart? ('of' PayloadFeatureMember)? ('from' FlowEndMember 'to' FlowEndMember)?
-                FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, cursorCache, stringBuilder);
-                FeatureTextualNotationBuilder.BuildValuePart(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, writerContext, stringBuilder);
+                FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
 
                 // 'of' PayloadFeatureMember? — IFeatureMembership but NOT IEndFeatureMembership
                 if (ownedRelationshipCursor.Current is IFeatureMembership payloadMember
                     && ownedRelationshipCursor.Current is not IEndFeatureMembership)
                 {
                     stringBuilder.Append("of ");
-                    FeatureMembershipTextualNotationBuilder.BuildPayloadFeatureMember(payloadMember, cursorCache, stringBuilder);
+                    FeatureMembershipTextualNotationBuilder.BuildPayloadFeatureMember(payloadMember, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                 }
 
@@ -73,14 +73,14 @@ namespace SysML2.NET.TextualNotation
                 if (ownedRelationshipCursor.Current is IEndFeatureMembership firstFlowEnd)
                 {
                     stringBuilder.Append("from ");
-                    EndFeatureMembershipTextualNotationBuilder.BuildFlowEndMember(firstFlowEnd, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildFlowEndMember(firstFlowEnd, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
 
                     stringBuilder.Append("to ");
 
                     if (ownedRelationshipCursor.Current is IEndFeatureMembership secondFlowEnd)
                     {
-                        EndFeatureMembershipTextualNotationBuilder.BuildFlowEndMember(secondFlowEnd, cursorCache, stringBuilder);
+                        EndFeatureMembershipTextualNotationBuilder.BuildFlowEndMember(secondFlowEnd, writerContext, stringBuilder);
                     }
 
                     ownedRelationshipCursor.Move();
@@ -96,14 +96,14 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is IEndFeatureMembership firstFlowEnd)
                 {
-                    EndFeatureMembershipTextualNotationBuilder.BuildFlowEndMember(firstFlowEnd, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildFlowEndMember(firstFlowEnd, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
 
                     stringBuilder.Append("to ");
 
                     if (ownedRelationshipCursor.Current is IEndFeatureMembership secondFlowEnd)
                     {
-                        EndFeatureMembershipTextualNotationBuilder.BuildFlowEndMember(secondFlowEnd, cursorCache, stringBuilder);
+                        EndFeatureMembershipTextualNotationBuilder.BuildFlowEndMember(secondFlowEnd, writerContext, stringBuilder);
                     }
 
                     ownedRelationshipCursor.Move();

--- a/SysML2.NET/TextualNotation/FlowUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/FlowUsageTextualNotationBuilder.cs
@@ -36,7 +36,7 @@ namespace SysML2.NET.TextualNotation
         /// Builds the Textual Notation string for the rule FlowDeclaration
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Flows.IFlowUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         /// <remarks>
         /// FlowDeclaration : FlowUsage =
@@ -47,9 +47,9 @@ namespace SysML2.NET.TextualNotation
         ///
         /// Auto-gen emits OccurrenceUsagePrefix + 'flow ' before and DefinitionBody after.
         /// </remarks>
-        private static void BuildFlowDeclarationHandCoded(IFlowUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildFlowDeclarationHandCoded(IFlowUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             var hasDeclaration = !string.IsNullOrWhiteSpace(poco.DeclaredShortName)
                                  || !string.IsNullOrWhiteSpace(poco.DeclaredName);
@@ -57,28 +57,28 @@ namespace SysML2.NET.TextualNotation
             if (hasDeclaration || ownedRelationshipCursor.Current is not IEndFeatureMembership)
             {
                 // Alt 1: UsageDeclaration ValuePart? ('of' FlowPayloadFeatureMember)? ('from' FlowEndMember 'to' FlowEndMember)?
-                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
-                FeatureTextualNotationBuilder.BuildValuePart(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
+                FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
 
                 if (ownedRelationshipCursor.Current is IFeatureMembership payloadMember
                     && ownedRelationshipCursor.Current is not IEndFeatureMembership)
                 {
                     stringBuilder.Append("of ");
-                    FeatureMembershipTextualNotationBuilder.BuildFlowPayloadFeatureMember(payloadMember, cursorCache, stringBuilder);
+                    FeatureMembershipTextualNotationBuilder.BuildFlowPayloadFeatureMember(payloadMember, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                 }
 
                 if (ownedRelationshipCursor.Current is IEndFeatureMembership firstFlowEnd)
                 {
                     stringBuilder.Append("from ");
-                    EndFeatureMembershipTextualNotationBuilder.BuildFlowEndMember(firstFlowEnd, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildFlowEndMember(firstFlowEnd, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
 
                     stringBuilder.Append("to ");
 
                     if (ownedRelationshipCursor.Current is IEndFeatureMembership secondFlowEnd)
                     {
-                        EndFeatureMembershipTextualNotationBuilder.BuildFlowEndMember(secondFlowEnd, cursorCache, stringBuilder);
+                        EndFeatureMembershipTextualNotationBuilder.BuildFlowEndMember(secondFlowEnd, writerContext, stringBuilder);
                     }
 
                     ownedRelationshipCursor.Move();
@@ -89,14 +89,14 @@ namespace SysML2.NET.TextualNotation
                 // Alt 2: FlowEndMember 'to' FlowEndMember
                 if (ownedRelationshipCursor.Current is IEndFeatureMembership firstFlowEnd)
                 {
-                    EndFeatureMembershipTextualNotationBuilder.BuildFlowEndMember(firstFlowEnd, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildFlowEndMember(firstFlowEnd, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
 
                     stringBuilder.Append("to ");
 
                     if (ownedRelationshipCursor.Current is IEndFeatureMembership secondFlowEnd)
                     {
-                        EndFeatureMembershipTextualNotationBuilder.BuildFlowEndMember(secondFlowEnd, cursorCache, stringBuilder);
+                        EndFeatureMembershipTextualNotationBuilder.BuildFlowEndMember(secondFlowEnd, writerContext, stringBuilder);
                     }
 
                     ownedRelationshipCursor.Move();
@@ -108,7 +108,7 @@ namespace SysML2.NET.TextualNotation
         /// Builds the Textual Notation string for the rule MessageDeclaration
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Flows.IFlowUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         /// <remarks>
         /// MessageDeclaration : FlowUsage =
@@ -119,9 +119,9 @@ namespace SysML2.NET.TextualNotation
         ///
         /// Auto-gen emits OccurrenceUsagePrefix + 'message ' before and DefinitionBody after.
         /// </remarks>
-        private static void BuildMessageDeclarationHandCoded(IFlowUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildMessageDeclarationHandCoded(IFlowUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             var hasDeclaration = !string.IsNullOrWhiteSpace(poco.DeclaredShortName)
                                  || !string.IsNullOrWhiteSpace(poco.DeclaredName);
@@ -129,28 +129,28 @@ namespace SysML2.NET.TextualNotation
             if (hasDeclaration || ownedRelationshipCursor.Current is not IParameterMembership)
             {
                 // Alt 1: UsageDeclaration ValuePart? ('of' FlowPayloadFeatureMember)? ('from' MessageEventMember 'to' MessageEventMember)?
-                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
-                FeatureTextualNotationBuilder.BuildValuePart(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
+                FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
 
                 if (ownedRelationshipCursor.Current is IFeatureMembership payloadMember
                     && ownedRelationshipCursor.Current is not IParameterMembership)
                 {
                     stringBuilder.Append("of ");
-                    FeatureMembershipTextualNotationBuilder.BuildFlowPayloadFeatureMember(payloadMember, cursorCache, stringBuilder);
+                    FeatureMembershipTextualNotationBuilder.BuildFlowPayloadFeatureMember(payloadMember, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                 }
 
                 if (ownedRelationshipCursor.Current is IParameterMembership firstMessageEvent)
                 {
                     stringBuilder.Append("from ");
-                    ParameterMembershipTextualNotationBuilder.BuildMessageEventMember(firstMessageEvent, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildMessageEventMember(firstMessageEvent, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
 
                     stringBuilder.Append("to ");
 
                     if (ownedRelationshipCursor.Current is IParameterMembership secondMessageEvent)
                     {
-                        ParameterMembershipTextualNotationBuilder.BuildMessageEventMember(secondMessageEvent, cursorCache, stringBuilder);
+                        ParameterMembershipTextualNotationBuilder.BuildMessageEventMember(secondMessageEvent, writerContext, stringBuilder);
                     }
 
                     ownedRelationshipCursor.Move();
@@ -161,14 +161,14 @@ namespace SysML2.NET.TextualNotation
                 // Alt 2: MessageEventMember 'to' MessageEventMember
                 if (ownedRelationshipCursor.Current is IParameterMembership firstMessageEvent)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildMessageEventMember(firstMessageEvent, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildMessageEventMember(firstMessageEvent, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
 
                     stringBuilder.Append("to ");
 
                     if (ownedRelationshipCursor.Current is IParameterMembership secondMessageEvent)
                     {
-                        ParameterMembershipTextualNotationBuilder.BuildMessageEventMember(secondMessageEvent, cursorCache, stringBuilder);
+                        ParameterMembershipTextualNotationBuilder.BuildMessageEventMember(secondMessageEvent, writerContext, stringBuilder);
                     }
 
                     ownedRelationshipCursor.Move();

--- a/SysML2.NET/TextualNotation/InterfaceUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/InterfaceUsageTextualNotationBuilder.cs
@@ -36,7 +36,7 @@ namespace SysML2.NET.TextualNotation
         /// Builds the Textual Notation string for the rule InterfaceUsageDeclaration
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Interfaces.IInterfaceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         /// <remarks>
         /// InterfaceUsageDeclaration : InterfaceUsage =
@@ -45,9 +45,9 @@ namespace SysML2.NET.TextualNotation
         ///
         /// Auto-gen delegates entirely to this method.
         /// </remarks>
-        private static void BuildInterfaceUsageDeclarationHandCoded(IInterfaceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildInterfaceUsageDeclarationHandCoded(IInterfaceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             var hasDeclaration = !string.IsNullOrWhiteSpace(poco.DeclaredShortName)
                                  || !string.IsNullOrWhiteSpace(poco.DeclaredName)
@@ -57,19 +57,19 @@ namespace SysML2.NET.TextualNotation
             if (hasDeclaration)
             {
                 // Alt 1: UsageDeclaration ValuePart? ('connect' InterfacePart)?
-                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, cursorCache, stringBuilder);
-                FeatureTextualNotationBuilder.BuildValuePart(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
+                FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
 
                 if (poco.OwnedRelationship.OfType<IEndFeatureMembership>().Any())
                 {
                     stringBuilder.Append("connect ");
-                    BuildInterfacePart(poco, cursorCache, stringBuilder);
+                    BuildInterfacePart(poco, writerContext, stringBuilder);
                 }
             }
             else
             {
                 // Alt 2: InterfacePart
-                BuildInterfacePart(poco, cursorCache, stringBuilder);
+                BuildInterfacePart(poco, writerContext, stringBuilder);
             }
         }
     }

--- a/SysML2.NET/TextualNotation/InvocationExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/InvocationExpressionTextualNotationBuilder.cs
@@ -33,9 +33,9 @@ namespace SysML2.NET.TextualNotation
         /// Build the non-existing InvocationTypeMember rule
         /// </summary>
         /// <param name="poco">The <see cref="IInvocationExpression"/> from which the rule should be built</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder"/></param>
-        private static void BuildInvocationTypeMember(IInvocationExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildInvocationTypeMember(IInvocationExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
         }
     }

--- a/SysML2.NET/TextualNotation/LiteralExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/LiteralExpressionTextualNotationBuilder.cs
@@ -33,9 +33,9 @@ namespace SysML2.NET.TextualNotation
         /// Build the Value rule for real
         /// </summary>
         /// <param name="poco">The <see cref="ILiteralExpression"/></param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder"/></param>
-        private static void BuildValue(ILiteralExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildValue(ILiteralExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
         }
     }

--- a/SysML2.NET/TextualNotation/NamespaceImportTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/NamespaceImportTextualNotationBuilder.cs
@@ -36,13 +36,13 @@ namespace SysML2.NET.TextualNotation
         /// <remarks>NamespaceImport=importedNamespace=[QualifiedName]'::''*'('::'isRecursive?='**')?|importedNamespace=FilterPackage{ownedRelatedElement+=importedNamespace}</remarks>
         /// </summary>
         /// <param name="poco">The <see cref="INamespaceImport" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        private static void BuildNamespaceImportHandCoded(INamespaceImport poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildNamespaceImportHandCoded(INamespaceImport poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             if (poco.OwnedRelatedElement.Contains(poco.ImportedNamespace) && poco.ImportedNamespace is IPackage filterPackage)
             {
-                PackageTextualNotationBuilder.BuildFilterPackage(filterPackage, cursorCache, stringBuilder);
+                PackageTextualNotationBuilder.BuildFilterPackage(filterPackage, writerContext, stringBuilder);
             }
             else if (poco.ImportedNamespace != null)
             {

--- a/SysML2.NET/TextualNotation/OperatorExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/OperatorExpressionTextualNotationBuilder.cs
@@ -45,18 +45,18 @@ namespace SysML2.NET.TextualNotation
         /// so a single call suffices for both operator branches.</para>
         /// </summary>
         /// <param name="poco">The <see cref="IOperatorExpression" /> being serialised</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        private static void BuildClassificationExpressionHandCoded(IOperatorExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildClassificationExpressionHandCoded(IOperatorExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             stringBuilder.Append(poco.Operator);
             stringBuilder.Append(' ');
 
             if (ownedRelationshipCursor.Current is IParameterMembership parameterMembership)
             {
-                ParameterMembershipTextualNotationBuilder.BuildTypeReferenceMember(parameterMembership, cursorCache, stringBuilder);
+                ParameterMembershipTextualNotationBuilder.BuildTypeReferenceMember(parameterMembership, writerContext, stringBuilder);
             }
 
             ownedRelationshipCursor.Move();
@@ -74,18 +74,18 @@ namespace SysML2.NET.TextualNotation
         /// handles both branches.</para>
         /// </summary>
         /// <param name="poco">The <see cref="IOperatorExpression" /> being serialised</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        private static void BuildMetaclassificationExpressionHandCoded(IOperatorExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildMetaclassificationExpressionHandCoded(IOperatorExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             stringBuilder.Append(poco.Operator);
             stringBuilder.Append(' ');
 
             if (ownedRelationshipCursor.Current is IParameterMembership parameterMembership)
             {
-                ParameterMembershipTextualNotationBuilder.BuildTypeReferenceMember(parameterMembership, cursorCache, stringBuilder);
+                ParameterMembershipTextualNotationBuilder.BuildTypeReferenceMember(parameterMembership, writerContext, stringBuilder);
             }
 
             ownedRelationshipCursor.Move();

--- a/SysML2.NET/TextualNotation/PackageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/PackageTextualNotationBuilder.cs
@@ -33,9 +33,9 @@ namespace SysML2.NET.TextualNotation
         /// Build the non-existing Filter Package import rule
         /// </summary>
         /// <param name="poco">The <see cref="IPackage"/> from which the rule should be built</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder"/></param>
-        private static void BuildFilterPackageImport(IPackage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildFilterPackageImport(IPackage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
         }
     }

--- a/SysML2.NET/TextualNotation/ReferenceUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/ReferenceUsageTextualNotationBuilder.cs
@@ -37,7 +37,7 @@ namespace SysML2.NET.TextualNotation
         /// Builds the Textual Notation string for the rule PayloadParameter
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         /// <remarks>
         /// PayloadParameter : ReferenceUsage =
@@ -47,7 +47,7 @@ namespace SysML2.NET.TextualNotation
         /// Alt 2 applies when the reference usage has identification AND a trigger-style
         /// feature value. Otherwise, delegate to PayloadFeature (Alt 1).
         /// </remarks>
-        private static void BuildPayloadParameterHandCoded(IReferenceUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildPayloadParameterHandCoded(IReferenceUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             var hasIdentification = !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName);
             var hasTriggerValue = poco.OwnedRelationship.OfType<IFeatureValue>().Any();
@@ -55,21 +55,21 @@ namespace SysML2.NET.TextualNotation
             if (hasIdentification && hasTriggerValue)
             {
                 // Alt 2: Identification PayloadFeatureSpecializationPart? TriggerValuePart
-                ElementTextualNotationBuilder.BuildIdentification(poco, cursorCache, stringBuilder);
+                ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
 
-                var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
                 if (ownedRelationshipCursor.Current is ISpecialization)
                 {
-                    FeatureTextualNotationBuilder.BuildPayloadFeatureSpecializationPart(poco, cursorCache, stringBuilder);
+                    FeatureTextualNotationBuilder.BuildPayloadFeatureSpecializationPart(poco, writerContext, stringBuilder);
                 }
 
-                FeatureTextualNotationBuilder.BuildTriggerValuePart(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildTriggerValuePart(poco, writerContext, stringBuilder);
             }
             else
             {
                 // Alt 1: PayloadFeature
-                FeatureTextualNotationBuilder.BuildPayloadFeature(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildPayloadFeature(poco, writerContext, stringBuilder);
             }
         }
     }

--- a/SysML2.NET/TextualNotation/RelationshipTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/RelationshipTextualNotationBuilder.cs
@@ -35,26 +35,26 @@ namespace SysML2.NET.TextualNotation
         /// <remarks>RelationshipOwnedElement:Relationship=ownedRelatedElement+=OwnedRelatedElement|ownedRelationship+=OwnedAnnotation. Each alternative consumes exactly one element from its respective collection.</remarks>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Root.Elements.IRelationship" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        private static void BuildRelationshipOwnedElementHandCoded(IRelationship poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildRelationshipOwnedElementHandCoded(IRelationship poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             // Alternative 1: process one OwnedRelatedElement if the ownedRelatedElement cursor has a current value
-            var ownedRelatedElementCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
+            var ownedRelatedElementCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelatedElement", poco.OwnedRelatedElement);
 
             if (ownedRelatedElementCursor.Current != null)
             {
-                ElementTextualNotationBuilder.BuildOwnedRelatedElement(ownedRelatedElementCursor.Current, cursorCache, stringBuilder);
+                ElementTextualNotationBuilder.BuildOwnedRelatedElement(ownedRelatedElementCursor.Current, writerContext, stringBuilder);
                 ownedRelatedElementCursor.Move();
                 return;
             }
 
             // Alternative 2: process one OwnedAnnotation from the ownedRelationship cursor
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current is IAnnotation annotation)
             {
-                AnnotationTextualNotationBuilder.BuildOwnedAnnotation(annotation, cursorCache, stringBuilder);
+                AnnotationTextualNotationBuilder.BuildOwnedAnnotation(annotation, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
             }
         }

--- a/SysML2.NET/TextualNotation/RenderingUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/RenderingUsageTextualNotationBuilder.cs
@@ -43,27 +43,27 @@ namespace SysML2.NET.TextualNotation
         /// which already includes its own body, so each alternative emits its own tail.</para>
         /// </summary>
         /// <param name="poco">The <see cref="IRenderingUsage"/> being serialised</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache"/> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache"/> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder"/> that contains the entire textual notation</param>
-        private static void BuildViewRenderingUsageHandCoded(IRenderingUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildViewRenderingUsageHandCoded(IRenderingUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (poco.OwnedRelationship.OfType<IReferenceSubsetting>().Any())
             {
                 // Alt 1: OwnedReferenceSubsetting FeatureSpecializationPart? UsageBody
                 if (ownedRelationshipCursor.Current is IReferenceSubsetting referenceSubsetting)
                 {
-                    ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(referenceSubsetting, cursorCache, stringBuilder);
+                    ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(referenceSubsetting, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                 }
 
                 if (ownedRelationshipCursor.Current is ISpecialization)
                 {
-                    FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, cursorCache, stringBuilder);
+                    FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, writerContext, stringBuilder);
                 }
 
-                UsageTextualNotationBuilder.BuildUsageBody(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsageBody(poco, writerContext, stringBuilder);
             }
             else
             {
@@ -71,11 +71,11 @@ namespace SysML2.NET.TextualNotation
                 while (ownedRelationshipCursor.Current is IOwningMembership membership
                        && membership.OwnedRelatedElement.OfType<IMetadataUsage>().Any())
                 {
-                    UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, cursorCache, stringBuilder);
+                    UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, writerContext, stringBuilder);
                 }
 
                 stringBuilder.Append("rendering ");
-                UsageTextualNotationBuilder.BuildUsage(poco, cursorCache, stringBuilder);
+                UsageTextualNotationBuilder.BuildUsage(poco, writerContext, stringBuilder);
             }
         }
     }

--- a/SysML2.NET/TextualNotation/RequirementUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/RequirementUsageTextualNotationBuilder.cs
@@ -49,24 +49,24 @@ namespace SysML2.NET.TextualNotation
         /// </para>
         /// </summary>
         /// <param name="poco">The <see cref="IRequirementUsage"/> being serialised</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache"/> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache"/> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder"/> that contains the entire textual notation</param>
-        private static void BuildRequirementVerificationUsageHandCoded(IRequirementUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildRequirementVerificationUsageHandCoded(IRequirementUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (poco.OwnedRelationship.OfType<IReferenceSubsetting>().Any())
             {
                 // Alt 1: consume the OwnedReferenceSubsetting and any trailing FeatureSpecialization*.
                 if (ownedRelationshipCursor.Current is IReferenceSubsetting referenceSubsetting)
                 {
-                    ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(referenceSubsetting, cursorCache, stringBuilder);
+                    ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(referenceSubsetting, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                 }
                 
                 while (ownedRelationshipCursor.Current is ISpecialization)
                 {
-                    FeatureTextualNotationBuilder.BuildFeatureSpecialization(poco, cursorCache, stringBuilder);
+                    FeatureTextualNotationBuilder.BuildFeatureSpecialization(poco, writerContext, stringBuilder);
                 }
             }
             else
@@ -76,14 +76,14 @@ namespace SysML2.NET.TextualNotation
                 while (ownedRelationshipCursor.Current is IOwningMembership membership
                        && membership.OwnedRelatedElement.OfType<IMetadataUsage>().Any())
                 {
-                    UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, cursorCache, stringBuilder);
+                    UsageTextualNotationBuilder.BuildUsageExtensionKeyword(poco, writerContext, stringBuilder);
                 }
 
                 stringBuilder.Append("requirement ");
-                ConstraintUsageTextualNotationBuilder.BuildConstraintUsageDeclaration(poco, cursorCache, stringBuilder);
+                ConstraintUsageTextualNotationBuilder.BuildConstraintUsageDeclaration(poco, writerContext, stringBuilder);
             }
 
-            TypeTextualNotationBuilder.BuildRequirementBody(poco, cursorCache, stringBuilder);
+            TypeTextualNotationBuilder.BuildRequirementBody(poco, writerContext, stringBuilder);
         }
     }
 }

--- a/SysML2.NET/TextualNotation/SendActionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/SendActionUsageTextualNotationBuilder.cs
@@ -42,26 +42,26 @@ namespace SysML2.NET.TextualNotation
         /// otherwise → Alt 1 (NodeParameterMember + optional SenderReceiverPart).</para>
         /// </summary>
         /// <param name="poco">The <see cref="ISendActionUsage" /> being serialised</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        private static void BuildSendNodeHandCoded(ISendActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildSendNodeHandCoded(ISendActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current is IParameterMembership { OwnedRelatedElement.Count: 0 } emptyMembership)
             {
-                ParameterMembershipTextualNotationBuilder.BuildEmptyParameterMember(emptyMembership, cursorCache, stringBuilder);
+                ParameterMembershipTextualNotationBuilder.BuildEmptyParameterMember(emptyMembership, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
-                BuildSenderReceiverPart(poco, cursorCache, stringBuilder);
+                BuildSenderReceiverPart(poco, writerContext, stringBuilder);
             }
             else if (ownedRelationshipCursor.Current is IParameterMembership nodeMembership)
             {
-                ParameterMembershipTextualNotationBuilder.BuildNodeParameterMember(nodeMembership, cursorCache, stringBuilder);
+                ParameterMembershipTextualNotationBuilder.BuildNodeParameterMember(nodeMembership, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
 
                 if (ownedRelationshipCursor.Current is IParameterMembership)
                 {
-                    BuildSenderReceiverPart(poco, cursorCache, stringBuilder);
+                    BuildSenderReceiverPart(poco, writerContext, stringBuilder);
                 }
             }
         }
@@ -78,23 +78,23 @@ namespace SysML2.NET.TextualNotation
         /// elements from the shared cursor.</para>
         /// </summary>
         /// <param name="poco">The <see cref="ISendActionUsage" /> being serialised</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        private static void BuildSenderReceiverPartHandCoded(ISendActionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildSenderReceiverPartHandCoded(ISendActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current is IParameterMembership { OwnedRelatedElement.Count: 0 } emptyMembership)
             {
                 // Alt 2: EmptyParameterMember 'to' NodeParameterMember
-                ParameterMembershipTextualNotationBuilder.BuildEmptyParameterMember(emptyMembership, cursorCache, stringBuilder);
+                ParameterMembershipTextualNotationBuilder.BuildEmptyParameterMember(emptyMembership, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
 
                 stringBuilder.Append("to ");
 
                 if (ownedRelationshipCursor.Current is IParameterMembership toMembership)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildNodeParameterMember(toMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildNodeParameterMember(toMembership, writerContext, stringBuilder);
                 }
 
                 ownedRelationshipCursor.Move();
@@ -103,13 +103,13 @@ namespace SysML2.NET.TextualNotation
             {
                 // Alt 1: 'via' NodeParameterMember ('to' NodeParameterMember)?
                 stringBuilder.Append("via ");
-                ParameterMembershipTextualNotationBuilder.BuildNodeParameterMember(viaMembership, cursorCache, stringBuilder);
+                ParameterMembershipTextualNotationBuilder.BuildNodeParameterMember(viaMembership, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
 
                 if (ownedRelationshipCursor.Current is IParameterMembership toMembership)
                 {
                     stringBuilder.Append("to ");
-                    ParameterMembershipTextualNotationBuilder.BuildNodeParameterMember(toMembership, cursorCache, stringBuilder);
+                    ParameterMembershipTextualNotationBuilder.BuildNodeParameterMember(toMembership, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                 }
             }

--- a/SysML2.NET/TextualNotation/SharedTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/SharedTextualNotationBuilder.cs
@@ -216,5 +216,24 @@ namespace SysML2.NET.TextualNotation
             stringBuilder.AppendLine(" */");
             stringBuilder.AppendLine();
         }
+
+        /// <summary>
+        /// Appends the Qualified Name of the <see cref="IElement"/> for the textual notation, inline with the section 8.2.3.5 of the KerML
+        /// Specification
+        /// </summary>
+        /// <param name="stringBuilder">The <see cref="StringBuilder"/> to append to</param>
+        /// <param name="poco">The <see cref="IElement"/> that needs to have its qualifiedName append</param>
+        internal static void AppendQualifiedName(StringBuilder stringBuilder, IElement poco)
+        {
+            switch (poco)
+            {
+                case IMembership membership:
+                    stringBuilder.Append(membership.MemberElement.qualifiedName);
+                    break;
+                default:
+                    stringBuilder.Append(poco.qualifiedName);
+                    break;
+            }
+        }
     }
 }

--- a/SysML2.NET/TextualNotation/SharedTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/SharedTextualNotationBuilder.cs
@@ -20,6 +20,7 @@
 
 namespace SysML2.NET.TextualNotation
 {
+    using System;
     using System.Linq;
     using System.Text;
 
@@ -50,27 +51,27 @@ namespace SysML2.NET.TextualNotation
         /// (dispatching to <see cref="FeatureTextualNotationBuilder.BuildBasicFeaturePrefix"/>).</para>
         /// </summary>
         /// <param name="poco">The <see cref="IFeature" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        private static void BuildFeaturePrefixHandCoded(IFeature poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildFeaturePrefixHandCoded(IFeature poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (poco.IsEnd)
             {
-                FeatureTextualNotationBuilder.BuildEndFeaturePrefix(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildEndFeaturePrefix(poco, writerContext, stringBuilder);
 
                 if (ownedRelationshipCursor.Current is IOwningMembership owningMembership
                     && owningMembership.OwnedRelatedElement.OfType<IFeature>().Any()
                     && !owningMembership.OwnedRelatedElement.OfType<IMetadataUsage>().Any())
                 {
-                    OwningMembershipTextualNotationBuilder.BuildOwnedCrossFeatureMember(owningMembership, cursorCache, stringBuilder);
+                    OwningMembershipTextualNotationBuilder.BuildOwnedCrossFeatureMember(owningMembership, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                 }
             }
             else
             {
-                FeatureTextualNotationBuilder.BuildBasicFeaturePrefix(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildBasicFeaturePrefix(poco, writerContext, stringBuilder);
             }
         }
 
@@ -89,51 +90,51 @@ namespace SysML2.NET.TextualNotation
         /// <c>SourceSuccessionMember</c> prefix before the <c>StructureUsageMember</c>.</para>
         /// </summary>
         /// <param name="poco">The <see cref="IElement" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        private static void BuildNonBehaviorBodyItemHandCoded(IElement poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildNonBehaviorBodyItemHandCoded(IElement poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current is IImport import)
             {
-                ImportTextualNotationBuilder.BuildImport(import, cursorCache, stringBuilder);
+                ImportTextualNotationBuilder.BuildImport(import, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
             }
             else if (ownedRelationshipCursor.Current is IFeatureMembership featureMembership)
             {
                 if (featureMembership.IsValidForSourceSuccessionMember())
                 {
-                    FeatureMembershipTextualNotationBuilder.BuildSourceSuccessionMember(featureMembership, cursorCache, stringBuilder);
+                    FeatureMembershipTextualNotationBuilder.BuildSourceSuccessionMember(featureMembership, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                 }
 
                 if (ownedRelationshipCursor.Current is IFeatureMembership structureMembership
                     && structureMembership.IsValidForStructureUsageMember())
                 {
-                    FeatureMembershipTextualNotationBuilder.BuildStructureUsageMember(structureMembership, cursorCache, stringBuilder);
+                    FeatureMembershipTextualNotationBuilder.BuildStructureUsageMember(structureMembership, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                 }
                 else if (ownedRelationshipCursor.Current is IVariantMembership variantMembership)
                 {
-                    VariantMembershipTextualNotationBuilder.BuildVariantUsageMember(variantMembership, cursorCache, stringBuilder);
+                    VariantMembershipTextualNotationBuilder.BuildVariantUsageMember(variantMembership, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                 }
                 else if (ownedRelationshipCursor.Current is IFeatureMembership nonOccurrenceMembership
                          && nonOccurrenceMembership.IsValidForNonOccurrenceUsageMember())
                 {
-                    FeatureMembershipTextualNotationBuilder.BuildNonOccurrenceUsageMember(nonOccurrenceMembership, cursorCache, stringBuilder);
+                    FeatureMembershipTextualNotationBuilder.BuildNonOccurrenceUsageMember(nonOccurrenceMembership, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                 }
                 else if (ownedRelationshipCursor.Current is IOwningMembership owningMembership)
                 {
                     if (owningMembership.IsValidForNonFeatureMember())
                     {
-                        OwningMembershipTextualNotationBuilder.BuildDefinitionMember(owningMembership, cursorCache, stringBuilder);
+                        OwningMembershipTextualNotationBuilder.BuildDefinitionMember(owningMembership, writerContext, stringBuilder);
                     }
                     else
                     {
-                        MembershipTextualNotationBuilder.BuildAliasMember(owningMembership, cursorCache, stringBuilder);
+                        MembershipTextualNotationBuilder.BuildAliasMember(owningMembership, writerContext, stringBuilder);
                     }
 
                     ownedRelationshipCursor.Move();
@@ -143,11 +144,11 @@ namespace SysML2.NET.TextualNotation
             {
                 if (owningMembership.IsValidForNonFeatureMember())
                 {
-                    OwningMembershipTextualNotationBuilder.BuildDefinitionMember(owningMembership, cursorCache, stringBuilder);
+                    OwningMembershipTextualNotationBuilder.BuildDefinitionMember(owningMembership, writerContext, stringBuilder);
                 }
                 else
                 {
-                    MembershipTextualNotationBuilder.BuildAliasMember(owningMembership, cursorCache, stringBuilder);
+                    MembershipTextualNotationBuilder.BuildAliasMember(owningMembership, writerContext, stringBuilder);
                 }
 
                 ownedRelationshipCursor.Move();
@@ -155,7 +156,7 @@ namespace SysML2.NET.TextualNotation
             else if (ownedRelationshipCursor.Current is IMembership membership)
             {
                 // AliasMember : Membership — plain Membership that is neither OwningMembership nor FeatureMembership
-                MembershipTextualNotationBuilder.BuildAliasMember(membership, cursorCache, stringBuilder);
+                MembershipTextualNotationBuilder.BuildAliasMember(membership, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
             }
         }
@@ -167,9 +168,9 @@ namespace SysML2.NET.TextualNotation
         /// <see cref="IExpression" /> POCO; this method simply emits it as a string.</para>
         /// </summary>
         /// <param name="poco">The <see cref="IExpression" /> that holds the real value expression</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        private static void BuildRealValueHandCoded(IExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildRealValueHandCoded(IExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             if (poco is ILiteralRational literalRational)
             {
@@ -218,22 +219,168 @@ namespace SysML2.NET.TextualNotation
         }
 
         /// <summary>
-        /// Appends the Qualified Name of the <see cref="IElement"/> for the textual notation, inline with the section 8.2.3.5 of the KerML
-        /// Specification
+        /// Appends the shortest resolvable name of the <see cref="IElement"/> for the textual notation,
+        /// per KerML specification section 8.2.3.5.
+        /// <para>When the <paramref name="writerContext"/> carries a non-null
+        /// <see cref="TextualNotationWriterContext.ContextNamespace"/>, the method walks up the
+        /// namespace chain to find whether the element's simple name resolves via imports
+        /// (per 8.2.3.5.4 Full Resolution). If so, the simple name is used; otherwise the full
+        /// <c>qualifiedName</c> is emitted.</para>
         /// </summary>
         /// <param name="stringBuilder">The <see cref="StringBuilder"/> to append to</param>
-        /// <param name="poco">The <see cref="IElement"/> that needs to have its qualifiedName append</param>
-        internal static void AppendQualifiedName(StringBuilder stringBuilder, IElement poco)
+        /// <param name="poco">The <see cref="IElement"/> that needs to have its name appended</param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext"/> providing the serialization context</param>
+        internal static void AppendQualifiedName(StringBuilder stringBuilder, IElement poco, TextualNotationWriterContext writerContext)
         {
-            switch (poco)
+            if (poco is IMembership membership)
             {
-                case IMembership membership:
-                    stringBuilder.Append(membership.MemberElement.qualifiedName);
-                    break;
-                default:
-                    stringBuilder.Append(poco.qualifiedName);
-                    break;
+                // Membership references (used in import declarations) must retain
+                // their full qualified name — the path identifies WHAT is being imported.
+                stringBuilder.Append(membership.MemberElement.qualifiedName);
             }
+            else
+            {
+                // Element references (used in type/feature references) can be shortened
+                // when the element is resolvable by its simple name via imports (8.2.3.5).
+                stringBuilder.Append(QueryShortestResolvableName(poco, writerContext?.ContextNamespace));
+            }
+        }
+
+        /// <summary>
+        /// Determines the shortest name that will resolve to the given <paramref name="element"/>
+        /// per the KerML name resolution rules (8.2.3.5).
+        /// <para>Per 8.2.3.5.4, full resolution walks up from the local namespace through
+        /// containing namespaces to the global namespace. If the element's simple name resolves
+        /// via the <c>membership</c> (which includes imported memberships) of any namespace in
+        /// that chain, the simple name is sufficient.</para>
+        /// </summary>
+        /// <param name="element">The referenced <see cref="IElement"/> to resolve</param>
+        /// <param name="contextNamespace">
+        /// The root <see cref="INamespace"/> being serialized, or <c>null</c> to fall back to the full qualified name
+        /// </param>
+        /// <returns>The shortest name that resolves to the element</returns>
+        private static string QueryShortestResolvableName(IElement element, INamespace contextNamespace)
+        {
+            if (element == null)
+            {
+                return string.Empty;
+            }
+
+            var simpleName = element.EscapedName();
+
+            if (!string.IsNullOrWhiteSpace(simpleName) && contextNamespace != null)
+            {
+                // Per 8.2.3.5.4, full resolution walks up from the local namespace through
+                // containing namespaces. The contextNamespace is the root namespace being
+                // serialized; imports that make the simple name resolvable may be on any
+                // descendant namespace (e.g. a LibraryPackage nested inside the root).
+                // We check the context namespace and all its descendant namespaces.
+                if (QueryIsResolvableInNamespaceTree(contextNamespace, element, simpleName))
+                {
+                    return simpleName;
+                }
+            }
+
+            return element.qualifiedName ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Recursively checks whether the given <paramref name="element"/> is resolvable by its
+        /// <paramref name="simpleName"/> within the <paramref name="namespace"/> or any of its
+        /// descendant namespaces (per 8.2.3.5.4 full resolution, which walks up from the local
+        /// namespace — checking descendants ensures we cover all import scopes in the output model).
+        /// </summary>
+        /// <param name="namespace">The namespace to check (including descendants)</param>
+        /// <param name="element">The element to find</param>
+        /// <param name="simpleName">The simple name to match</param>
+        /// <returns><c>true</c> if the element is found by simple name in the namespace tree</returns>
+        private static bool QueryIsResolvableInNamespaceTree(INamespace @namespace, IElement element, string simpleName)
+        {
+            try
+            {
+                if (QueryIsResolvableBySimpleName(@namespace, element, simpleName))
+                {
+                    return true;
+                }
+            }
+            catch (NotSupportedException)
+            {
+                // membership may not be fully implemented for this namespace
+            }
+
+            try
+            {
+                foreach (var childNamespace in @namespace.ownedMember.OfType<INamespace>())
+                {
+                    if (QueryIsResolvableInNamespaceTree(childNamespace, element, simpleName))
+                    {
+                        return true;
+                    }
+                }
+            }
+            catch (NotSupportedException)
+            {
+                // ownedMember may not be fully implemented for this namespace
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks whether the given <paramref name="element"/> is resolvable by its
+        /// <paramref name="simpleName"/> within the <paramref name="namespace"/>'s
+        /// memberships (owned, imported, and inherited).
+        /// </summary>
+        /// <param name="namespace">The namespace to check</param>
+        /// <param name="element">The element to find</param>
+        /// <param name="simpleName">The simple name to match</param>
+        /// <returns><c>true</c> if the element is found by simple name in the namespace</returns>
+        private static bool QueryIsResolvableBySimpleName(INamespace @namespace, IElement element, string simpleName)
+        {
+            // Check ownedMembership first (non-derived, always available)
+            foreach (var ownedMember in @namespace.ownedMembership)
+            {
+                if (ownedMember is IOwningMembership owningMembership
+                    && owningMembership.OwnedRelatedElement.Contains(element))
+                {
+                    return true;
+                }
+
+                if (ownedMember.MemberElement == element)
+                {
+                    return true;
+                }
+            }
+
+            // Check imports: walk ownedImport (ownedRelationship filtered to IImport) to find
+            // MembershipImports that reference the element directly by its membership.
+            foreach (var import in @namespace.ownedImport)
+            {
+                if (import is IMembershipImport membershipImport
+                    && membershipImport.ImportedMembership is IMembership importedMembership
+                    && importedMembership.MemberElement == element)
+                {
+                    return true;
+                }
+
+                if (import is INamespaceImport namespaceImport)
+                {
+                    var importedNs = namespaceImport.ImportedNamespace;
+
+                    if (importedNs != null)
+                    {
+                        foreach (var visibleMember in importedNs.ownedMembership)
+                        {
+                            if (visibleMember.MemberElement == element)
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/SysML2.NET/TextualNotation/SharedTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/SharedTextualNotationBuilder.cs
@@ -103,14 +103,14 @@ namespace SysML2.NET.TextualNotation
             }
             else if (ownedRelationshipCursor.Current is IFeatureMembership featureMembership)
             {
-                if (featureMembership.IsValidForSourceSuccessionMember())
+                if (featureMembership.IsValidForSourceSuccessionMember(writerContext))
                 {
                     FeatureMembershipTextualNotationBuilder.BuildSourceSuccessionMember(featureMembership, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                 }
 
                 if (ownedRelationshipCursor.Current is IFeatureMembership structureMembership
-                    && structureMembership.IsValidForStructureUsageMember())
+                    && structureMembership.IsValidForStructureUsageMember(writerContext))
                 {
                     FeatureMembershipTextualNotationBuilder.BuildStructureUsageMember(structureMembership, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
@@ -121,14 +121,14 @@ namespace SysML2.NET.TextualNotation
                     ownedRelationshipCursor.Move();
                 }
                 else if (ownedRelationshipCursor.Current is IFeatureMembership nonOccurrenceMembership
-                         && nonOccurrenceMembership.IsValidForNonOccurrenceUsageMember())
+                         && nonOccurrenceMembership.IsValidForNonOccurrenceUsageMember(writerContext))
                 {
                     FeatureMembershipTextualNotationBuilder.BuildNonOccurrenceUsageMember(nonOccurrenceMembership, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                 }
                 else if (ownedRelationshipCursor.Current is IOwningMembership owningMembership)
                 {
-                    if (owningMembership.IsValidForNonFeatureMember())
+                    if (owningMembership.IsValidForNonFeatureMember(writerContext))
                     {
                         OwningMembershipTextualNotationBuilder.BuildDefinitionMember(owningMembership, writerContext, stringBuilder);
                     }
@@ -142,7 +142,7 @@ namespace SysML2.NET.TextualNotation
             }
             else if (ownedRelationshipCursor.Current is IOwningMembership owningMembership)
             {
-                if (owningMembership.IsValidForNonFeatureMember())
+                if (owningMembership.IsValidForNonFeatureMember(writerContext))
                 {
                     OwningMembershipTextualNotationBuilder.BuildDefinitionMember(owningMembership, writerContext, stringBuilder);
                 }

--- a/SysML2.NET/TextualNotation/SuccessionFlowTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/SuccessionFlowTextualNotationBuilder.cs
@@ -35,7 +35,7 @@ namespace SysML2.NET.TextualNotation
         /// Builds the Textual Notation string for the rule FlowDeclaration
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Interactions.ISuccessionFlow" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         /// <remarks>
         /// FlowDeclaration : Flow =
@@ -48,9 +48,9 @@ namespace SysML2.NET.TextualNotation
         /// Auto-gen emits FeaturePrefix + 'succession flow ' before and TypeBody after.
         /// Same grammar as Flow's FlowDeclaration; ISuccessionFlow extends IFlow.
         /// </remarks>
-        private static void BuildFlowDeclarationHandCoded(ISuccessionFlow poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildFlowDeclarationHandCoded(ISuccessionFlow poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             var hasDeclaration = !string.IsNullOrWhiteSpace(poco.DeclaredShortName)
                                  || !string.IsNullOrWhiteSpace(poco.DeclaredName);
@@ -58,15 +58,15 @@ namespace SysML2.NET.TextualNotation
             if (hasDeclaration || ownedRelationshipCursor.Current is not IEndFeatureMembership)
             {
                 // Alt 1: FeatureDeclaration ValuePart? ('of' PayloadFeatureMember)? ('from' FlowEndMember 'to' FlowEndMember)?
-                FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, cursorCache, stringBuilder);
-                FeatureTextualNotationBuilder.BuildValuePart(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, writerContext, stringBuilder);
+                FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
 
                 // 'of' PayloadFeatureMember? — IFeatureMembership but NOT IEndFeatureMembership
                 if (ownedRelationshipCursor.Current is IFeatureMembership payloadMember
                     && ownedRelationshipCursor.Current is not IEndFeatureMembership)
                 {
                     stringBuilder.Append("of ");
-                    FeatureMembershipTextualNotationBuilder.BuildPayloadFeatureMember(payloadMember, cursorCache, stringBuilder);
+                    FeatureMembershipTextualNotationBuilder.BuildPayloadFeatureMember(payloadMember, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                 }
 
@@ -74,14 +74,14 @@ namespace SysML2.NET.TextualNotation
                 if (ownedRelationshipCursor.Current is IEndFeatureMembership firstFlowEnd)
                 {
                     stringBuilder.Append("from ");
-                    EndFeatureMembershipTextualNotationBuilder.BuildFlowEndMember(firstFlowEnd, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildFlowEndMember(firstFlowEnd, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
 
                     stringBuilder.Append("to ");
 
                     if (ownedRelationshipCursor.Current is IEndFeatureMembership secondFlowEnd)
                     {
-                        EndFeatureMembershipTextualNotationBuilder.BuildFlowEndMember(secondFlowEnd, cursorCache, stringBuilder);
+                        EndFeatureMembershipTextualNotationBuilder.BuildFlowEndMember(secondFlowEnd, writerContext, stringBuilder);
                     }
 
                     ownedRelationshipCursor.Move();
@@ -97,14 +97,14 @@ namespace SysML2.NET.TextualNotation
 
                 if (ownedRelationshipCursor.Current is IEndFeatureMembership firstFlowEnd)
                 {
-                    EndFeatureMembershipTextualNotationBuilder.BuildFlowEndMember(firstFlowEnd, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildFlowEndMember(firstFlowEnd, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
 
                     stringBuilder.Append("to ");
 
                     if (ownedRelationshipCursor.Current is IEndFeatureMembership secondFlowEnd)
                     {
-                        EndFeatureMembershipTextualNotationBuilder.BuildFlowEndMember(secondFlowEnd, cursorCache, stringBuilder);
+                        EndFeatureMembershipTextualNotationBuilder.BuildFlowEndMember(secondFlowEnd, writerContext, stringBuilder);
                     }
 
                     ownedRelationshipCursor.Move();

--- a/SysML2.NET/TextualNotation/SuccessionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/SuccessionTextualNotationBuilder.cs
@@ -35,7 +35,7 @@ namespace SysML2.NET.TextualNotation
         /// Builds the Textual Notation string for the rule SuccessionDeclaration
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Kernel.Connectors.ISuccession" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         /// <remarks>
         /// SuccessionDeclaration : Succession =
@@ -44,9 +44,9 @@ namespace SysML2.NET.TextualNotation
         ///
         /// Auto-gen delegates entirely to this method.
         /// </remarks>
-        private static void BuildSuccessionDeclarationHandCoded(ISuccession poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildSuccessionDeclarationHandCoded(ISuccession poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             var hasDeclaration = !string.IsNullOrWhiteSpace(poco.DeclaredShortName)
                                  || !string.IsNullOrWhiteSpace(poco.DeclaredName)
@@ -56,19 +56,19 @@ namespace SysML2.NET.TextualNotation
             if (hasDeclaration)
             {
                 // Alt 1: FeatureDeclaration ('first' ConnectorEndMember 'then' ConnectorEndMember)?
-                FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, cursorCache, stringBuilder);
+                FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, writerContext, stringBuilder);
 
                 if (ownedRelationshipCursor.Current is IEndFeatureMembership firstEnd)
                 {
                     stringBuilder.Append("first ");
-                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(firstEnd, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(firstEnd, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
 
                     stringBuilder.Append("then ");
 
                     if (ownedRelationshipCursor.Current is IEndFeatureMembership secondEnd)
                     {
-                        EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(secondEnd, cursorCache, stringBuilder);
+                        EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(secondEnd, writerContext, stringBuilder);
                     }
 
                     ownedRelationshipCursor.Move();
@@ -85,14 +85,14 @@ namespace SysML2.NET.TextualNotation
                 if (ownedRelationshipCursor.Current is IEndFeatureMembership firstEnd)
                 {
                     stringBuilder.Append("first ");
-                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(firstEnd, cursorCache, stringBuilder);
+                    EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(firstEnd, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
 
                     stringBuilder.Append("then ");
 
                     if (ownedRelationshipCursor.Current is IEndFeatureMembership secondEnd)
                     {
-                        EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(secondEnd, cursorCache, stringBuilder);
+                        EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(secondEnd, writerContext, stringBuilder);
                     }
 
                     ownedRelationshipCursor.Move();

--- a/SysML2.NET/TextualNotation/TextualNotationValidationExtensions.cs
+++ b/SysML2.NET/TextualNotation/TextualNotationValidationExtensions.cs
@@ -58,29 +58,30 @@ namespace SysML2.NET.TextualNotation
         /// <summary>
         /// Asserts that the <see cref="IFeature"/> is valid for the Typings rule.
         /// <para><c>Typings : Feature = TypedBy (',' ownedRelationship += FeatureTyping)*</c></para>
-        /// <para>Matches when the feature owns at least one <see cref="IFeatureTyping"/>.</para>
+        /// <para>Matches when the feature's <c>ownedRelationship</c> cursor is currently
+        /// positioned at an <see cref="IFeatureTyping"/>.</para>
         /// </summary>
         /// <param name="feature">The <see cref="IFeature"/></param>
-        /// <returns>True if the feature owns an <see cref="IFeatureTyping"/></returns>
-        internal static bool IsValidForTypings(this IFeature feature)
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/></param>
+        /// <returns>True if the cursor's current element is an <see cref="IFeatureTyping"/></returns>
+        internal static bool IsValidForTypings(this IFeature feature, TextualNotationWriterContext writerContext)
         {
-            return feature?.OwnedRelationship.Any(relationship => relationship is IFeatureTyping) == true;
+            return QueryCurrentOwnedRelationship(feature, writerContext) is IFeatureTyping;
         }
 
         /// <summary>
         /// Asserts that the <see cref="IFeature"/> is valid for the Subsettings rule.
         /// <para><c>Subsettings : Feature = Subsets (',' ownedRelationship += OwnedSubsetting)*</c></para>
-        /// <para>Matches when the feature owns an <see cref="ISubsetting"/> that is a plain subsetting —
-        /// i.e. not one of the more specific subtypes (<see cref="IRedefinition"/>,
-        /// <see cref="IReferenceSubsetting"/>, <see cref="ICrossSubsetting"/>), each of which has its
-        /// own dedicated rule (Redefinitions / References / Crosses) elsewhere in the switch.</para>
+        /// <para>Matches when the cursor is at an <see cref="ISubsetting"/> that is NOT one of the
+        /// more specific subtypes (<see cref="IRedefinition"/>, <see cref="IReferenceSubsetting"/>,
+        /// <see cref="ICrossSubsetting"/>), each of which has its own dedicated rule.</para>
         /// </summary>
         /// <param name="feature">The <see cref="IFeature"/></param>
-        /// <returns>True if the feature owns a plain <see cref="ISubsetting"/></returns>
-        internal static bool IsValidForSubsettings(this IFeature feature)
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/></param>
+        /// <returns>True if the cursor's current element is a plain <see cref="ISubsetting"/></returns>
+        internal static bool IsValidForSubsettings(this IFeature feature, TextualNotationWriterContext writerContext)
         {
-            return feature?.OwnedRelationship.Any(relationship =>
-                relationship is ISubsetting and not IRedefinition and not IReferenceSubsetting and not ICrossSubsetting) == true;
+            return QueryCurrentOwnedRelationship(feature, writerContext) is ISubsetting and not IRedefinition and not IReferenceSubsetting and not ICrossSubsetting;
         }
 
         /// <summary>
@@ -88,10 +89,11 @@ namespace SysML2.NET.TextualNotation
         /// <para><c>References : Feature = REFERENCES ownedRelationship += OwnedReferenceSubsetting</c></para>
         /// </summary>
         /// <param name="feature">The <see cref="IFeature"/></param>
-        /// <returns>True if the feature owns an <see cref="IReferenceSubsetting"/></returns>
-        internal static bool IsValidForReferences(this IFeature feature)
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/></param>
+        /// <returns>True if the cursor's current element is an <see cref="IReferenceSubsetting"/></returns>
+        internal static bool IsValidForReferences(this IFeature feature, TextualNotationWriterContext writerContext)
         {
-            return feature?.OwnedRelationship.Any(relationship => relationship is IReferenceSubsetting) == true;
+            return QueryCurrentOwnedRelationship(feature, writerContext) is IReferenceSubsetting;
         }
 
         /// <summary>
@@ -99,10 +101,11 @@ namespace SysML2.NET.TextualNotation
         /// <para><c>Crosses : Feature = CROSSES ownedRelationship += OwnedCrossSubsetting</c></para>
         /// </summary>
         /// <param name="feature">The <see cref="IFeature"/></param>
-        /// <returns>True if the feature owns an <see cref="ICrossSubsetting"/></returns>
-        internal static bool IsValidForCrosses(this IFeature feature)
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/></param>
+        /// <returns>True if the cursor's current element is an <see cref="ICrossSubsetting"/></returns>
+        internal static bool IsValidForCrosses(this IFeature feature, TextualNotationWriterContext writerContext)
         {
-            return feature?.OwnedRelationship.Any(relationship => relationship is ICrossSubsetting) == true;
+            return QueryCurrentOwnedRelationship(feature, writerContext) is ICrossSubsetting;
         }
 
         /// <summary>
@@ -110,10 +113,11 @@ namespace SysML2.NET.TextualNotation
         /// <para><c>ChainingPart : Feature = 'chains' (ownedRelationship += OwnedFeatureChaining | FeatureChain)</c></para>
         /// </summary>
         /// <param name="feature">The <see cref="IFeature"/></param>
-        /// <returns>True if the feature owns an <see cref="IFeatureChaining"/></returns>
-        internal static bool IsValidForChainingPart(this IFeature feature)
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/></param>
+        /// <returns>True if the cursor's current element is an <see cref="IFeatureChaining"/></returns>
+        internal static bool IsValidForChainingPart(this IFeature feature, TextualNotationWriterContext writerContext)
         {
-            return feature?.OwnedRelationship.Any(relationship => relationship is IFeatureChaining) == true;
+            return QueryCurrentOwnedRelationship(feature, writerContext) is IFeatureChaining;
         }
 
         /// <summary>
@@ -121,24 +125,26 @@ namespace SysML2.NET.TextualNotation
         /// <para><c>InvertingPart : Feature = 'inverse' 'of' ownedRelationship += OwnedFeatureInverting</c></para>
         /// </summary>
         /// <param name="feature">The <see cref="IFeature"/></param>
-        /// <returns>True if the feature owns an <see cref="IFeatureInverting"/></returns>
-        internal static bool IsValidForInvertingPart(this IFeature feature)
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/></param>
+        /// <returns>True if the cursor's current element is an <see cref="IFeatureInverting"/></returns>
+        internal static bool IsValidForInvertingPart(this IFeature feature, TextualNotationWriterContext writerContext)
         {
-            return feature?.OwnedRelationship.Any(relationship => relationship is IFeatureInverting) == true;
+            return QueryCurrentOwnedRelationship(feature, writerContext) is IFeatureInverting;
         }
 
         /// <summary>
         /// Asserts that the <see cref="IFeature"/> is valid for the PositionalArgumentList rule.
         /// <para><c>PositionalArgumentList : Feature = e.ownedRelationship += ArgumentMember (',' e.ownedRelationship += ArgumentMember)*</c></para>
-        /// <para>Matches when the feature owns an <see cref="IParameterMembership"/> (as opposed to
-        /// NamedArgumentList, which owns plain <see cref="IFeatureMembership"/> members without being
-        /// <see cref="IParameterMembership"/>).</para>
+        /// <para>Matches when the cursor is positioned at an <see cref="IParameterMembership"/>
+        /// (positional arguments) — the alternative <c>NamedArgumentList</c> uses plain
+        /// <see cref="IFeatureMembership"/> members.</para>
         /// </summary>
         /// <param name="feature">The <see cref="IFeature"/></param>
-        /// <returns>True if the feature owns an <see cref="IParameterMembership"/></returns>
-        internal static bool IsValidForPositionalArgumentList(this IFeature feature)
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/></param>
+        /// <returns>True if the cursor's current element is an <see cref="IParameterMembership"/></returns>
+        internal static bool IsValidForPositionalArgumentList(this IFeature feature, TextualNotationWriterContext writerContext)
         {
-            return feature?.OwnedRelationship.Any(relationship => relationship is IParameterMembership) == true;
+            return QueryCurrentOwnedRelationship(feature, writerContext) is IParameterMembership;
         }
 
         /// <summary>
@@ -146,10 +152,11 @@ namespace SysML2.NET.TextualNotation
         /// <para><c>DisjoiningPart : Type = 'disjoint' 'from' ownedRelationship += OwnedDisjoining (',' ownedRelationship += OwnedDisjoining)*</c></para>
         /// </summary>
         /// <param name="type">The <see cref="IType"/></param>
-        /// <returns>True if the type owns an <see cref="IDisjoining"/></returns>
-        internal static bool IsValidForDisjoiningPart(this IType type)
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/></param>
+        /// <returns>True if the cursor's current element is an <see cref="IDisjoining"/></returns>
+        internal static bool IsValidForDisjoiningPart(this IType type, TextualNotationWriterContext writerContext)
         {
-            return type?.OwnedRelationship.Any(relationship => relationship is IDisjoining) == true;
+            return QueryCurrentOwnedRelationship(type, writerContext) is IDisjoining;
         }
 
         /// <summary>
@@ -157,10 +164,11 @@ namespace SysML2.NET.TextualNotation
         /// <para><c>UnioningPart : Type = 'unions' ownedRelationship += Unioning (',' ownedRelationship += Unioning)*</c></para>
         /// </summary>
         /// <param name="type">The <see cref="IType"/></param>
-        /// <returns>True if the type owns an <see cref="IUnioning"/></returns>
-        internal static bool IsValidForUnioningPart(this IType type)
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/></param>
+        /// <returns>True if the cursor's current element is an <see cref="IUnioning"/></returns>
+        internal static bool IsValidForUnioningPart(this IType type, TextualNotationWriterContext writerContext)
         {
-            return type?.OwnedRelationship.Any(relationship => relationship is IUnioning) == true;
+            return QueryCurrentOwnedRelationship(type, writerContext) is IUnioning;
         }
 
         /// <summary>
@@ -168,10 +176,28 @@ namespace SysML2.NET.TextualNotation
         /// <para><c>IntersectingPart : Type = 'intersects' ownedRelationship += Intersecting (',' ownedRelationship += Intersecting)*</c></para>
         /// </summary>
         /// <param name="type">The <see cref="IType"/></param>
-        /// <returns>True if the type owns an <see cref="IIntersecting"/></returns>
-        internal static bool IsValidForIntersectingPart(this IType type)
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/></param>
+        /// <returns>True if the cursor's current element is an <see cref="IIntersecting"/></returns>
+        internal static bool IsValidForIntersectingPart(this IType type, TextualNotationWriterContext writerContext)
         {
-            return type?.OwnedRelationship.Any(relationship => relationship is IIntersecting) == true;
+            return QueryCurrentOwnedRelationship(type, writerContext) is IIntersecting;
+        }
+
+        /// <summary>
+        /// Returns the current element under the <c>ownedRelationship</c> cursor for the given
+        /// <paramref name="element"/>, or <c>null</c> when context/cursor cannot be obtained.
+        /// </summary>
+        /// <param name="element">The <see cref="IFeature"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/></param>
+        /// <returns>The current cursor element, or <c>null</c></returns>
+        private static IElement QueryCurrentOwnedRelationship(IElement element, TextualNotationWriterContext writerContext)
+        {
+            if (element == null || writerContext?.CursorCache == null)
+            {
+                return null;
+            }
+
+            return writerContext.CursorCache.GetOrCreateCursor(element.Id, "ownedRelationship", element.OwnedRelationship).Current;
         }
 
         /// <summary>
@@ -184,8 +210,9 @@ namespace SysML2.NET.TextualNotation
         /// SatisfyRequirementUsage inherits <see cref="IRequirementUsage"/>).</para>
         /// </summary>
         /// <param name="featureMembership">The <see cref="IFeatureMembership"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the membership owns a behavior-usage element</returns>
-        internal static bool IsValidForBehaviorUsageMember(this IFeatureMembership featureMembership)
+        internal static bool IsValidForBehaviorUsageMember(this IFeatureMembership featureMembership, TextualNotationWriterContext writerContext)
         {
             return featureMembership?.OwnedRelatedElement.Any(element =>
                 element is IActionUsage or IStateUsage or IConstraintUsage
@@ -199,8 +226,9 @@ namespace SysML2.NET.TextualNotation
         /// so exactly two <see cref="IEndFeatureMembership"/> entries = binary.</para>
         /// </summary>
         /// <param name="connector">The <see cref="IConnector"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the connector owns exactly two <see cref="IEndFeatureMembership"/> children</returns>
-        internal static bool IsValidForBinaryConnectorDeclaration(this IConnector connector)
+        internal static bool IsValidForBinaryConnectorDeclaration(this IConnector connector, TextualNotationWriterContext writerContext)
         {
             return connector?.OwnedRelationship.OfType<IEndFeatureMembership>().Count() == 2;
         }
@@ -213,8 +241,9 @@ namespace SysML2.NET.TextualNotation
         /// <see cref="IEndFeatureMembership"/> entries: exactly two = binary, otherwise n-ary.</para>
         /// </summary>
         /// <param name="connectionUsage">The <see cref="IConnectionUsage"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the connection usage owns exactly two <see cref="IEndFeatureMembership"/> children</returns>
-        internal static bool IsValidForBinaryConnectorPart(this IConnectionUsage connectionUsage)
+        internal static bool IsValidForBinaryConnectorPart(this IConnectionUsage connectionUsage, TextualNotationWriterContext writerContext)
         {
             return connectionUsage?.OwnedRelationship.OfType<IEndFeatureMembership>().Count() == 2;
         }
@@ -226,8 +255,9 @@ namespace SysML2.NET.TextualNotation
         /// <para><c>InterfaceEndMember : EndFeatureMembership</c> — exactly two <see cref="IEndFeatureMembership"/> = binary.</para>
         /// </summary>
         /// <param name="interfaceUsage">The <see cref="IInterfaceUsage"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the interface usage owns exactly two <see cref="IEndFeatureMembership"/> children</returns>
-        internal static bool IsValidForBinaryInterfacePart(this IInterfaceUsage interfaceUsage)
+        internal static bool IsValidForBinaryInterfacePart(this IInterfaceUsage interfaceUsage, TextualNotationWriterContext writerContext)
         {
             return interfaceUsage?.OwnedRelationship.OfType<IEndFeatureMembership>().Count() == 2;
         }
@@ -242,8 +272,9 @@ namespace SysML2.NET.TextualNotation
         /// <see cref="IFlowUsage"/>.</para>
         /// </summary>
         /// <param name="usage">The <see cref="IUsage"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the usage is a structural-usage metaclass</returns>
-        internal static bool IsValidForStructureUsageElement(this IUsage usage)
+        internal static bool IsValidForStructureUsageElement(this IUsage usage, TextualNotationWriterContext writerContext)
         {
             return usage is IOccurrenceUsage or IItemUsage or IPartUsage or IViewUsage
                 or IRenderingUsage or IPortUsage or IConnectionUsage or IInterfaceUsage
@@ -257,8 +288,9 @@ namespace SysML2.NET.TextualNotation
         /// specific rules (<c>IndividualUsage</c>, <c>PortionUsage</c>).</para>
         /// </summary>
         /// <param name="occurrenceUsage">The <see cref="IOccurrenceUsage"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the usage is a plain occurrence (no individual, no portion kind)</returns>
-        internal static bool IsValidForOccurrenceUsage(this IOccurrenceUsage occurrenceUsage)
+        internal static bool IsValidForOccurrenceUsage(this IOccurrenceUsage occurrenceUsage, TextualNotationWriterContext writerContext)
         {
             return occurrenceUsage is { IsIndividual: false, PortionKind: null };
         }
@@ -271,8 +303,9 @@ namespace SysML2.NET.TextualNotation
         /// and should flow to the default case.</para>
         /// </summary>
         /// <param name="occurrenceUsage">The <see cref="IOccurrenceUsage"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the usage is an individual (not a portion)</returns>
-        internal static bool IsValidForIndividualUsage(this IOccurrenceUsage occurrenceUsage)
+        internal static bool IsValidForIndividualUsage(this IOccurrenceUsage occurrenceUsage, TextualNotationWriterContext writerContext)
         {
             return occurrenceUsage is { IsIndividual: true, PortionKind: null };
         }
@@ -285,8 +318,9 @@ namespace SysML2.NET.TextualNotation
         /// <c>IndividualDefinition</c> is the default fallback.</para>
         /// </summary>
         /// <param name="occurrenceDefinition">The <see cref="IOccurrenceDefinition"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the definition is a plain occurrence (not an individual)</returns>
-        internal static bool IsValidForOccurrenceDefinition(this IOccurrenceDefinition occurrenceDefinition)
+        internal static bool IsValidForOccurrenceDefinition(this IOccurrenceDefinition occurrenceDefinition, TextualNotationWriterContext writerContext)
         {
             return occurrenceDefinition is { IsIndividual: false };
         }
@@ -297,8 +331,9 @@ namespace SysML2.NET.TextualNotation
         /// <para><c>FlowUsage = OccurrenceUsagePrefix 'flow' FlowDeclaration DefinitionBody</c></para>
         /// </summary>
         /// <param name="flowUsage">The <see cref="IFlowUsage"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the usage is not abstract (i.e. not a Message)</returns>
-        internal static bool IsValidForFlowUsage(this IFlowUsage flowUsage)
+        internal static bool IsValidForFlowUsage(this IFlowUsage flowUsage, TextualNotationWriterContext writerContext)
         {
             return flowUsage is { IsAbstract: false };
         }
@@ -310,8 +345,9 @@ namespace SysML2.NET.TextualNotation
         /// distinguisher between a Message and a plain FlowUsage in the unparse direction.</para>
         /// </summary>
         /// <param name="flowUsage">The <see cref="IFlowUsage"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the usage is abstract (a Message)</returns>
-        internal static bool IsValidForMessage(this IFlowUsage flowUsage)
+        internal static bool IsValidForMessage(this IFlowUsage flowUsage, TextualNotationWriterContext writerContext)
         {
             return flowUsage is { IsAbstract: true };
         }
@@ -322,8 +358,9 @@ namespace SysML2.NET.TextualNotation
         /// <para><c>GuardExpressionMember : TransitionFeatureMembership = 'if' { kind = 'guard' } …</c></para>
         /// </summary>
         /// <param name="transitionUsage">The <see cref="ITransitionUsage"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the transition owns a guard-kind transition feature membership</returns>
-        internal static bool IsValidForGuardedTargetSuccession(this ITransitionUsage transitionUsage)
+        internal static bool IsValidForGuardedTargetSuccession(this ITransitionUsage transitionUsage, TextualNotationWriterContext writerContext)
         {
             return transitionUsage?.OwnedRelationship.Any(relationship =>
                 relationship is ITransitionFeatureMembership { Kind: SysML2.NET.Core.Systems.States.TransitionFeatureKind.Guard }) == true;
@@ -335,8 +372,9 @@ namespace SysML2.NET.TextualNotation
         /// <para><c>ActionBodyParameter : ActionUsage = ('action' UsageDeclaration?)? '{' ActionBodyItem* '}'</c></para>
         /// </summary>
         /// <param name="parameterMembership">The <see cref="IParameterMembership"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the membership owns an <see cref="IActionUsage"/></returns>
-        internal static bool IsValidForActionBodyParameterMember(this IParameterMembership parameterMembership)
+        internal static bool IsValidForActionBodyParameterMember(this IParameterMembership parameterMembership, TextualNotationWriterContext writerContext)
         {
             return parameterMembership?.OwnedRelatedElement.OfType<IActionUsage>().Any() == true;
         }
@@ -397,8 +435,9 @@ namespace SysML2.NET.TextualNotation
         /// <para><c>ConditionalExpression : OperatorExpression = operator='if' …</c></para>
         /// </summary>
         /// <param name="operatorExpression">The <see cref="IOperatorExpression"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the expression's <c>Operator</c> is <c>"if"</c></returns>
-        internal static bool IsValidForConditionalExpression(this IOperatorExpression operatorExpression)
+        internal static bool IsValidForConditionalExpression(this IOperatorExpression operatorExpression, TextualNotationWriterContext writerContext)
         {
             return operatorExpression?.Operator == "if";
         }
@@ -408,8 +447,9 @@ namespace SysML2.NET.TextualNotation
         /// <para><c>operator = ConditionalBinaryOperator</c> where <c>ConditionalBinaryOperator = '??' | 'or' | 'and' | 'implies'</c></para>
         /// </summary>
         /// <param name="operatorExpression">The <see cref="IOperatorExpression"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the expression's <c>Operator</c> is one of the conditional binary operators</returns>
-        internal static bool IsValidForConditionalBinaryOperatorExpression(this IOperatorExpression operatorExpression)
+        internal static bool IsValidForConditionalBinaryOperatorExpression(this IOperatorExpression operatorExpression, TextualNotationWriterContext writerContext)
         {
             return operatorExpression?.Operator is not null && ConditionalBinaryOperators.Contains(operatorExpression.Operator);
         }
@@ -422,8 +462,9 @@ namespace SysML2.NET.TextualNotation
         /// requires the expression to own at least two <see cref="IParameterMembership"/> arguments.</para>
         /// </summary>
         /// <param name="operatorExpression">The <see cref="IOperatorExpression"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the expression matches the BinaryOperatorExpression rule</returns>
-        internal static bool IsValidForBinaryOperatorExpression(this IOperatorExpression operatorExpression)
+        internal static bool IsValidForBinaryOperatorExpression(this IOperatorExpression operatorExpression, TextualNotationWriterContext writerContext)
         {
             if (operatorExpression?.Operator is null || !BinaryOperators.Contains(operatorExpression.Operator))
             {
@@ -445,8 +486,9 @@ namespace SysML2.NET.TextualNotation
         /// to own a single <see cref="IParameterMembership"/> argument.</para>
         /// </summary>
         /// <param name="operatorExpression">The <see cref="IOperatorExpression"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the expression matches the UnaryOperatorExpression rule</returns>
-        internal static bool IsValidForUnaryOperatorExpression(this IOperatorExpression operatorExpression)
+        internal static bool IsValidForUnaryOperatorExpression(this IOperatorExpression operatorExpression, TextualNotationWriterContext writerContext)
         {
             if (operatorExpression?.Operator is null || !UnaryOperators.Contains(operatorExpression.Operator))
             {
@@ -469,8 +511,9 @@ namespace SysML2.NET.TextualNotation
         /// <para>Matches when the operator is one of <c>'istype'</c>, <c>'hastype'</c>, <c>'@'</c>, or <c>'as'</c>.</para>
         /// </summary>
         /// <param name="operatorExpression">The <see cref="IOperatorExpression"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the expression's <c>Operator</c> is a classification-test or cast operator</returns>
-        internal static bool IsValidForClassificationExpression(this IOperatorExpression operatorExpression)
+        internal static bool IsValidForClassificationExpression(this IOperatorExpression operatorExpression, TextualNotationWriterContext writerContext)
         {
             return operatorExpression?.Operator is not null && ClassificationExpressionOperators.Contains(operatorExpression.Operator);
         }
@@ -488,8 +531,9 @@ namespace SysML2.NET.TextualNotation
         /// deferred.</para>
         /// </summary>
         /// <param name="operatorExpression">The <see cref="IOperatorExpression"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the expression's <c>Operator</c> is a meta-cast or metaclassification-test operator</returns>
-        internal static bool IsValidForMetaclassificationExpression(this IOperatorExpression operatorExpression)
+        internal static bool IsValidForMetaclassificationExpression(this IOperatorExpression operatorExpression, TextualNotationWriterContext writerContext)
         {
             return operatorExpression?.Operator is not null && MetaclassificationExpressionOperators.Contains(operatorExpression.Operator);
         }
@@ -504,8 +548,9 @@ namespace SysML2.NET.TextualNotation
         /// disambiguates.</para>
         /// </summary>
         /// <param name="expression">The <see cref="IExpression"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True for any non-null expression</returns>
-        internal static bool IsValidForSequenceExpression(this IExpression expression)
+        internal static bool IsValidForSequenceExpression(this IExpression expression, TextualNotationWriterContext writerContext)
         {
             return expression is not null;
         }
@@ -521,8 +566,9 @@ namespace SysML2.NET.TextualNotation
         /// dispatcher should place any future BodyExpression case before this guard.</para>
         /// </summary>
         /// <param name="featureReferenceExpression">The <see cref="IFeatureReferenceExpression"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True for any non-null expression</returns>
-        internal static bool IsValidForFeatureReferenceExpression(this IFeatureReferenceExpression featureReferenceExpression)
+        internal static bool IsValidForFeatureReferenceExpression(this IFeatureReferenceExpression featureReferenceExpression, TextualNotationWriterContext writerContext)
         {
             return featureReferenceExpression is not null;
         }
@@ -537,8 +583,9 @@ namespace SysML2.NET.TextualNotation
         /// an <c>ActionBodyItem</c> dispatch, which is the only caller.</para>
         /// </summary>
         /// <param name="featureMembership">The <see cref="IFeatureMembership"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the membership references its target via cross-reference only</returns>
-        internal static bool IsValidForInitialNodeMember(this IFeatureMembership featureMembership)
+        internal static bool IsValidForInitialNodeMember(this IFeatureMembership featureMembership, TextualNotationWriterContext writerContext)
         {
             return featureMembership is { MemberElement: not null }
                 && featureMembership.OwnedRelatedElement.Count == 0;
@@ -553,8 +600,9 @@ namespace SysML2.NET.TextualNotation
         /// checked first, then ActionTargetSuccessionMember).</para>
         /// </summary>
         /// <param name="featureMembership">The <see cref="IFeatureMembership"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the membership owns a succession or transition usage</returns>
-        internal static bool IsValidForActionTargetSuccessionMember(this IFeatureMembership featureMembership)
+        internal static bool IsValidForActionTargetSuccessionMember(this IFeatureMembership featureMembership, TextualNotationWriterContext writerContext)
         {
             return featureMembership?.OwnedRelatedElement.Any(element => element is ISuccessionAsUsage or ITransitionUsage) == true;
         }
@@ -568,8 +616,9 @@ namespace SysML2.NET.TextualNotation
         /// or its descendants). The broadest accurate predicate is "owns an <see cref="IActionUsage"/>".</para>
         /// </summary>
         /// <param name="featureMembership">The <see cref="IFeatureMembership"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the membership owns an <see cref="IActionUsage"/></returns>
-        internal static bool IsValidForActionBehaviorMember(this IFeatureMembership featureMembership)
+        internal static bool IsValidForActionBehaviorMember(this IFeatureMembership featureMembership, TextualNotationWriterContext writerContext)
         {
             return featureMembership?.OwnedRelatedElement.OfType<IActionUsage>().Any() == true;
         }
@@ -580,8 +629,9 @@ namespace SysML2.NET.TextualNotation
         /// <para><c>GuardedSuccession : TransitionUsage = ('succession' UsageDeclaration)? 'first' … ownedRelationship += GuardExpressionMember 'then' …</c></para>
         /// </summary>
         /// <param name="featureMembership">The <see cref="IFeatureMembership"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the membership owns a transition usage with a guard-kind feature</returns>
-        internal static bool IsValidForGuardedSuccessionMember(this IFeatureMembership featureMembership)
+        internal static bool IsValidForGuardedSuccessionMember(this IFeatureMembership featureMembership, TextualNotationWriterContext writerContext)
         {
             return featureMembership?.OwnedRelatedElement.OfType<ITransitionUsage>().Any(transition =>
                 transition.OwnedRelationship.Any(relationship =>
@@ -598,8 +648,9 @@ namespace SysML2.NET.TextualNotation
         /// broader predicate only matches the residual transition case.</para>
         /// </summary>
         /// <param name="featureMembership">The <see cref="IFeatureMembership"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the membership owns an <see cref="ITransitionUsage"/></returns>
-        internal static bool IsValidForTransitionUsageMember(this IFeatureMembership featureMembership)
+        internal static bool IsValidForTransitionUsageMember(this IFeatureMembership featureMembership, TextualNotationWriterContext writerContext)
         {
             return featureMembership?.OwnedRelatedElement.OfType<ITransitionUsage>().Any() == true;
         }
@@ -615,8 +666,9 @@ namespace SysML2.NET.TextualNotation
         /// perfectly capture the parse context.</para>
         /// </summary>
         /// <param name="featureMembership">The <see cref="IFeatureMembership"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the membership owns a transition usage whose first parameter is empty</returns>
-        internal static bool IsValidForTargetTransitionUsageMember(this IFeatureMembership featureMembership)
+        internal static bool IsValidForTargetTransitionUsageMember(this IFeatureMembership featureMembership, TextualNotationWriterContext writerContext)
         {
             return featureMembership?.OwnedRelatedElement.OfType<ITransitionUsage>().Any(transition =>
                 transition.OwnedRelationship.OfType<IParameterMembership>().FirstOrDefault() is IParameterMembership parameterMembership
@@ -628,8 +680,9 @@ namespace SysML2.NET.TextualNotation
         /// <para><c>EntryActionMember : StateSubactionMembership = MemberPrefix kind = 'entry' …</c></para>
         /// </summary>
         /// <param name="featureMembership">The <see cref="IFeatureMembership"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the membership is a <see cref="IStateSubactionMembership"/> with <c>Kind == Entry</c></returns>
-        internal static bool IsValidForEntryActionMember(this IFeatureMembership featureMembership)
+        internal static bool IsValidForEntryActionMember(this IFeatureMembership featureMembership, TextualNotationWriterContext writerContext)
         {
             return featureMembership is IStateSubactionMembership { Kind: SysML2.NET.Core.Systems.States.StateSubactionKind.Entry };
         }
@@ -641,70 +694,38 @@ namespace SysML2.NET.TextualNotation
         /// <see cref="ISuccessionAsUsage"/>.</para>
         /// </summary>
         /// <param name="featureMembership">The <see cref="IFeatureMembership"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if the membership owns a succession or transition usage</returns>
-        internal static bool IsValidForEntryTransitionMemberRule(this IFeatureMembership featureMembership)
+        internal static bool IsValidForEntryTransitionMemberRule(this IFeatureMembership featureMembership, TextualNotationWriterContext writerContext)
         {
             return featureMembership?.OwnedRelatedElement.Any(element => element is ITransitionUsage or ISuccessionAsUsage) == true;
         }
-
+        
         /// <summary>
-        /// Asserts that the <see cref="IFeatureMembership"/> is valid for the DoActionMember rule (StateBodyItem).
-        /// <para><c>DoActionMember : StateSubactionMembership = MemberPrefix kind = 'do' …</c></para>
-        /// </summary>
-        /// <param name="featureMembership">The <see cref="IFeatureMembership"/></param>
-        /// <returns>True if the membership is a <see cref="IStateSubactionMembership"/> with <c>Kind == Do</c></returns>
-        internal static bool IsValidForDoActionMember(this IFeatureMembership featureMembership)
-        {
-            return featureMembership is IStateSubactionMembership { Kind: SysML2.NET.Core.Systems.States.StateSubactionKind.Do };
-        }
-
-        /// <summary>
-        /// Asserts that the <see cref="IFeatureMembership"/> is valid for the ExitActionMember rule (StateBodyItem).
-        /// <para><c>ExitActionMember : StateSubactionMembership = MemberPrefix kind = 'exit' …</c></para>
-        /// </summary>
-        /// <param name="featureMembership">The <see cref="IFeatureMembership"/></param>
-        /// <returns>True if the membership is a <see cref="IStateSubactionMembership"/> with <c>Kind == Exit</c></returns>
-        internal static bool IsValidForExitActionMember(this IFeatureMembership featureMembership)
-        {
-            return featureMembership is IStateSubactionMembership { Kind: SysML2.NET.Core.Systems.States.StateSubactionKind.Exit };
-        }
-
-        /// <summary>
-        /// Asserts that the <see cref="IElement"/> matches the lexical <c>BASIC_NAME</c> rule
-        /// (i.e. the name would be expressed as a <c>BASIC_NAME</c> rather than an
-        /// <c>UNRESTRICTED_NAME</c>). Used to dispatch inside the generated <c>NAME</c>
-        /// switch inlined by <c>QualifiedName</c>.
-        /// <para>Delegates to <see cref="StringExtensions.QueryIsValidBasicName"/>, which checks
-        /// the declared name against the <c>[a-zA-Z_][a-zA-Z0-9_]*</c> pattern and excludes
-        /// reserved keywords.</para>
-        /// </summary>
-        /// <param name="element">The <see cref="IElement"/></param>
-        /// <returns>True if the element's declared name is a valid basic name</returns>
-        internal static bool IsValidForBASIC_NAME(this IElement element)
-        {
-            return !string.IsNullOrWhiteSpace(element?.DeclaredName) && element.DeclaredName.QueryIsValidBasicName();
-        }
-
-        /// <summary>
-        /// Asserts that the <see cref="IOwningMembership"/> contains at least one <see cref="IFeature"/>
-        /// inside the <see cref="IRelationship.OwnedRelatedElement"/> collection
+        /// Asserts that the <see cref="IOwningMembership"/> is valid for the NonFeatureMember rule.
+        /// <para><c>NonFeatureMember : OwningMembership = MemberPrefix ownedRelatedElement += MemberElement</c></para>
+        /// <para><c>MemberElement = AnnotatingElement | NonFeatureElement</c> — a NonFeatureMember
+        /// owns an element that is NOT an <see cref="IFeature"/>.</para>
         /// </summary>
         /// <param name="owningMembership">The <see cref="IOwningMembership"/></param>
-        /// <returns>True if one <see cref="IFeature"/> is contained in the <see cref="IRelationship.OwnedRelatedElement"/></returns>
-        internal static bool IsValidForNonFeatureMember(this IOwningMembership owningMembership)
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
+        /// <returns>True if no <see cref="IFeature"/> is contained in the <see cref="IRelationship.OwnedRelatedElement"/></returns>
+        internal static bool IsValidForNonFeatureMember(this IOwningMembership owningMembership, TextualNotationWriterContext writerContext)
+        {
+            return !owningMembership.OwnedRelatedElement.OfType<IFeature>().Any();
+        }
+
+        /// <summary>
+        /// Asserts that the <see cref="IOwningMembership"/> is valid for the FeatureMember rule.
+        /// <para><c>FeatureMember : OwningMembership = TypeFeatureMember | OwnedFeatureMember</c></para>
+        /// <para>Both alternatives own an <see cref="IFeature"/>.</para>
+        /// </summary>
+        /// <param name="owningMembership">The <see cref="IOwningMembership"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
+        /// <returns>True if at least one <see cref="IFeature"/> is contained in the <see cref="IRelationship.OwnedRelatedElement"/></returns>
+        internal static bool IsValidForFeatureMember(this IOwningMembership owningMembership, TextualNotationWriterContext writerContext)
         {
             return owningMembership.OwnedRelatedElement.OfType<IFeature>().Any();
-        }
-
-        /// <summary>
-        /// Asserts that the <see cref="IOwningMembership"/> does not contain any <see cref="IFeature"/>
-        /// inside the <see cref="IRelationship.OwnedRelatedElement"/> collection
-        /// </summary>
-        /// <param name="owningMembership">The <see cref="IOwningMembership"/></param>
-        /// <returns>True if no <see cref="IFeature"/> is contained in the <see cref="IRelationship.OwnedRelatedElement"/></returns>
-        internal static bool IsValidForFeatureMember(this IOwningMembership owningMembership)
-        {
-            return !owningMembership.IsValidForNonFeatureMember();
         }
 
         /// <summary>
@@ -712,8 +733,9 @@ namespace SysML2.NET.TextualNotation
         /// inside the <see cref="IRelationship.OwnedRelatedElement"/> collection
         /// </summary>
         /// <param name="featureMembership">The <see cref="IFeatureMembership"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if it contains one <see cref="ISuccessionAsUsage"/></returns>
-        internal static bool IsValidForSourceSuccessionMember(this IFeatureMembership featureMembership)
+        internal static bool IsValidForSourceSuccessionMember(this IFeatureMembership featureMembership, TextualNotationWriterContext writerContext)
         {
             return featureMembership.OwnedRelatedElement.OfType<ISuccessionAsUsage>().Any();
         }
@@ -723,8 +745,9 @@ namespace SysML2.NET.TextualNotation
         /// inside the <see cref="IRelationship.OwnedRelatedElement"/> collection
         /// </summary>
         /// <param name="featureMembership">The <see cref="IFeatureMembership"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if it contains one <see cref="IOccurrenceUsage"/></returns>
-        internal static bool IsValidForOccurrenceUsageMember(this IFeatureMembership featureMembership)
+        internal static bool IsValidForOccurrenceUsageMember(this IFeatureMembership featureMembership, TextualNotationWriterContext writerContext)
         {
             return featureMembership.OwnedRelatedElement.OfType<IOccurrenceUsage>().Any();
         }
@@ -734,10 +757,11 @@ namespace SysML2.NET.TextualNotation
         /// but no <see cref="IOccurrenceUsage"/> inside the <see cref="IRelationship.OwnedRelatedElement"/> collection
         /// </summary>
         /// <param name="featureMembership">The <see cref="IFeatureMembership"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if it contains one <see cref="IUsage"/> but no <see cref="IOccurrenceUsage"/></returns>
-        internal static bool IsValidForNonOccurrenceUsageMember(this IFeatureMembership featureMembership)
+        internal static bool IsValidForNonOccurrenceUsageMember(this IFeatureMembership featureMembership, TextualNotationWriterContext writerContext)
         {
-            return !featureMembership.IsValidForOccurrenceUsageMember() && featureMembership.OwnedRelatedElement.OfType<IUsage>().Any();
+            return !featureMembership.IsValidForOccurrenceUsageMember(writerContext) && featureMembership.OwnedRelatedElement.OfType<IUsage>().Any();
         }
 
         /// <summary>
@@ -745,8 +769,9 @@ namespace SysML2.NET.TextualNotation
         /// inside the <see cref="IRelationship.OwnedRelatedElement"/> collection
         /// </summary>
         /// <param name="featureMembership">The <see cref="IFeatureMembership"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
         /// <returns>True if contains any of the required element types</returns>
-        internal static bool IsValidForStructureUsageMember(this IFeatureMembership featureMembership)
+        internal static bool IsValidForStructureUsageMember(this IFeatureMembership featureMembership, TextualNotationWriterContext writerContext)
         {
             return featureMembership.OwnedRelatedElement.OfType<OccurrenceUsage>().Any()
                    || featureMembership.OwnedRelatedElement.OfType<EventOccurrenceUsage>().Any()

--- a/SysML2.NET/TextualNotation/TextualNotationWriterContext.cs
+++ b/SysML2.NET/TextualNotation/TextualNotationWriterContext.cs
@@ -1,0 +1,69 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="TextualNotationWriterContext.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.TextualNotation
+{
+    using System;
+
+    using SysML2.NET.Core.POCO.Root.Namespaces;
+
+    /// <summary>
+    /// Provides the serialization context for the textual notation builders.
+    /// Carries the <see cref="ICursorCache"/> for cursor-based element traversal,
+    /// the <see cref="INamespace"/> context for qualified name resolution (KerML 8.2.3.5),
+    /// and future writer settings (indentation, short/long notation preferences, etc.).
+    /// </summary>
+    public class TextualNotationWriterContext : IDisposable
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TextualNotationWriterContext"/> class.
+        /// </summary>
+        /// <param name="contextNamespace">
+        /// The root <see cref="INamespace"/> being serialized. Used by
+        /// <see cref="SharedTextualNotationBuilder.AppendQualifiedName"/> to determine
+        /// the shortest resolvable name for cross-references.
+        /// </param>
+        public TextualNotationWriterContext(INamespace contextNamespace)
+        {
+            this.CursorCache = new CursorCache();
+            this.ContextNamespace = contextNamespace ?? throw new ArgumentNullException(nameof(contextNamespace));
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ICursorCache"/> used for cursor-based element traversal.
+        /// </summary>
+        public ICursorCache CursorCache { get; }
+
+        /// <summary>
+        /// Gets the root <see cref="INamespace"/> being serialized, providing the
+        /// context for qualified name resolution per KerML specification section 8.2.3.5.
+        /// </summary>
+        public INamespace ContextNamespace { get; }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting
+        /// unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            this.CursorCache.Dispose();
+        }
+    }
+}

--- a/SysML2.NET/TextualNotation/TransitionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/TransitionUsageTextualNotationBuilder.cs
@@ -34,7 +34,7 @@ namespace SysML2.NET.TextualNotation
         /// Builds the Textual Notation string for the rule TargetTransitionUsage
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.States.ITransitionUsage" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         /// <remarks>
         /// TargetTransitionUsage : TransitionUsage =
@@ -57,19 +57,19 @@ namespace SysML2.NET.TextualNotation
         /// TransitionSuccessionMember + ActionBody after. This method handles only the
         /// optional middle section.
         /// </remarks>
-        private static void BuildTargetTransitionUsageHandCoded(ITransitionUsage poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildTargetTransitionUsageHandCoded(ITransitionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             if (ownedRelationshipCursor.Current is ITransitionFeatureMembership { Kind: SysML2.NET.Core.Systems.States.TransitionFeatureKind.Guard } guardMember)
             {
                 // Alt 3: GuardExpressionMember (EffectBehaviorMember)?
-                TransitionFeatureMembershipTextualNotationBuilder.BuildGuardExpressionMember(guardMember, cursorCache, stringBuilder);
+                TransitionFeatureMembershipTextualNotationBuilder.BuildGuardExpressionMember(guardMember, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
 
                 if (ownedRelationshipCursor.Current is ITransitionFeatureMembership { Kind: SysML2.NET.Core.Systems.States.TransitionFeatureKind.Effect } effectMember)
                 {
-                    TransitionFeatureMembershipTextualNotationBuilder.BuildEffectBehaviorMember(effectMember, cursorCache, stringBuilder);
+                    TransitionFeatureMembershipTextualNotationBuilder.BuildEffectBehaviorMember(effectMember, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                 }
             }
@@ -91,25 +91,25 @@ namespace SysML2.NET.TextualNotation
                 }
 
                 // Both Alt 1 and Alt 2: consume EmptyParameterMember
-                ParameterMembershipTextualNotationBuilder.BuildEmptyParameterMember(emptyParam, cursorCache, stringBuilder);
+                ParameterMembershipTextualNotationBuilder.BuildEmptyParameterMember(emptyParam, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
 
                 // Consume TriggerActionMember if present (mandatory in Alt 2, optional in Alt 1)
                 if (ownedRelationshipCursor.Current is ITransitionFeatureMembership { Kind: SysML2.NET.Core.Systems.States.TransitionFeatureKind.Trigger } triggerMember)
                 {
-                    TransitionFeatureMembershipTextualNotationBuilder.BuildTriggerActionMember(triggerMember, cursorCache, stringBuilder);
+                    TransitionFeatureMembershipTextualNotationBuilder.BuildTriggerActionMember(triggerMember, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                 }
 
                 if (ownedRelationshipCursor.Current is ITransitionFeatureMembership { Kind: SysML2.NET.Core.Systems.States.TransitionFeatureKind.Guard } guardAfterTrigger)
                 {
-                    TransitionFeatureMembershipTextualNotationBuilder.BuildGuardExpressionMember(guardAfterTrigger, cursorCache, stringBuilder);
+                    TransitionFeatureMembershipTextualNotationBuilder.BuildGuardExpressionMember(guardAfterTrigger, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                 }
 
                 if (ownedRelationshipCursor.Current is ITransitionFeatureMembership { Kind: SysML2.NET.Core.Systems.States.TransitionFeatureKind.Effect } effectAfterGuard)
                 {
-                    TransitionFeatureMembershipTextualNotationBuilder.BuildEffectBehaviorMember(effectAfterGuard, cursorCache, stringBuilder);
+                    TransitionFeatureMembershipTextualNotationBuilder.BuildEffectBehaviorMember(effectAfterGuard, writerContext, stringBuilder);
                     ownedRelationshipCursor.Move();
                 }
             }

--- a/SysML2.NET/TextualNotation/TriggerInvocationExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/TriggerInvocationExpressionTextualNotationBuilder.cs
@@ -36,11 +36,11 @@ namespace SysML2.NET.TextualNotation
         /// <remarks>TriggerExpression:TriggerInvocationExpression=kind=('at'|'after')ownedRelationship+=ArgumentMember|kind='when'ownedRelationship+=ArgumentExpressionMember</remarks>
         /// </summary>
         /// <param name="poco">The <see cref="ITriggerInvocationExpression" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        private static void BuildTriggerExpressionHandCoded(ITriggerInvocationExpression poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildTriggerExpressionHandCoded(ITriggerInvocationExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             switch (poco.Kind)
             {
@@ -51,7 +51,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is IParameterMembership argumentMember)
                     {
-                        ParameterMembershipTextualNotationBuilder.BuildArgumentMember(argumentMember, cursorCache, stringBuilder);
+                        ParameterMembershipTextualNotationBuilder.BuildArgumentMember(argumentMember, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                     }
 
@@ -61,7 +61,7 @@ namespace SysML2.NET.TextualNotation
 
                     if (ownedRelationshipCursor.Current is IParameterMembership argumentExpressionMember)
                     {
-                        ParameterMembershipTextualNotationBuilder.BuildArgumentExpressionMember(argumentExpressionMember, cursorCache, stringBuilder);
+                        ParameterMembershipTextualNotationBuilder.BuildArgumentExpressionMember(argumentExpressionMember, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                     }
 

--- a/SysML2.NET/TextualNotation/TypeTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/TypeTextualNotationBuilder.cs
@@ -39,11 +39,11 @@ namespace SysML2.NET.TextualNotation
         /// <remarks>ActionBodyItem:Type=NonBehaviorBodyItem|ownedRelationship+=InitialNodeMember(ownedRelationship+=ActionTargetSuccessionMember)*|(ownedRelationship+=SourceSuccessionMember)?ownedRelationship+=ActionBehaviorMember(ownedRelationship+=ActionTargetSuccessionMember)*|ownedRelationship+=GuardedSuccessionMember</remarks>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        private static void BuildActionBodyItemHandCoded(IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildActionBodyItemHandCoded(IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             while (ownedRelationshipCursor.Current != null)
             {
@@ -52,12 +52,12 @@ namespace SysML2.NET.TextualNotation
                     // Action-specific cases
                     case IFeatureMembership featureMembershipForInitialNode when featureMembershipForInitialNode.IsValidForInitialNodeMember():
                     {
-                        FeatureMembershipTextualNotationBuilder.BuildInitialNodeMember(featureMembershipForInitialNode, cursorCache, stringBuilder);
+                        FeatureMembershipTextualNotationBuilder.BuildInitialNodeMember(featureMembershipForInitialNode, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
 
                         while (ownedRelationshipCursor.Current is IFeatureMembership targetSuccession && targetSuccession.IsValidForActionTargetSuccessionMember())
                         {
-                            FeatureMembershipTextualNotationBuilder.BuildActionTargetSuccessionMember(targetSuccession, cursorCache, stringBuilder);
+                            FeatureMembershipTextualNotationBuilder.BuildActionTargetSuccessionMember(targetSuccession, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
                         }
 
@@ -70,22 +70,22 @@ namespace SysML2.NET.TextualNotation
 
                         if (nextElement is IFeatureMembership nextForActionBehavior && nextForActionBehavior.IsValidForActionBehaviorMember())
                         {
-                            FeatureMembershipTextualNotationBuilder.BuildSourceSuccessionMember(featureMembershipForSuccession, cursorCache, stringBuilder);
+                            FeatureMembershipTextualNotationBuilder.BuildSourceSuccessionMember(featureMembershipForSuccession, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
-                            FeatureMembershipTextualNotationBuilder.BuildActionBehaviorMember((IFeatureMembership)ownedRelationshipCursor.Current, cursorCache, stringBuilder);
+                            FeatureMembershipTextualNotationBuilder.BuildActionBehaviorMember((IFeatureMembership)ownedRelationshipCursor.Current, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
 
                             while (ownedRelationshipCursor.Current is IFeatureMembership targetSuccession && targetSuccession.IsValidForActionTargetSuccessionMember())
                             {
-                                FeatureMembershipTextualNotationBuilder.BuildActionTargetSuccessionMember(targetSuccession, cursorCache, stringBuilder);
+                                FeatureMembershipTextualNotationBuilder.BuildActionTargetSuccessionMember(targetSuccession, writerContext, stringBuilder);
                                 ownedRelationshipCursor.Move();
                             }
                         }
                         else if (nextElement is IFeatureMembership nextForStructure && nextForStructure.IsValidForStructureUsageMember())
                         {
-                            FeatureMembershipTextualNotationBuilder.BuildSourceSuccessionMember(featureMembershipForSuccession, cursorCache, stringBuilder);
+                            FeatureMembershipTextualNotationBuilder.BuildSourceSuccessionMember(featureMembershipForSuccession, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
-                            FeatureMembershipTextualNotationBuilder.BuildStructureUsageMember((IFeatureMembership)ownedRelationshipCursor.Current, cursorCache, stringBuilder);
+                            FeatureMembershipTextualNotationBuilder.BuildStructureUsageMember((IFeatureMembership)ownedRelationshipCursor.Current, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
                         }
                         else
@@ -98,12 +98,12 @@ namespace SysML2.NET.TextualNotation
 
                     case IFeatureMembership featureMembershipForActionBehavior when featureMembershipForActionBehavior.IsValidForActionBehaviorMember():
                     {
-                        FeatureMembershipTextualNotationBuilder.BuildActionBehaviorMember(featureMembershipForActionBehavior, cursorCache, stringBuilder);
+                        FeatureMembershipTextualNotationBuilder.BuildActionBehaviorMember(featureMembershipForActionBehavior, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
 
                         while (ownedRelationshipCursor.Current is IFeatureMembership targetSuccession && targetSuccession.IsValidForActionTargetSuccessionMember())
                         {
-                            FeatureMembershipTextualNotationBuilder.BuildActionTargetSuccessionMember(targetSuccession, cursorCache, stringBuilder);
+                            FeatureMembershipTextualNotationBuilder.BuildActionTargetSuccessionMember(targetSuccession, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
                         }
 
@@ -111,38 +111,38 @@ namespace SysML2.NET.TextualNotation
                     }
 
                     case IFeatureMembership featureMembershipForGuarded when featureMembershipForGuarded.IsValidForGuardedSuccessionMember():
-                        FeatureMembershipTextualNotationBuilder.BuildGuardedSuccessionMember(featureMembershipForGuarded, cursorCache, stringBuilder);
+                        FeatureMembershipTextualNotationBuilder.BuildGuardedSuccessionMember(featureMembershipForGuarded, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
                     // NonBehaviorBodyItem cases
                     case IImport import:
-                        ImportTextualNotationBuilder.BuildImport(import, cursorCache, stringBuilder);
+                        ImportTextualNotationBuilder.BuildImport(import, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
                     case IVariantMembership variantMembership:
-                        VariantMembershipTextualNotationBuilder.BuildVariantUsageMember(variantMembership, cursorCache, stringBuilder);
+                        VariantMembershipTextualNotationBuilder.BuildVariantUsageMember(variantMembership, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
                     case IFeatureMembership featureMembershipForStructure when featureMembershipForStructure.IsValidForStructureUsageMember():
-                        FeatureMembershipTextualNotationBuilder.BuildStructureUsageMember(featureMembershipForStructure, cursorCache, stringBuilder);
+                        FeatureMembershipTextualNotationBuilder.BuildStructureUsageMember(featureMembershipForStructure, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
                     case IFeatureMembership featureMembershipForNonOccurrence when featureMembershipForNonOccurrence.IsValidForNonOccurrenceUsageMember():
-                        FeatureMembershipTextualNotationBuilder.BuildNonOccurrenceUsageMember(featureMembershipForNonOccurrence, cursorCache, stringBuilder);
+                        FeatureMembershipTextualNotationBuilder.BuildNonOccurrenceUsageMember(featureMembershipForNonOccurrence, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
                     case IOwningMembership owningMembership:
-                        OwningMembershipTextualNotationBuilder.BuildDefinitionMember(owningMembership, cursorCache, stringBuilder);
+                        OwningMembershipTextualNotationBuilder.BuildDefinitionMember(owningMembership, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
                     case IMembership membership:
-                        MembershipTextualNotationBuilder.BuildAliasMember(membership, cursorCache, stringBuilder);
+                        MembershipTextualNotationBuilder.BuildAliasMember(membership, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
@@ -158,18 +158,18 @@ namespace SysML2.NET.TextualNotation
         /// <remarks>DefinitionBodyItem:Type=ownedRelationship+=DefinitionMember|ownedRelationship+=VariantUsageMember|ownedRelationship+=NonOccurrenceUsageMember|(ownedRelationship+=SourceSuccessionMember)?ownedRelationship+=OccurrenceUsageMember|ownedRelationship+=AliasMember|ownedRelationship+=Import</remarks>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        private static void BuildDefinitionBodyItemHandCoded(IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildDefinitionBodyItemHandCoded(IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             while (ownedRelationshipCursor.Current != null)
             {
                 switch (ownedRelationshipCursor.Current)
                 {
                     case IVariantMembership variantMembership:
-                        VariantMembershipTextualNotationBuilder.BuildVariantUsageMember(variantMembership, cursorCache, stringBuilder);
+                        VariantMembershipTextualNotationBuilder.BuildVariantUsageMember(variantMembership, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
@@ -179,9 +179,9 @@ namespace SysML2.NET.TextualNotation
 
                         if (nextElement is IFeatureMembership nextFeatureMembership && nextFeatureMembership.IsValidForOccurrenceUsageMember())
                         {
-                            FeatureMembershipTextualNotationBuilder.BuildSourceSuccessionMember(featureMembershipForSuccession, cursorCache, stringBuilder);
+                            FeatureMembershipTextualNotationBuilder.BuildSourceSuccessionMember(featureMembershipForSuccession, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
-                            FeatureMembershipTextualNotationBuilder.BuildOccurrenceUsageMember((IFeatureMembership)ownedRelationshipCursor.Current, cursorCache, stringBuilder);
+                            FeatureMembershipTextualNotationBuilder.BuildOccurrenceUsageMember((IFeatureMembership)ownedRelationshipCursor.Current, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
                         }
                         else
@@ -193,27 +193,27 @@ namespace SysML2.NET.TextualNotation
                     }
 
                     case IFeatureMembership featureMembershipForOccurrence when featureMembershipForOccurrence.IsValidForOccurrenceUsageMember():
-                        FeatureMembershipTextualNotationBuilder.BuildOccurrenceUsageMember(featureMembershipForOccurrence, cursorCache, stringBuilder);
+                        FeatureMembershipTextualNotationBuilder.BuildOccurrenceUsageMember(featureMembershipForOccurrence, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
                     case IFeatureMembership featureMembershipForNonOccurrence when featureMembershipForNonOccurrence.IsValidForNonOccurrenceUsageMember():
-                        FeatureMembershipTextualNotationBuilder.BuildNonOccurrenceUsageMember(featureMembershipForNonOccurrence, cursorCache, stringBuilder);
+                        FeatureMembershipTextualNotationBuilder.BuildNonOccurrenceUsageMember(featureMembershipForNonOccurrence, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
                     case IOwningMembership owningMembership:
-                        OwningMembershipTextualNotationBuilder.BuildDefinitionMember(owningMembership, cursorCache, stringBuilder);
+                        OwningMembershipTextualNotationBuilder.BuildDefinitionMember(owningMembership, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
                     case IMembership membership:
-                        MembershipTextualNotationBuilder.BuildAliasMember(membership, cursorCache, stringBuilder);
+                        MembershipTextualNotationBuilder.BuildAliasMember(membership, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
                     case IImport import:
-                        ImportTextualNotationBuilder.BuildImport(import, cursorCache, stringBuilder);
+                        ImportTextualNotationBuilder.BuildImport(import, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
@@ -229,25 +229,25 @@ namespace SysML2.NET.TextualNotation
         /// <remarks>TypeDeclaration:Type=(isSufficient?='all')?Identification(ownedRelationship+=OwnedMultiplicity)?(SpecializationPart|ConjugationPart)+TypeRelationshipPart*</remarks>
         /// </summary>
         /// <param name="poco">The <see cref="IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        private static void BuildTypeDeclarationHandCoded(IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildTypeDeclarationHandCoded(IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             if (poco.IsSufficient)
             {
                 stringBuilder.Append("all ");
             }
 
-            ElementTextualNotationBuilder.BuildIdentification(poco, cursorCache, stringBuilder);
+            ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
 
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             // Optional OwnedMultiplicity: single += consumption if the current ownedRelationship element
             // is an OwningMembership containing an IMultiplicity (OwnedMultiplicity:OwningMembership).
             if (ownedRelationshipCursor.Current is IOwningMembership multiplicityMember
                 && multiplicityMember.OwnedRelatedElement.OfType<IMultiplicity>().Any())
             {
-                OwningMembershipTextualNotationBuilder.BuildOwnedMultiplicity(multiplicityMember, cursorCache, stringBuilder);
+                OwningMembershipTextualNotationBuilder.BuildOwnedMultiplicity(multiplicityMember, writerContext, stringBuilder);
                 ownedRelationshipCursor.Move();
             }
 
@@ -260,11 +260,11 @@ namespace SysML2.NET.TextualNotation
             {
                 if (ownedRelationshipCursor.Current is ISpecialization)
                 {
-                    BuildSpecializationPart(poco, cursorCache, stringBuilder);
+                    BuildSpecializationPart(poco, writerContext, stringBuilder);
                 }
                 else
                 {
-                    BuildConjugationPart(poco, cursorCache, stringBuilder);
+                    BuildConjugationPart(poco, writerContext, stringBuilder);
                 }
             }
 
@@ -277,19 +277,19 @@ namespace SysML2.NET.TextualNotation
             {
                 if (ownedRelationshipCursor.Current is IDisjoining)
                 {
-                    BuildDisjoiningPart(poco, cursorCache, stringBuilder);
+                    BuildDisjoiningPart(poco, writerContext, stringBuilder);
                 }
                 else if (ownedRelationshipCursor.Current is IUnioning)
                 {
-                    BuildUnioningPart(poco, cursorCache, stringBuilder);
+                    BuildUnioningPart(poco, writerContext, stringBuilder);
                 }
                 else if (ownedRelationshipCursor.Current is IIntersecting)
                 {
-                    BuildIntersectingPart(poco, cursorCache, stringBuilder);
+                    BuildIntersectingPart(poco, writerContext, stringBuilder);
                 }
                 else
                 {
-                    BuildDifferencingPart(poco, cursorCache, stringBuilder);
+                    BuildDifferencingPart(poco, writerContext, stringBuilder);
                 }
             }
         }
@@ -299,18 +299,18 @@ namespace SysML2.NET.TextualNotation
         /// <remarks>InterfaceBodyItem:Type=ownedRelationship+=DefinitionMember|ownedRelationship+=VariantUsageMember|ownedRelationship+=InterfaceNonOccurrenceUsageMember|(ownedRelationship+=SourceSuccessionMember)?ownedRelationship+=InterfaceOccurrenceUsageMember|ownedRelationship+=AliasMember|ownedRelationship+=Import</remarks>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        private static void BuildInterfaceBodyItemHandCoded(IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildInterfaceBodyItemHandCoded(IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             while (ownedRelationshipCursor.Current != null)
             {
                 switch (ownedRelationshipCursor.Current)
                 {
                     case IVariantMembership variantMembership:
-                        VariantMembershipTextualNotationBuilder.BuildVariantUsageMember(variantMembership, cursorCache, stringBuilder);
+                        VariantMembershipTextualNotationBuilder.BuildVariantUsageMember(variantMembership, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
@@ -320,9 +320,9 @@ namespace SysML2.NET.TextualNotation
 
                         if (nextElement is IFeatureMembership nextFeatureMembership && nextFeatureMembership.IsValidForOccurrenceUsageMember())
                         {
-                            FeatureMembershipTextualNotationBuilder.BuildSourceSuccessionMember(featureMembershipForSuccession, cursorCache, stringBuilder);
+                            FeatureMembershipTextualNotationBuilder.BuildSourceSuccessionMember(featureMembershipForSuccession, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
-                            FeatureMembershipTextualNotationBuilder.BuildInterfaceOccurrenceUsageMember((IFeatureMembership)ownedRelationshipCursor.Current, cursorCache, stringBuilder);
+                            FeatureMembershipTextualNotationBuilder.BuildInterfaceOccurrenceUsageMember((IFeatureMembership)ownedRelationshipCursor.Current, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
                         }
                         else
@@ -334,27 +334,27 @@ namespace SysML2.NET.TextualNotation
                     }
 
                     case IFeatureMembership featureMembershipForOccurrence when featureMembershipForOccurrence.IsValidForOccurrenceUsageMember():
-                        FeatureMembershipTextualNotationBuilder.BuildInterfaceOccurrenceUsageMember(featureMembershipForOccurrence, cursorCache, stringBuilder);
+                        FeatureMembershipTextualNotationBuilder.BuildInterfaceOccurrenceUsageMember(featureMembershipForOccurrence, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
                     case IFeatureMembership featureMembershipForNonOccurrence when featureMembershipForNonOccurrence.IsValidForNonOccurrenceUsageMember():
-                        FeatureMembershipTextualNotationBuilder.BuildInterfaceNonOccurrenceUsageMember(featureMembershipForNonOccurrence, cursorCache, stringBuilder);
+                        FeatureMembershipTextualNotationBuilder.BuildInterfaceNonOccurrenceUsageMember(featureMembershipForNonOccurrence, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
                     case IOwningMembership owningMembership:
-                        OwningMembershipTextualNotationBuilder.BuildDefinitionMember(owningMembership, cursorCache, stringBuilder);
+                        OwningMembershipTextualNotationBuilder.BuildDefinitionMember(owningMembership, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
                     case IMembership membership:
-                        MembershipTextualNotationBuilder.BuildAliasMember(membership, cursorCache, stringBuilder);
+                        MembershipTextualNotationBuilder.BuildAliasMember(membership, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
                     case IImport import:
-                        ImportTextualNotationBuilder.BuildImport(import, cursorCache, stringBuilder);
+                        ImportTextualNotationBuilder.BuildImport(import, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
@@ -370,7 +370,7 @@ namespace SysML2.NET.TextualNotation
         /// <remarks>StateBodyItem:Type=NonBehaviorBodyItem|(ownedRelationship+=SourceSuccessionMember)?ownedRelationship+=BehaviorUsageMember(ownedRelationship+=TargetTransitionUsageMember)*|ownedRelationship+=TransitionUsageMember|ownedRelationship+=EntryActionMember(ownedRelationship+=EntryTransitionMember)*|ownedRelationship+=DoActionMember|ownedRelationship+=ExitActionMember</remarks>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IType" /> from which the rule should be build</param>
-        /// <param name="cursorCache">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
+        /// <param name="writerContext">The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         /// <remarks>
         /// StateBodyItem : Type =
@@ -384,9 +384,9 @@ namespace SysML2.NET.TextualNotation
         ///   | ownedRelationship += DoActionMember
         ///   | ownedRelationship += ExitActionMember
         /// </remarks>
-        private static void BuildStateBodyItemHandCoded(IType poco, ICursorCache cursorCache, StringBuilder stringBuilder)
+        private static void BuildStateBodyItemHandCoded(IType poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = cursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
             while (ownedRelationshipCursor.Current != null)
             {
@@ -395,12 +395,12 @@ namespace SysML2.NET.TextualNotation
                     // State-specific cases: Entry/Do/Exit action members
                     case IStateSubactionMembership { Kind: SysML2.NET.Core.Systems.States.StateSubactionKind.Entry } entryActionMember:
                     {
-                        StateSubactionMembershipTextualNotationBuilder.BuildEntryActionMember(entryActionMember, cursorCache, stringBuilder);
+                        StateSubactionMembershipTextualNotationBuilder.BuildEntryActionMember(entryActionMember, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
 
                         while (ownedRelationshipCursor.Current is IFeatureMembership entryTransition && entryTransition.IsValidForEntryTransitionMemberRule())
                         {
-                            FeatureMembershipTextualNotationBuilder.BuildEntryTransitionMember(entryTransition, cursorCache, stringBuilder);
+                            FeatureMembershipTextualNotationBuilder.BuildEntryTransitionMember(entryTransition, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
                         }
 
@@ -408,12 +408,12 @@ namespace SysML2.NET.TextualNotation
                     }
 
                     case IStateSubactionMembership { Kind: SysML2.NET.Core.Systems.States.StateSubactionKind.Do } doActionMember:
-                        StateSubactionMembershipTextualNotationBuilder.BuildDoActionMember(doActionMember, cursorCache, stringBuilder);
+                        StateSubactionMembershipTextualNotationBuilder.BuildDoActionMember(doActionMember, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
                     case IStateSubactionMembership { Kind: SysML2.NET.Core.Systems.States.StateSubactionKind.Exit } exitActionMember:
-                        StateSubactionMembershipTextualNotationBuilder.BuildExitActionMember(exitActionMember, cursorCache, stringBuilder);
+                        StateSubactionMembershipTextualNotationBuilder.BuildExitActionMember(exitActionMember, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
@@ -424,22 +424,22 @@ namespace SysML2.NET.TextualNotation
 
                         if (nextElement is IFeatureMembership nextForBehavior && nextForBehavior.IsValidForBehaviorUsageMember())
                         {
-                            FeatureMembershipTextualNotationBuilder.BuildSourceSuccessionMember(featureMembershipForSuccession, cursorCache, stringBuilder);
+                            FeatureMembershipTextualNotationBuilder.BuildSourceSuccessionMember(featureMembershipForSuccession, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
-                            FeatureMembershipTextualNotationBuilder.BuildBehaviorUsageMember((IFeatureMembership)ownedRelationshipCursor.Current, cursorCache, stringBuilder);
+                            FeatureMembershipTextualNotationBuilder.BuildBehaviorUsageMember((IFeatureMembership)ownedRelationshipCursor.Current, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
 
                             while (ownedRelationshipCursor.Current is IFeatureMembership targetTransition && targetTransition.IsValidForTargetTransitionUsageMember())
                             {
-                                FeatureMembershipTextualNotationBuilder.BuildTargetTransitionUsageMember(targetTransition, cursorCache, stringBuilder);
+                                FeatureMembershipTextualNotationBuilder.BuildTargetTransitionUsageMember(targetTransition, writerContext, stringBuilder);
                                 ownedRelationshipCursor.Move();
                             }
                         }
                         else if (nextElement is IFeatureMembership nextForStructure && nextForStructure.IsValidForStructureUsageMember())
                         {
-                            FeatureMembershipTextualNotationBuilder.BuildSourceSuccessionMember(featureMembershipForSuccession, cursorCache, stringBuilder);
+                            FeatureMembershipTextualNotationBuilder.BuildSourceSuccessionMember(featureMembershipForSuccession, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
-                            FeatureMembershipTextualNotationBuilder.BuildStructureUsageMember((IFeatureMembership)ownedRelationshipCursor.Current, cursorCache, stringBuilder);
+                            FeatureMembershipTextualNotationBuilder.BuildStructureUsageMember((IFeatureMembership)ownedRelationshipCursor.Current, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
                         }
                         else
@@ -453,12 +453,12 @@ namespace SysML2.NET.TextualNotation
                     // BehaviorUsageMember without preceding SourceSuccessionMember
                     case IFeatureMembership featureMembershipForBehavior when featureMembershipForBehavior.IsValidForBehaviorUsageMember():
                     {
-                        FeatureMembershipTextualNotationBuilder.BuildBehaviorUsageMember(featureMembershipForBehavior, cursorCache, stringBuilder);
+                        FeatureMembershipTextualNotationBuilder.BuildBehaviorUsageMember(featureMembershipForBehavior, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
 
                         while (ownedRelationshipCursor.Current is IFeatureMembership targetTransition && targetTransition.IsValidForTargetTransitionUsageMember())
                         {
-                            FeatureMembershipTextualNotationBuilder.BuildTargetTransitionUsageMember(targetTransition, cursorCache, stringBuilder);
+                            FeatureMembershipTextualNotationBuilder.BuildTargetTransitionUsageMember(targetTransition, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
                         }
 
@@ -467,38 +467,38 @@ namespace SysML2.NET.TextualNotation
 
                     // TransitionUsageMember
                     case IFeatureMembership featureMembershipForTransition when featureMembershipForTransition.IsValidForTransitionUsageMember():
-                        FeatureMembershipTextualNotationBuilder.BuildTransitionUsageMember(featureMembershipForTransition, cursorCache, stringBuilder);
+                        FeatureMembershipTextualNotationBuilder.BuildTransitionUsageMember(featureMembershipForTransition, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
                     // NonBehaviorBodyItem cases
                     case IImport import:
-                        ImportTextualNotationBuilder.BuildImport(import, cursorCache, stringBuilder);
+                        ImportTextualNotationBuilder.BuildImport(import, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
                     case IVariantMembership variantMembership:
-                        VariantMembershipTextualNotationBuilder.BuildVariantUsageMember(variantMembership, cursorCache, stringBuilder);
+                        VariantMembershipTextualNotationBuilder.BuildVariantUsageMember(variantMembership, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
                     case IFeatureMembership featureMembershipForStructure when featureMembershipForStructure.IsValidForStructureUsageMember():
-                        FeatureMembershipTextualNotationBuilder.BuildStructureUsageMember(featureMembershipForStructure, cursorCache, stringBuilder);
+                        FeatureMembershipTextualNotationBuilder.BuildStructureUsageMember(featureMembershipForStructure, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
                     case IFeatureMembership featureMembershipForNonOccurrence when featureMembershipForNonOccurrence.IsValidForNonOccurrenceUsageMember():
-                        FeatureMembershipTextualNotationBuilder.BuildNonOccurrenceUsageMember(featureMembershipForNonOccurrence, cursorCache, stringBuilder);
+                        FeatureMembershipTextualNotationBuilder.BuildNonOccurrenceUsageMember(featureMembershipForNonOccurrence, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
                     case IOwningMembership owningMembership:
-                        OwningMembershipTextualNotationBuilder.BuildDefinitionMember(owningMembership, cursorCache, stringBuilder);
+                        OwningMembershipTextualNotationBuilder.BuildDefinitionMember(owningMembership, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
                     case IMembership membership:
-                        MembershipTextualNotationBuilder.BuildAliasMember(membership, cursorCache, stringBuilder);
+                        MembershipTextualNotationBuilder.BuildAliasMember(membership, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 

--- a/SysML2.NET/TextualNotation/TypeTextualNotationBuilder.cs
+++ b/SysML2.NET/TextualNotation/TypeTextualNotationBuilder.cs
@@ -50,12 +50,12 @@ namespace SysML2.NET.TextualNotation
                 switch (ownedRelationshipCursor.Current)
                 {
                     // Action-specific cases
-                    case IFeatureMembership featureMembershipForInitialNode when featureMembershipForInitialNode.IsValidForInitialNodeMember():
+                    case IFeatureMembership featureMembershipForInitialNode when featureMembershipForInitialNode.IsValidForInitialNodeMember(writerContext):
                     {
                         FeatureMembershipTextualNotationBuilder.BuildInitialNodeMember(featureMembershipForInitialNode, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
 
-                        while (ownedRelationshipCursor.Current is IFeatureMembership targetSuccession && targetSuccession.IsValidForActionTargetSuccessionMember())
+                        while (ownedRelationshipCursor.Current is IFeatureMembership targetSuccession && targetSuccession.IsValidForActionTargetSuccessionMember(writerContext))
                         {
                             FeatureMembershipTextualNotationBuilder.BuildActionTargetSuccessionMember(targetSuccession, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
@@ -64,24 +64,24 @@ namespace SysML2.NET.TextualNotation
                         break;
                     }
 
-                    case IFeatureMembership featureMembershipForSuccession when featureMembershipForSuccession.IsValidForSourceSuccessionMember():
+                    case IFeatureMembership featureMembershipForSuccession when featureMembershipForSuccession.IsValidForSourceSuccessionMember(writerContext):
                     {
                         var nextElement = ownedRelationshipCursor.GetNext(1);
 
-                        if (nextElement is IFeatureMembership nextForActionBehavior && nextForActionBehavior.IsValidForActionBehaviorMember())
+                        if (nextElement is IFeatureMembership nextForActionBehavior && nextForActionBehavior.IsValidForActionBehaviorMember(writerContext))
                         {
                             FeatureMembershipTextualNotationBuilder.BuildSourceSuccessionMember(featureMembershipForSuccession, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
                             FeatureMembershipTextualNotationBuilder.BuildActionBehaviorMember((IFeatureMembership)ownedRelationshipCursor.Current, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
 
-                            while (ownedRelationshipCursor.Current is IFeatureMembership targetSuccession && targetSuccession.IsValidForActionTargetSuccessionMember())
+                            while (ownedRelationshipCursor.Current is IFeatureMembership targetSuccession && targetSuccession.IsValidForActionTargetSuccessionMember(writerContext))
                             {
                                 FeatureMembershipTextualNotationBuilder.BuildActionTargetSuccessionMember(targetSuccession, writerContext, stringBuilder);
                                 ownedRelationshipCursor.Move();
                             }
                         }
-                        else if (nextElement is IFeatureMembership nextForStructure && nextForStructure.IsValidForStructureUsageMember())
+                        else if (nextElement is IFeatureMembership nextForStructure && nextForStructure.IsValidForStructureUsageMember(writerContext))
                         {
                             FeatureMembershipTextualNotationBuilder.BuildSourceSuccessionMember(featureMembershipForSuccession, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
@@ -96,12 +96,12 @@ namespace SysML2.NET.TextualNotation
                         break;
                     }
 
-                    case IFeatureMembership featureMembershipForActionBehavior when featureMembershipForActionBehavior.IsValidForActionBehaviorMember():
+                    case IFeatureMembership featureMembershipForActionBehavior when featureMembershipForActionBehavior.IsValidForActionBehaviorMember(writerContext):
                     {
                         FeatureMembershipTextualNotationBuilder.BuildActionBehaviorMember(featureMembershipForActionBehavior, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
 
-                        while (ownedRelationshipCursor.Current is IFeatureMembership targetSuccession && targetSuccession.IsValidForActionTargetSuccessionMember())
+                        while (ownedRelationshipCursor.Current is IFeatureMembership targetSuccession && targetSuccession.IsValidForActionTargetSuccessionMember(writerContext))
                         {
                             FeatureMembershipTextualNotationBuilder.BuildActionTargetSuccessionMember(targetSuccession, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
@@ -110,7 +110,7 @@ namespace SysML2.NET.TextualNotation
                         break;
                     }
 
-                    case IFeatureMembership featureMembershipForGuarded when featureMembershipForGuarded.IsValidForGuardedSuccessionMember():
+                    case IFeatureMembership featureMembershipForGuarded when featureMembershipForGuarded.IsValidForGuardedSuccessionMember(writerContext):
                         FeatureMembershipTextualNotationBuilder.BuildGuardedSuccessionMember(featureMembershipForGuarded, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
@@ -126,12 +126,12 @@ namespace SysML2.NET.TextualNotation
                         ownedRelationshipCursor.Move();
                         break;
 
-                    case IFeatureMembership featureMembershipForStructure when featureMembershipForStructure.IsValidForStructureUsageMember():
+                    case IFeatureMembership featureMembershipForStructure when featureMembershipForStructure.IsValidForStructureUsageMember(writerContext):
                         FeatureMembershipTextualNotationBuilder.BuildStructureUsageMember(featureMembershipForStructure, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
-                    case IFeatureMembership featureMembershipForNonOccurrence when featureMembershipForNonOccurrence.IsValidForNonOccurrenceUsageMember():
+                    case IFeatureMembership featureMembershipForNonOccurrence when featureMembershipForNonOccurrence.IsValidForNonOccurrenceUsageMember(writerContext):
                         FeatureMembershipTextualNotationBuilder.BuildNonOccurrenceUsageMember(featureMembershipForNonOccurrence, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
@@ -173,11 +173,11 @@ namespace SysML2.NET.TextualNotation
                         ownedRelationshipCursor.Move();
                         break;
 
-                    case IFeatureMembership featureMembershipForSuccession when featureMembershipForSuccession.IsValidForSourceSuccessionMember():
+                    case IFeatureMembership featureMembershipForSuccession when featureMembershipForSuccession.IsValidForSourceSuccessionMember(writerContext):
                     {
                         var nextElement = ownedRelationshipCursor.GetNext(1);
 
-                        if (nextElement is IFeatureMembership nextFeatureMembership && nextFeatureMembership.IsValidForOccurrenceUsageMember())
+                        if (nextElement is IFeatureMembership nextFeatureMembership && nextFeatureMembership.IsValidForOccurrenceUsageMember(writerContext))
                         {
                             FeatureMembershipTextualNotationBuilder.BuildSourceSuccessionMember(featureMembershipForSuccession, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
@@ -192,12 +192,12 @@ namespace SysML2.NET.TextualNotation
                         break;
                     }
 
-                    case IFeatureMembership featureMembershipForOccurrence when featureMembershipForOccurrence.IsValidForOccurrenceUsageMember():
+                    case IFeatureMembership featureMembershipForOccurrence when featureMembershipForOccurrence.IsValidForOccurrenceUsageMember(writerContext):
                         FeatureMembershipTextualNotationBuilder.BuildOccurrenceUsageMember(featureMembershipForOccurrence, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
-                    case IFeatureMembership featureMembershipForNonOccurrence when featureMembershipForNonOccurrence.IsValidForNonOccurrenceUsageMember():
+                    case IFeatureMembership featureMembershipForNonOccurrence when featureMembershipForNonOccurrence.IsValidForNonOccurrenceUsageMember(writerContext):
                         FeatureMembershipTextualNotationBuilder.BuildNonOccurrenceUsageMember(featureMembershipForNonOccurrence, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
@@ -314,11 +314,11 @@ namespace SysML2.NET.TextualNotation
                         ownedRelationshipCursor.Move();
                         break;
 
-                    case IFeatureMembership featureMembershipForSuccession when featureMembershipForSuccession.IsValidForSourceSuccessionMember():
+                    case IFeatureMembership featureMembershipForSuccession when featureMembershipForSuccession.IsValidForSourceSuccessionMember(writerContext):
                     {
                         var nextElement = ownedRelationshipCursor.GetNext(1);
 
-                        if (nextElement is IFeatureMembership nextFeatureMembership && nextFeatureMembership.IsValidForOccurrenceUsageMember())
+                        if (nextElement is IFeatureMembership nextFeatureMembership && nextFeatureMembership.IsValidForOccurrenceUsageMember(writerContext))
                         {
                             FeatureMembershipTextualNotationBuilder.BuildSourceSuccessionMember(featureMembershipForSuccession, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
@@ -333,12 +333,12 @@ namespace SysML2.NET.TextualNotation
                         break;
                     }
 
-                    case IFeatureMembership featureMembershipForOccurrence when featureMembershipForOccurrence.IsValidForOccurrenceUsageMember():
+                    case IFeatureMembership featureMembershipForOccurrence when featureMembershipForOccurrence.IsValidForOccurrenceUsageMember(writerContext):
                         FeatureMembershipTextualNotationBuilder.BuildInterfaceOccurrenceUsageMember(featureMembershipForOccurrence, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
-                    case IFeatureMembership featureMembershipForNonOccurrence when featureMembershipForNonOccurrence.IsValidForNonOccurrenceUsageMember():
+                    case IFeatureMembership featureMembershipForNonOccurrence when featureMembershipForNonOccurrence.IsValidForNonOccurrenceUsageMember(writerContext):
                         FeatureMembershipTextualNotationBuilder.BuildInterfaceNonOccurrenceUsageMember(featureMembershipForNonOccurrence, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
@@ -398,7 +398,7 @@ namespace SysML2.NET.TextualNotation
                         StateSubactionMembershipTextualNotationBuilder.BuildEntryActionMember(entryActionMember, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
 
-                        while (ownedRelationshipCursor.Current is IFeatureMembership entryTransition && entryTransition.IsValidForEntryTransitionMemberRule())
+                        while (ownedRelationshipCursor.Current is IFeatureMembership entryTransition && entryTransition.IsValidForEntryTransitionMemberRule(writerContext))
                         {
                             FeatureMembershipTextualNotationBuilder.BuildEntryTransitionMember(entryTransition, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
@@ -418,24 +418,24 @@ namespace SysML2.NET.TextualNotation
                         break;
 
                     // SourceSuccessionMember? + BehaviorUsageMember + TargetTransitionUsageMember*
-                    case IFeatureMembership featureMembershipForSuccession when featureMembershipForSuccession.IsValidForSourceSuccessionMember():
+                    case IFeatureMembership featureMembershipForSuccession when featureMembershipForSuccession.IsValidForSourceSuccessionMember(writerContext):
                     {
                         var nextElement = ownedRelationshipCursor.GetNext(1);
 
-                        if (nextElement is IFeatureMembership nextForBehavior && nextForBehavior.IsValidForBehaviorUsageMember())
+                        if (nextElement is IFeatureMembership nextForBehavior && nextForBehavior.IsValidForBehaviorUsageMember(writerContext))
                         {
                             FeatureMembershipTextualNotationBuilder.BuildSourceSuccessionMember(featureMembershipForSuccession, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
                             FeatureMembershipTextualNotationBuilder.BuildBehaviorUsageMember((IFeatureMembership)ownedRelationshipCursor.Current, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
 
-                            while (ownedRelationshipCursor.Current is IFeatureMembership targetTransition && targetTransition.IsValidForTargetTransitionUsageMember())
+                            while (ownedRelationshipCursor.Current is IFeatureMembership targetTransition && targetTransition.IsValidForTargetTransitionUsageMember(writerContext))
                             {
                                 FeatureMembershipTextualNotationBuilder.BuildTargetTransitionUsageMember(targetTransition, writerContext, stringBuilder);
                                 ownedRelationshipCursor.Move();
                             }
                         }
-                        else if (nextElement is IFeatureMembership nextForStructure && nextForStructure.IsValidForStructureUsageMember())
+                        else if (nextElement is IFeatureMembership nextForStructure && nextForStructure.IsValidForStructureUsageMember(writerContext))
                         {
                             FeatureMembershipTextualNotationBuilder.BuildSourceSuccessionMember(featureMembershipForSuccession, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
@@ -451,12 +451,12 @@ namespace SysML2.NET.TextualNotation
                     }
 
                     // BehaviorUsageMember without preceding SourceSuccessionMember
-                    case IFeatureMembership featureMembershipForBehavior when featureMembershipForBehavior.IsValidForBehaviorUsageMember():
+                    case IFeatureMembership featureMembershipForBehavior when featureMembershipForBehavior.IsValidForBehaviorUsageMember(writerContext):
                     {
                         FeatureMembershipTextualNotationBuilder.BuildBehaviorUsageMember(featureMembershipForBehavior, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
 
-                        while (ownedRelationshipCursor.Current is IFeatureMembership targetTransition && targetTransition.IsValidForTargetTransitionUsageMember())
+                        while (ownedRelationshipCursor.Current is IFeatureMembership targetTransition && targetTransition.IsValidForTargetTransitionUsageMember(writerContext))
                         {
                             FeatureMembershipTextualNotationBuilder.BuildTargetTransitionUsageMember(targetTransition, writerContext, stringBuilder);
                             ownedRelationshipCursor.Move();
@@ -466,7 +466,7 @@ namespace SysML2.NET.TextualNotation
                     }
 
                     // TransitionUsageMember
-                    case IFeatureMembership featureMembershipForTransition when featureMembershipForTransition.IsValidForTransitionUsageMember():
+                    case IFeatureMembership featureMembershipForTransition when featureMembershipForTransition.IsValidForTransitionUsageMember(writerContext):
                         FeatureMembershipTextualNotationBuilder.BuildTransitionUsageMember(featureMembershipForTransition, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
@@ -482,12 +482,12 @@ namespace SysML2.NET.TextualNotation
                         ownedRelationshipCursor.Move();
                         break;
 
-                    case IFeatureMembership featureMembershipForStructure when featureMembershipForStructure.IsValidForStructureUsageMember():
+                    case IFeatureMembership featureMembershipForStructure when featureMembershipForStructure.IsValidForStructureUsageMember(writerContext):
                         FeatureMembershipTextualNotationBuilder.BuildStructureUsageMember(featureMembershipForStructure, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;
 
-                    case IFeatureMembership featureMembershipForNonOccurrence when featureMembershipForNonOccurrence.IsValidForNonOccurrenceUsageMember():
+                    case IFeatureMembership featureMembershipForNonOccurrence when featureMembershipForNonOccurrence.IsValidForNonOccurrenceUsageMember(writerContext):
                         FeatureMembershipTextualNotationBuilder.BuildNonOccurrenceUsageMember(featureMembershipForNonOccurrence, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
                         break;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/SysML2.NET/pulls) open
- [x] I have verified that I am following the SysML2.NET [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/SysML2.NET/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Textual notation fixed for the QualifiedName for the Membership, as described per the KerML specification, section 8.2.3.5
<!-- Thanks for contributing to SysML2.NET! -->