### PR TITLE
247 bug fix inconsistencies on textual notation

### DIFF
--- a/SysML2.NET.CodeGenerator/Grammar/Model/TextualNotationRule.cs
+++ b/SysML2.NET.CodeGenerator/Grammar/Model/TextualNotationRule.cs
@@ -20,6 +20,7 @@
 
 namespace SysML2.NET.CodeGenerator.Grammar.Model
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
 
@@ -271,6 +272,87 @@ namespace SysML2.NET.CodeGenerator.Grammar.Model
                         foreach (var groupAlternative in groupElement.Alternatives)
                         {
                             CollectAllReferencedPropertyNamesFromElements(groupAlternative.Elements, allRules, result, visited);
+                        }
+
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Recursively collects the <c>+=</c> <see cref="AssignmentElement"/> items targeting
+        /// <paramref name="propertyName"/> declared by this rule and any transitively-referenced
+        /// NonTerminal rules. Used by the generator to resolve the runtime type(s) an optional
+        /// non-terminal reference will consume from the named cursor, so the caller can emit a
+        /// type-strict <c>cursor.Current is T</c> guard.
+        /// </summary>
+        /// <param name="propertyName">The property name whose <c>+=</c> consumptions are collected</param>
+        /// <param name="allRules">All available rules for resolving NonTerminal references</param>
+        /// <returns>The collected <c>+=</c> <see cref="AssignmentElement"/> items</returns>
+        public IReadOnlyList<AssignmentElement> QueryAllReferencedCollectionAssignments(string propertyName, IReadOnlyList<TextualNotationRule> allRules)
+        {
+            var result = new List<AssignmentElement>();
+            var visited = new HashSet<string>();
+            CollectAllReferencedCollectionAssignments(this, propertyName, allRules, result, visited);
+            return result;
+        }
+
+        /// <summary>
+        /// Recursively collects <c>+=</c> <see cref="AssignmentElement"/> items targeting
+        /// <paramref name="propertyName"/> from a rule and its referenced NonTerminal rules.
+        /// </summary>
+        /// <param name="rule">The rule to inspect</param>
+        /// <param name="propertyName">The property name to match</param>
+        /// <param name="allRules">All available rules for resolving NonTerminal references</param>
+        /// <param name="result">The accumulated list of <c>+=</c> assignments</param>
+        /// <param name="visited">Set of already-visited rule names to prevent infinite recursion</param>
+        private static void CollectAllReferencedCollectionAssignments(TextualNotationRule rule, string propertyName, IReadOnlyList<TextualNotationRule> allRules, List<AssignmentElement> result, HashSet<string> visited)
+        {
+            if (!visited.Add(rule.RuleName))
+            {
+                return;
+            }
+
+            foreach (var alternative in rule.Alternatives)
+            {
+                CollectAllReferencedCollectionAssignmentsFromElements(alternative.Elements, propertyName, allRules, result, visited);
+            }
+        }
+
+        /// <summary>
+        /// Recursively collects <c>+=</c> <see cref="AssignmentElement"/> items targeting
+        /// <paramref name="propertyName"/> from a list of <see cref="RuleElement"/>.
+        /// </summary>
+        /// <param name="elements">The elements to inspect</param>
+        /// <param name="propertyName">The property name to match</param>
+        /// <param name="allRules">All available rules for resolving NonTerminal references</param>
+        /// <param name="result">The accumulated list of <c>+=</c> assignments</param>
+        /// <param name="visited">Set of already-visited rule names to prevent infinite recursion</param>
+        private static void CollectAllReferencedCollectionAssignmentsFromElements(IEnumerable<RuleElement> elements, string propertyName, IReadOnlyList<TextualNotationRule> allRules, List<AssignmentElement> result, HashSet<string> visited)
+        {
+            foreach (var element in elements)
+            {
+                switch (element)
+                {
+                    case AssignmentElement { Operator: "+=" } assignmentElement
+                        when string.Equals(assignmentElement.Property, propertyName, StringComparison.OrdinalIgnoreCase):
+                        result.Add(assignmentElement);
+                        break;
+
+                    case NonTerminalElement nonTerminalElement:
+                        var referencedRule = allRules.SingleOrDefault(x => x.RuleName == nonTerminalElement.Name);
+
+                        if (referencedRule != null)
+                        {
+                            CollectAllReferencedCollectionAssignments(referencedRule, propertyName, allRules, result, visited);
+                        }
+
+                        break;
+
+                    case GroupElement groupElement:
+                        foreach (var groupAlternative in groupElement.Alternatives)
+                        {
+                            CollectAllReferencedCollectionAssignmentsFromElements(groupAlternative.Elements, propertyName, allRules, result, visited);
                         }
 
                         break;

--- a/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.CollectionProcessing.cs
+++ b/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.CollectionProcessing.cs
@@ -29,6 +29,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
     using SysML2.NET.CodeGenerator.Extensions;
     using SysML2.NET.CodeGenerator.Grammar.Model;
 
+    using uml4net.Classification;
     using uml4net.CommonStructure;
     using uml4net.Extensions;
     using uml4net.StructuredClassifiers;
@@ -370,10 +371,24 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
         /// <summary>
         /// Generates an inline condition expression for an optional non-terminal reference.
+        /// For enumerable properties whose consumption type can be resolved from the referenced
+        /// rule's <c>+=</c> assignments, emits a cursor-typed guard
+        /// (<c>{prop}Cursor.Current is T</c>) — declaring the cursor immediately into
+        /// <paramref name="writer" /> when not already present in
+        /// <see cref="RuleGenerationContext.DefinedCursors" />. The cursor principle aligns the
+        /// caller's guard with the position the called rule will actually consume from. When the
+        /// type cannot be resolved or <paramref name="variableName"/> is not the top-level
+        /// <c>poco</c>, the legacy <c>{var}.{Property}.Count != 0</c> form is preserved.
         /// </summary>
-        private string GenerateInlineOptionalCondition(TextualNotationRule referencedRule, IClass targetClass, IReadOnlyList<TextualNotationRule> allRules, string variableName)
+        /// <param name="writer">The <see cref="EncodedTextWriter" /> used to emit any required cursor declarations</param>
+        /// <param name="referencedRule">The optional non-terminal's referenced rule</param>
+        /// <param name="targetClass">The host class (provides UML metadata)</param>
+        /// <param name="ruleGenerationContext">The current <see cref="RuleGenerationContext" /></param>
+        /// <param name="variableName">The variable name from which the property is accessed (typically <c>poco</c>)</param>
+        /// <returns>The condition expression, or <c>null</c> when no property names are referenced</returns>
+        private string GenerateInlineOptionalCondition(EncodedTextWriter writer, TextualNotationRule referencedRule, IClass targetClass, RuleGenerationContext ruleGenerationContext, string variableName)
         {
-            var propertyNames = referencedRule.QueryAllReferencedPropertyNames(allRules);
+            var propertyNames = referencedRule.QueryAllReferencedPropertyNames(ruleGenerationContext.AllRules);
 
             if (propertyNames.Count == 0)
             {
@@ -396,7 +411,25 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
                 if (property.QueryIsEnumerable())
                 {
-                    conditionParts.Add($"{variableName}.{umlPropertyName}.Count != 0");
+                    var cursorTypedCheck = TryBuildCursorTypedCheck(writer, referencedRule, targetClass, property, propertyName, ruleGenerationContext, variableName);
+
+                    if (cursorTypedCheck != null)
+                    {
+                        conditionParts.Add(cursorTypedCheck);
+                    }
+                    else if (referencedRule.QueryAllReferencedCollectionAssignments(propertyName, ruleGenerationContext.AllRules).Count > 0)
+                    {
+                        // The referenced rule has += consumptions of this property but the cursor
+                        // types could not be resolved — fall back to the legacy collection-level
+                        // non-empty check rather than skip the clause entirely.
+                        conditionParts.Add($"{variableName}.{umlPropertyName}.Count != 0");
+                    }
+
+                    // No += consumptions exist for this property anywhere in the referenced rule
+                    // tree (the property name reached the result set via a scalar `=` reference,
+                    // typically pulled in by a transitive non-terminal walk). Skipping the clause
+                    // tightens the guard to reflect what the called rule will actually consume
+                    // and avoids evaluating derived properties that the caller never reads.
                 }
                 else
                 {
@@ -405,6 +438,95 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
             }
 
             return conditionParts.Count != 0 ? string.Join(" || ", conditionParts) : null;
+        }
+
+        /// <summary>
+        /// Resolves the runtime types the referenced rule's <c>+=</c> assignments consume from the
+        /// supplied <paramref name="property" /> and, when all are resolvable AND
+        /// <paramref name="variableName" /> is <c>poco</c>, returns a cursor-typed boolean
+        /// expression (declaring or reusing a cursor as needed). Returns <c>null</c> to signal
+        /// that the caller should fall back to the legacy <c>.Count != 0</c> form.
+        /// </summary>
+        /// <param name="writer">The <see cref="EncodedTextWriter" /> used to emit a cursor declaration when one is required</param>
+        /// <param name="referencedRule">The optional non-terminal's referenced rule</param>
+        /// <param name="targetClass">The host class (provides the UML cache for class-name resolution)</param>
+        /// <param name="property">The host class property targeted by the rule's <c>+=</c> consumptions</param>
+        /// <param name="propertyName">The matching grammar property name</param>
+        /// <param name="ruleGenerationContext">The current <see cref="RuleGenerationContext" /></param>
+        /// <param name="variableName">The variable name the host method uses for the POCO</param>
+        /// <returns>The cursor-typed boolean expression, or <c>null</c> if the legacy fallback should be used</returns>
+        private static string TryBuildCursorTypedCheck(EncodedTextWriter writer, TextualNotationRule referencedRule, IClass targetClass, IProperty property, string propertyName, RuleGenerationContext ruleGenerationContext, string variableName)
+        {
+            if (!string.Equals(variableName, "poco", StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            var collectionAssignments = referencedRule.QueryAllReferencedCollectionAssignments(propertyName, ruleGenerationContext.AllRules);
+
+            if (collectionAssignments.Count == 0)
+            {
+                return null;
+            }
+
+            var resolvedTypeNames = new List<string>();
+
+            foreach (var assignmentElement in collectionAssignments)
+            {
+                var typeName = ResolveAssignmentTargetTypeName(assignmentElement, targetClass, ruleGenerationContext);
+
+                if (typeName == null)
+                {
+                    return null;
+                }
+
+                if (!resolvedTypeNames.Contains(typeName))
+                {
+                    resolvedTypeNames.Add(typeName);
+                }
+            }
+
+            var cursorVariableName = EnsureCursorDeclared(writer, property, ruleGenerationContext);
+
+            if (resolvedTypeNames.Count == 1)
+            {
+                return $"{cursorVariableName}.Current is {resolvedTypeNames[0]}";
+            }
+
+            var typeChecks = resolvedTypeNames.Select(typeName => $"{cursorVariableName}.Current is {typeName}");
+
+            return $"({string.Join(" || ", typeChecks)})";
+        }
+
+        /// <summary>
+        /// Returns the cursor variable name for <paramref name="property" />, reusing an
+        /// already-declared cursor when one is present in
+        /// <see cref="RuleGenerationContext.DefinedCursors" /> and emitting a new declaration into
+        /// <paramref name="writer" /> otherwise. The new declaration is registered in
+        /// <see cref="RuleGenerationContext.DefinedCursors" /> so subsequent host-rule elements
+        /// targeting the same property reuse it.
+        /// </summary>
+        /// <param name="writer">The <see cref="EncodedTextWriter" /> that receives the cursor declaration line when emitted</param>
+        /// <param name="property">The property whose cursor is needed</param>
+        /// <param name="ruleGenerationContext">The current <see cref="RuleGenerationContext" /></param>
+        /// <returns>The cursor variable name to use in the guard expression</returns>
+        private static string EnsureCursorDeclared(EncodedTextWriter writer, IProperty property, RuleGenerationContext ruleGenerationContext)
+        {
+            var existingCursor = ruleGenerationContext.DefinedCursors.FirstOrDefault(x => x.IsCursorValidForProperty(property));
+
+            if (existingCursor != null)
+            {
+                return existingCursor.CursorVariableName;
+            }
+
+            var cursorDefinition = new CursorDefinition { DefinedForProperty = property };
+            var propertyAccessName = property.QueryPropertyNameBasedOnUmlProperties();
+
+            writer.WriteSafeString($"var {cursorDefinition.CursorVariableName} = writerContext.CursorCache.GetOrCreateCursor(poco.Id, \"{property.Name}\", poco.{propertyAccessName});{Environment.NewLine}");
+
+            ruleGenerationContext.DefinedCursors.Add(cursorDefinition);
+
+            return cursorDefinition.CursorVariableName;
         }
 
         /// <summary>
@@ -422,7 +544,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                 return false;
             }
 
-            var condition = this.GenerateInlineOptionalCondition(referencedRule, targetClass, ruleGenerationContext.AllRules, variableName);
+            var condition = this.GenerateInlineOptionalCondition(writer, referencedRule, targetClass, ruleGenerationContext, variableName);
 
             if (condition == null)
             {

--- a/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.ElementProcessing.cs
+++ b/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.ElementProcessing.cs
@@ -275,9 +275,16 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                         var previousCaller = ruleGenerationContext.CallerRule;
                         ruleGenerationContext.CallerRule = assignmentElement;
 
-                        var isInsideOptionalGroup = assignmentElement.Container is GroupElement { IsOptional: true, IsCollection: false };
+                        // Route the cursor Move() through PendingCursorMove so that ProcessNonTerminalElement
+                        // emits it INSIDE the type-discrimination block — Move() then fires only when the
+                        // runtime cast actually matches (cursor advances only on real += consumption,
+                        // honouring the Move() ↔ += Golden Rule). When the assignment is inside a collection
+                        // group `(...)*` / `(...)+`, the loop body's own emitter handles the move; when it is
+                        // part of a multi-alternative dispatch, the dispatcher handles the move.
+                        var shouldEmitCursorMove = !isPartOfMultipleAlternative
+                            && assignmentElement.Container is not GroupElement { IsCollection: true };
 
-                        if (isInsideOptionalGroup)
+                        if (shouldEmitCursorMove)
                         {
                             ruleGenerationContext.PendingCursorMove = $"{Environment.NewLine}{cursorToUse.CursorVariableName}.Move();{Environment.NewLine}";
                         }
@@ -285,13 +292,6 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                         this.ProcessNonTerminalElement(writer, umlClass, nonTerminalElement, ruleGenerationContext);
                         ruleGenerationContext.CurrentVariableName = previousVariableName;
                         ruleGenerationContext.CallerRule = previousCaller;
-
-                        if (!isPartOfMultipleAlternative
-                            && assignmentElement.Container is not GroupElement { IsCollection: true }
-                            && !isInsideOptionalGroup)
-                        {
-                            writer.WriteSafeString($"{cursorToUse.CursorVariableName}.Move();{Environment.NewLine}");
-                        }
                     }
                     else if (assignmentElement.Value is GroupElement groupElement)
                     {
@@ -322,7 +322,16 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                     {
                         writer.WriteSafeString($"{Environment.NewLine}if({targetProperty.QueryIfStatementContentForNonEmpty("poco")}){Environment.NewLine}");
                         writer.WriteSafeString($"{{{Environment.NewLine}");
-                        writer.WriteSafeString($"stringBuilder.Append(poco.{targetProperty.Name.CapitalizeFirstLetter()});{Environment.NewLine}");
+
+                        if (assignmentElement.Value is NonTerminalElement { Name: "NAME" })
+                        {
+                            writer.WriteSafeString($"SharedTextualNotationBuilder.AppendName(stringBuilder, poco.{targetProperty.Name.CapitalizeFirstLetter()});{Environment.NewLine}");
+                        }
+                        else
+                        {
+                            writer.WriteSafeString($"stringBuilder.Append(poco.{targetProperty.Name.CapitalizeFirstLetter()});{Environment.NewLine}");
+                        }
+
                         writer.WriteSafeString("}");
                     }
                     else
@@ -334,6 +343,10 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                             if (assignmentElement.Value is NonTerminalElement { Name: "REGULAR_COMMENT" })
                             {
                                 writer.WriteSafeString($"SharedTextualNotationBuilder.AppendRegularComment(stringBuilder, poco.{targetPropertyName});");
+                            }
+                            else if (assignmentElement.Value is NonTerminalElement { Name: "NAME" })
+                            {
+                                writer.WriteSafeString($"SharedTextualNotationBuilder.AppendName(stringBuilder, poco.{targetPropertyName});");
                             }
                             else
                             {

--- a/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.ElementProcessing.cs
+++ b/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.ElementProcessing.cs
@@ -348,6 +348,15 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                             {
                                 writer.WriteSafeString($"SharedTextualNotationBuilder.AppendName(stringBuilder, poco.{targetPropertyName});");
                             }
+                            else if (string.Equals(targetPropertyName, "Operator", StringComparison.Ordinal))
+                            {
+                                // Operator tokens (binary, unary, conditional) need a trailing
+                                // space to separate them from the next operand. Matches the
+                                // convention used by the operator-switch dispatch path
+                                // (RuleProcessor.PatternHandlers.cs:94-95).
+                                writer.WriteSafeString($"stringBuilder.Append(poco.{targetPropertyName});{Environment.NewLine}");
+                                writer.WriteSafeString("stringBuilder.Append(' ');");
+                            }
                             else
                             {
                                 writer.WriteSafeString($"stringBuilder.Append(poco.{targetPropertyName});");
@@ -433,7 +442,13 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
             }
             else
             {
-                writer.WriteSafeString($"Build{assignmentElement.Property.CapitalizeFirstLetter()}(poco, writerContext, stringBuilder);");
+                // The grammar's assignment property does not resolve against the target
+                // metamodel class (e.g. the OMG kebnf carries a one-off `ownedFeatureMember`
+                // vs. metamodel `ownedMemberFeature` typo for `OwnedExpressionMember`).
+                // Delegate to the HandCoded sibling per the documented convention rather
+                // than emitting a name-collision-prone `Build{Property}(poco, …)` call.
+                var handCodedRuleName = assignmentElement.TextualNotationRule?.RuleName ?? "Unknown";
+                this.EmitHandCodedFallback(writer, handCodedRuleName, ruleGenerationContext);
             }
         }
 

--- a/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.PatternHandlers.cs
+++ b/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.PatternHandlers.cs
@@ -694,6 +694,67 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                         }
                     }
 
+                    // Self-default inheritance-ambiguity guard synthesis.
+                    //
+                    // The criterion: emit guards only when one of the switch's alternatives
+                    // has the same UML class as the rule's `NamedElementToGenerate`. That is
+                    // the "self-default" shape — the rule uses its own target class as one
+                    // alternative and that alternative becomes the default catch-all arm
+                    // for inline/non-named subclass forms. The canonical example is
+                    // FeatureElement: `FeatureElement : Feature = Feature | Step | Expression | …`
+                    // where `Feature` is both an alternative and the rule's target. An
+                    // inline IOperatorExpression (subclass of IExpression with no declared
+                    // name) reaching the switch would match `case IExpression` and be
+                    // mis-rendered; a property-derived guard like `DeclaredName != null`
+                    // makes that arm decline the match and fall through to `BuildFeature`.
+                    //
+                    // When the rule does NOT exhibit this self-default pattern
+                    // (BuildAnnotatingElement, BuildDefinitionElement, BuildNonFeatureElement
+                    // — `NamedElementToGenerate` is `Element`/`AnnotatingElement` but no
+                    // alternative targets that class), the most-derived-first ordering
+                    // alone is sufficient: every legitimate runtime metaclass maps to its
+                    // own arm. No guards are emitted, regardless of any speculative
+                    // metamodel inheritance overlap.
+                    //
+                    // For each non-default alternative under a self-default rule, run the
+                    // depth-aware synthesizer on the called rule's parsed body. Every
+                    // synthesized clause (with property-mismatch and scalar-on-`+=` filters
+                    // already applied) becomes part of the arm's `when` predicate, joined
+                    // by `&&`. Shared clauses across siblings are harmless — they filter
+                    // out subclass forms uniformly while runtime metaclass + most-derived
+                    // ordering still routes named instances to the correct concrete arm.
+                    var generatingClassForSelfDefault = ruleGenerationContext.NamedElementToGenerate as IClass;
+                    var isSelfDefault = generatingClassForSelfDefault != null
+                        && mappedNonTerminalElements.Any(element => element.UmlClass == generatingClassForSelfDefault);
+
+                    if (isSelfDefault)
+                    {
+                        var ambiguousElements = mappedNonTerminalElements
+                            .Where(element => !duplicateClasses.ContainsKey(element.UmlClass))
+                            .Where(element => element.UmlClass != generatingClassForSelfDefault)
+                            .Where(element => !whenGuards.ContainsKey(element.RuleElement))
+                            .Where(element => !IsTypeDispatcherRule(ruleGenerationContext.AllRules.SingleOrDefault(rule => rule.RuleName == element.RuleElement.Name)))
+                            .ToList();
+
+                        foreach (var ambiguous in ambiguousElements)
+                        {
+                            var referencedRule = ruleGenerationContext.AllRules
+                                .SingleOrDefault(rule => rule.RuleName == ambiguous.RuleElement.Name);
+
+                            if (referencedRule == null)
+                            {
+                                continue;
+                            }
+
+                            var clauses = CollectGuardClausesForRule(referencedRule, ambiguous.UmlClass, umlClass.Cache, ruleGenerationContext.AllRules, 3);
+
+                            if (clauses.Count > 0)
+                            {
+                                whenGuards[ambiguous.RuleElement] = string.Join(" && ", clauses);
+                            }
+                        }
+                    }
+
                     var reorderedElements = new List<(NonTerminalElement RuleElement, IClass UmlClass)>();
                     var processedDuplicateClasses = new HashSet<IClass>();
 
@@ -1019,21 +1080,131 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
         /// case variable name placeholder) ready for insertion into <c>whenGuards</c>, or
         /// <c>null</c> when the rule body carries no usable parsed assignments.
         /// </returns>
-        private static string SynthesiseGuardFromRuleBody(TextualNotationRule rule, IClass targetClass, IXmiElementCache cache, IReadOnlyList<TextualNotationRule> allRules)
+        private static string SynthesiseGuardFromRuleBody(TextualNotationRule rule, IClass targetClass, IXmiElementCache cache, IReadOnlyList<TextualNotationRule> allRules, int maxDepth = 0)
         {
             if (rule == null || targetClass == null)
             {
                 return null;
             }
 
-            var targetProperties = targetClass.QueryAllProperties();
-            var clauses = new List<string>();
-            var firstCursorEmitted = false;
-            var cursorMayHaveAdvanced = false;
-
-            CollectGuardClauses(rule.Alternatives.SelectMany(alternative => alternative.Elements), targetProperties, cache, allRules, clauses, ref firstCursorEmitted, ref cursorMayHaveAdvanced);
+            var clauses = CollectGuardClausesForRule(rule, targetClass, cache, allRules, maxDepth);
 
             return clauses.Count == 0 ? null : string.Join(" && ", clauses);
+        }
+
+        /// <summary>
+        /// Determines whether <paramref name="rule"/> is itself a type-dispatcher — i.e.
+        /// a rule whose body is exclusively a union of single-NonTerminal alternatives
+        /// (<c>Subclass1 | Subclass2 | …</c>) that delegate to per-subclass builders.
+        /// <para>
+        /// Used by the inheritance-ambiguity pass to suppress guard emission on a switch
+        /// arm whose called rule already routes subclasses internally. For example, the
+        /// <c>LiteralExpression</c> rule body is
+        /// <c>LiteralBoolean | LiteralInteger | LiteralRational | LiteralString | LiteralInfinity</c>
+        /// — any <see cref="ILiteralExpression"/> subclass that reaches a
+        /// <c>case ILiteralExpression</c> arm is correctly dispatched to its concrete
+        /// builder by <c>BuildLiteralExpression</c>'s inner switch. Contrast with the
+        /// <c>Expression</c> rule body
+        /// <c>FeaturePrefix 'expr' FeatureDeclaration ValuePart? FunctionBody</c>: a
+        /// concrete construction rule that only renders the base form, so a subclass
+        /// (e.g. <see cref="IOperatorExpression"/>) reaching a <c>case IExpression</c>
+        /// arm would be mis-rendered as a standalone Expression declaration and DOES
+        /// need a guard.
+        /// </para>
+        /// </summary>
+        /// <param name="rule">The rule to test, or <c>null</c></param>
+        /// <returns><c>true</c> when <paramref name="rule"/> is a multi-alternative type-dispatcher</returns>
+        private static bool IsTypeDispatcherRule(TextualNotationRule rule)
+        {
+            if (rule == null || rule.Alternatives.Count < 2)
+            {
+                return false;
+            }
+
+            return rule.Alternatives.All(alternative =>
+                alternative.Elements.Count == 1
+                && alternative.Elements[0] is NonTerminalElement);
+        }
+
+        /// <summary>
+        /// Runs the structural-predicate walk for <paramref name="rule"/> and returns the raw list
+        /// of synthesised clauses, before they are joined with <c>&amp;&amp;</c>. Centralises the
+        /// per-walk seeding of <see cref="HashSet{T}"/> (visited-rules) and the cursor-state
+        /// bookkeeping.
+        /// </summary>
+        /// <param name="rule">The entry <see cref="TextualNotationRule"/> to walk.</param>
+        /// <param name="targetClass">The dispatch-time target <see cref="IClass"/> (the alternative's UML class).</param>
+        /// <param name="cache">The <see cref="IXmiElementCache"/> for resolving NonTerminal RHS targets.</param>
+        /// <param name="allRules">All available rules for NonTerminal resolution.</param>
+        /// <param name="maxDepth">Recursion budget: 0 = shallow (current/legacy behavior), N&gt;0 = recurse up to <paramref name="maxDepth"/> NonTerminal references deep.</param>
+        /// <returns>The per-clause list (unjoined) in source-order.</returns>
+        private static List<string> CollectGuardClausesForRule(TextualNotationRule rule, IClass targetClass, IXmiElementCache cache, IReadOnlyList<TextualNotationRule> allRules, int maxDepth)
+        {
+            var targetProperties = targetClass.QueryAllProperties();
+            var perAlternativeClauses = new List<List<string>>();
+
+            foreach (var alternative in rule.Alternatives)
+            {
+                var altClauses = new List<string>();
+                var firstCursorEmitted = false;
+                var cursorMayHaveAdvanced = false;
+                var visitedRules = new HashSet<string>(StringComparer.Ordinal);
+
+                if (!string.IsNullOrEmpty(rule.RuleName))
+                {
+                    visitedRules.Add(rule.RuleName);
+                }
+
+                CollectGuardClauses(alternative.Elements, targetProperties, cache, allRules, altClauses, ref firstCursorEmitted, ref cursorMayHaveAdvanced, visitedRules, maxDepth);
+
+                perAlternativeClauses.Add(altClauses);
+            }
+
+            var combined = CombineAlternativesAsOr(perAlternativeClauses);
+
+            return combined == null
+                ? new List<string>()
+                : new List<string> { combined };
+        }
+
+        /// <summary>
+        /// Combines per-grammar-alternative clause lists into a single OR-disjunction
+        /// string, respecting grammar semantics: a rule body of the shape
+        /// <c>alt1 | alt2 | …</c> means "exactly one of these paths is taken at parse
+        /// time" → the corresponding dispatch-time predicate is the disjunction of the
+        /// per-alternative AND-conjunctions.
+        /// <para>
+        /// Each non-empty alternative's clause list is joined by <c>&amp;&amp;</c>
+        /// (wrapped in parens when it has 2+ clauses to keep operator precedence
+        /// explicit). Empty alternatives are dropped. Identical alternatives collapse
+        /// to a single clause. When 2+ distinct alternatives remain, the overall result
+        /// is wrapped in parens and joined by <c>||</c>.
+        /// </para>
+        /// </summary>
+        /// <param name="perAlternativeClauses">One list of synthesized clauses per grammar alternative.</param>
+        /// <returns>A single combined predicate string, or <c>null</c> when every alternative is empty.</returns>
+        private static string CombineAlternativesAsOr(List<List<string>> perAlternativeClauses)
+        {
+            var nonEmpty = perAlternativeClauses
+                .Where(altClauses => altClauses.Count > 0)
+                .Select(altClauses => altClauses.Count == 1
+                    ? altClauses[0]
+                    : "(" + string.Join(" && ", altClauses) + ")")
+                .ToList();
+
+            if (nonEmpty.Count == 0)
+            {
+                return null;
+            }
+
+            var distinct = nonEmpty.Distinct(StringComparer.Ordinal).ToList();
+
+            if (distinct.Count == 1)
+            {
+                return distinct[0];
+            }
+
+            return "(" + string.Join(" || ", distinct) + ")";
         }
 
         /// <summary>
@@ -1064,7 +1235,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
         /// trailing <c>ownedRelationship += EmptyMultiplicityMember</c>) therefore correctly
         /// produce no cursor clause and fall back to leaving the rule as the unguarded default.
         /// </param>
-        private static void CollectGuardClauses(IEnumerable<RuleElement> elements, IEnumerable<IProperty> targetProperties, IXmiElementCache cache, IReadOnlyList<TextualNotationRule> allRules, List<string> clauses, ref bool firstCursorEmitted, ref bool cursorMayHaveAdvanced)
+        private static void CollectGuardClauses(IEnumerable<RuleElement> elements, IEnumerable<IProperty> targetProperties, IXmiElementCache cache, IReadOnlyList<TextualNotationRule> allRules, List<string> clauses, ref bool firstCursorEmitted, ref bool cursorMayHaveAdvanced, HashSet<string> visitedRules, int remainingDepth)
         {
             foreach (var element in elements)
             {
@@ -1072,6 +1243,16 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                 {
                     case AssignmentElement assignment:
                     {
+                        // Skip optional assignments (`?` / `*` suffix on the assignment
+                        // itself). Their target property may legitimately be unset on a
+                        // valid runtime POCO, so an emitted `&&`-joined predicate would
+                        // wrongly reject those instances at dispatch time. Only mandatory
+                        // assignments (no suffix or `+` suffix) yield guard clauses.
+                        if (assignment.IsOptional)
+                        {
+                            break;
+                        }
+
                         var clause = TryBuildClauseForAssignment(assignment, targetProperties, cache, allRules, ref firstCursorEmitted, cursorMayHaveAdvanced);
 
                         if (!string.IsNullOrEmpty(clause))
@@ -1088,21 +1269,92 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                         break;
                     }
 
-                    case NonTerminalElement:
+                    case NonTerminalElement nonTerminal:
                     {
-                        // A NonTerminal reference may advance the dispatch cursor at runtime
-                        // because the referenced rule may consume `ownedRelationship +=`
-                        // internally. Conservatively assume it does so that we don't synthesise
-                        // a stale cursor-0 predicate for a later `ownedRelationship +=`.
+                        // Deep walk: if there is still depth budget and the referenced rule
+                        // has not yet been visited on this walk, descend into its body so
+                        // structural predicates further down the rule chain (e.g.
+                        // FeatureDeclaration → FeatureIdentification → declaredName = NAME)
+                        // are surfaced as additional clauses. Per-alternative OR-combine: a
+                        // referenced rule with multiple alternatives means exactly one path
+                        // fires at parse-time, so the dispatch-time predicate must be the
+                        // disjunction of the per-alternative AND-conjunctions (not their
+                        // conjunction). Once any NonTerminal is walked, the dispatch cursor
+                        // may have advanced (we cannot statically replay the entire builder),
+                        // so cursor-predicate emission is suppressed for the rest of this
+                        // walk via cursorMayHaveAdvanced = true.
+                        if (remainingDepth > 0)
+                        {
+                            var referencedRule = allRules.SingleOrDefault(rule => rule.RuleName == nonTerminal.Name);
+
+                            if (referencedRule != null && visitedRules.Add(nonTerminal.Name))
+                            {
+                                cursorMayHaveAdvanced = true;
+
+                                var perReferencedAlternativeClauses = new List<List<string>>();
+
+                                foreach (var referencedAlternative in referencedRule.Alternatives)
+                                {
+                                    var altClauses = new List<string>();
+                                    CollectGuardClauses(referencedAlternative.Elements, targetProperties, cache, allRules, altClauses, ref firstCursorEmitted, ref cursorMayHaveAdvanced, visitedRules, remainingDepth - 1);
+                                    perReferencedAlternativeClauses.Add(altClauses);
+                                }
+
+                                var combinedReferenced = CombineAlternativesAsOr(perReferencedAlternativeClauses);
+
+                                if (!string.IsNullOrEmpty(combinedReferenced))
+                                {
+                                    clauses.Add(combinedReferenced);
+                                }
+
+                                break;
+                            }
+                        }
+
+                        // Shallow fallback: depth budget exhausted, rule not found, or
+                        // already visited. A NonTerminal reference may advance the dispatch
+                        // cursor at runtime, so conservatively suppress any later cursor
+                        // predicates.
                         cursorMayHaveAdvanced = true;
                         break;
                     }
 
                     case GroupElement group:
                     {
+                        // Skip optional groups (`?` and `*` suffix). Assignments inside an
+                        // optional group are not guaranteed to fire at parse-time and
+                        // therefore the associated property may legitimately be unset on a
+                        // valid runtime POCO. Emitting them as mandatory `&&` clauses would
+                        // wrongly reject those POCOs at dispatch time. Only walk groups
+                        // that are guaranteed to execute: a group with no suffix or with
+                        // `+` (one-or-more — at least one iteration is mandatory).
+                        if (group.IsOptional)
+                        {
+                            break;
+                        }
+
+                        // Per-alternative walk + OR-combine: each `group.Alternatives`
+                        // entry represents an "or-branch" of the group (`(a | b | c)`).
+                        // At runtime exactly one branch is taken, so the dispatch-time
+                        // predicate is the disjunction of per-branch AND-conjunctions.
+                        // Cursor-state (`firstCursorEmitted`, `cursorMayHaveAdvanced`) is
+                        // shared across branches because any branch may consume the
+                        // dispatch cursor; once that happens for any branch we must
+                        // conservatively suppress subsequent cursor predicates.
+                        var perGroupAlternativeClauses = new List<List<string>>();
+
                         foreach (var groupAlternative in group.Alternatives)
                         {
-                            CollectGuardClauses(groupAlternative.Elements, targetProperties, cache, allRules, clauses, ref firstCursorEmitted, ref cursorMayHaveAdvanced);
+                            var altClauses = new List<string>();
+                            CollectGuardClauses(groupAlternative.Elements, targetProperties, cache, allRules, altClauses, ref firstCursorEmitted, ref cursorMayHaveAdvanced, visitedRules, remainingDepth);
+                            perGroupAlternativeClauses.Add(altClauses);
+                        }
+
+                        var combined = CombineAlternativesAsOr(perGroupAlternativeClauses);
+
+                        if (!string.IsNullOrEmpty(combined))
+                        {
+                            clauses.Add(combined);
                         }
 
                         break;
@@ -1139,14 +1391,37 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
             var matchingProperty = targetProperties.FirstOrDefault(property => string.Equals(property.Name, assignment.Property, StringComparison.OrdinalIgnoreCase));
 
-            var propertyAccessor = matchingProperty != null
-                ? matchingProperty.QueryPropertyNameBasedOnUmlProperties()
-                : assignment.Property.CapitalizeFirstLetter();
+            if (matchingProperty == null)
+            {
+                // The assignment targets a property that does not exist on the outer
+                // alternative's class. This can happen when the depth-aware walk descends
+                // into a NonTerminal whose target metaclass is unrelated to the outer's
+                // class (e.g. walking AnnotatingElement's switch dispatches into Comment
+                // / Documentation rules that assign `body`, `locale`, `language` which
+                // are NOT on the outer IAnnotatingElement). Emitting `{0}.{Prop}` would
+                // produce a compile error since the case variable lacks that member.
+                // Skip the clause; the outer guard remains correct without it.
+                return null;
+            }
+
+            // Drop `+=` clauses whose target property is not actually a collection on the
+            // outer class. The grammar's `+=` annotation tells the parser to append to a
+            // collection in the called rule's target metaclass — but when the depth-aware
+            // walk crosses a NonTerminal boundary, the OUTER class may expose the same
+            // property name as a scalar (e.g. `ISubsetting.Specific` is a single IFeature,
+            // not an IFeature collection). Emitting `{0}.Specific.OfType<…>().Any()` would
+            // fail to compile against the scalar property.
+            if (assignment.Operator == "+=" && !matchingProperty.QueryIsEnumerable())
+            {
+                return null;
+            }
+
+            var propertyAccessor = matchingProperty.QueryPropertyNameBasedOnUmlProperties();
 
             switch (assignment.Operator)
             {
                 case "=":
-                    return BuildScalarAssignmentClause(assignment, propertyAccessor, cache, allRules);
+                    return BuildScalarAssignmentClause(assignment, matchingProperty, propertyAccessor, cache, allRules);
                 case "+=":
                     return BuildCollectionAssignmentClause(assignment, propertyAccessor, cache, allRules, ref firstCursorEmitted, cursorMayHaveAdvanced);
                 default:
@@ -1155,32 +1430,79 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
         }
 
         /// <summary>
+        /// Determines whether <paramref name="property"/> can hold <c>null</c> in C#. True for
+        /// reference-typed properties (POCO interfaces, <see cref="string"/>) and nullable
+        /// value-typed properties (e.g. <c>int?</c>, <c>VisibilityKind?</c>); false for
+        /// non-nullable value types (mandatory enums or primitives with multiplicity [1]).
+        /// <para>
+        /// Used by <see cref="BuildScalarAssignmentClause"/> to suppress tautological
+        /// <c>!= null</c> guards on properties that the runtime POCO cannot leave unset.
+        /// </para>
+        /// </summary>
+        /// <param name="property">The <see cref="IProperty"/> resolved against the outer alternative class.</param>
+        /// <returns><c>true</c> if a runtime instance of the property could be <c>null</c>.</returns>
+        private static bool IsPropertyNullableInCSharp(IProperty property)
+        {
+            return property.QueryIsReferenceType()
+                   || property.QueryIsNullableAndNotString()
+                   || property.QueryIsString();
+        }
+
+        /// <summary>
         /// Translates a parsed scalar <c>=</c> assignment into its corresponding
         /// <c>when</c>-clause predicate. Terminal-literal RHS becomes an equality check;
         /// <c>[QualifiedName]</c> RHS becomes a non-null check; NonTerminal RHS narrows to
         /// the referenced rule's target metaclass when known.
+        /// <para>
+        /// When the matching property is a non-nullable value type (mandatory enum /
+        /// primitive — multiplicity [1] in UML), <c>!= null</c> and <c>is I…</c>
+        /// predicates would be a tautology (always-true) or a compile error (value type
+        /// vs reference type), so they are silently dropped. Only the terminal-equality
+        /// branch (<c>{0}.{Prop} == "literal"</c>) survives for non-nullable scalars.
+        /// </para>
         /// </summary>
         /// <param name="assignment">The <see cref="AssignmentElement"/> with <see cref="AssignmentElement.Operator"/> <c>=</c></param>
+        /// <param name="matchingProperty">The <see cref="IProperty"/> on the outer alternative class that this assignment binds — consulted for C# nullability.</param>
         /// <param name="propertyAccessor">The C# property name resolved via <see cref="PropertyExtension.QueryPropertyNameBasedOnUmlProperties"/></param>
         /// <param name="cache">The <see cref="IXmiElementCache"/> for resolving NonTerminal RHS targets</param>
         /// <param name="allRules">All available rules for NonTerminal resolution</param>
         /// <returns>A template clause, or <c>null</c> when no useful clause can be synthesised.</returns>
-        private static string BuildScalarAssignmentClause(AssignmentElement assignment, string propertyAccessor, IXmiElementCache cache, IReadOnlyList<TextualNotationRule> allRules)
+        private static string BuildScalarAssignmentClause(AssignmentElement assignment, IProperty matchingProperty, string propertyAccessor, IXmiElementCache cache, IReadOnlyList<TextualNotationRule> allRules)
         {
             switch (assignment.Value)
             {
                 case TerminalElement terminal when !string.IsNullOrEmpty(terminal.Value):
+                    // Terminal-literal equality is meaningful for any property type.
                     return $"{{0}}.{propertyAccessor} == \"{terminal.Value}\"";
 
                 case ValueLiteralElement valueLiteral when valueLiteral.QueryIsQualifiedName():
-                    return $"{{0}}.{propertyAccessor} != null";
+                    // [QualifiedName] RHS → non-null check; only meaningful when the C#
+                    // property can be null. Non-nullable value types (multiplicity [1]
+                    // enums / primitives) would yield a tautology — drop the clause.
+                    return IsPropertyNullableInCSharp(matchingProperty)
+                        ? $"{{0}}.{propertyAccessor} != null"
+                        : null;
 
                 case NonTerminalElement nonTerminal:
                 {
                     var rhsTargetClass = RuleQueryUtilities.ResolveRuleTargetClass(nonTerminal, cache, allRules);
-                    return rhsTargetClass != null
-                        ? $"{{0}}.{propertyAccessor} is {rhsTargetClass.QueryFullyQualifiedTypeName()}"
-                        : $"{{0}}.{propertyAccessor} != null";
+
+                    if (rhsTargetClass != null)
+                    {
+                        // `is I{Rhs}` requires a reference-typed property. For non-nullable
+                        // value-typed properties (mandatory enums / primitives) the cast
+                        // would not compile, so drop the clause.
+                        return matchingProperty.QueryIsReferenceType()
+                            ? $"{{0}}.{propertyAccessor} is {rhsTargetClass.QueryFullyQualifiedTypeName()}"
+                            : null;
+                    }
+
+                    // Fallback when the NonTerminal does not resolve to an IClass (e.g.
+                    // its target is an enum literal or unresolved name) — emit `!= null`
+                    // only when the property can actually hold null.
+                    return IsPropertyNullableInCSharp(matchingProperty)
+                        ? $"{{0}}.{propertyAccessor} != null"
+                        : null;
                 }
 
                 default:
@@ -1189,23 +1511,31 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
         }
 
         /// <summary>
-        /// Translates a parsed collection <c>+=</c> assignment into its corresponding
-        /// <c>when</c>-clause predicate. For the first <c>ownedRelationship +=</c> in the
-        /// rule body the predicate inspects the dispatch cursor's current element; for any
-        /// other collection it inspects the collection contents directly. Subsequent
-        /// <c>ownedRelationship +=</c> assignments produce no clause because the cursor
-        /// will have advanced past them by the time their position is reached at runtime.
+        /// Translates a parsed collection <c>+=</c> assignment into a cursor-based
+        /// <c>when</c>-clause predicate. The clause inspects the first element of the
+        /// target collection via the project's standard cursor pattern
+        /// (<c>writerContext.CursorCache.GetOrCreateCursor(…).Current is …</c>) — this
+        /// keeps the dispatch-time guards consistent with how the rest of the textual
+        /// notation builders consume containment collections.
+        /// <para>
+        /// For <c>ownedRelationship +=</c> the predicate is additionally gated by the
+        /// outer walk's <paramref name="cursorMayHaveAdvanced"/> tracker: once any
+        /// prior <c>ownedRelationship +=</c> or a NonTerminal reference may have
+        /// advanced the dispatch cursor past position 0, no further cursor predicate
+        /// is emitted (it would check a stale position). For other collections that
+        /// concern does not apply — each collection has its own independent cursor.
+        /// </para>
         /// </summary>
         /// <param name="assignment">The <see cref="AssignmentElement"/> with <see cref="AssignmentElement.Operator"/> <c>+=</c></param>
         /// <param name="propertyAccessor">The C# collection-property name resolved via <see cref="PropertyExtension.QueryPropertyNameBasedOnUmlProperties"/></param>
         /// <param name="cache">The <see cref="IXmiElementCache"/> for resolving NonTerminal RHS targets</param>
         /// <param name="allRules">All available rules for NonTerminal resolution</param>
-        /// <param name="firstCursorEmitted">Tracks whether a cursor predicate has been emitted yet for this rule.</param>
+        /// <param name="firstCursorEmitted">Tracks whether the first <c>ownedRelationship</c> cursor predicate has been emitted yet for this walk.</param>
         /// <param name="cursorMayHaveAdvanced">
-        /// When true, the dispatch cursor may have advanced past position 0 at runtime due to a
-        /// prior <c>ownedRelationship +=</c> or a preceding <c>NonTerminal</c> reference whose
-        /// target rule may consume the cursor. Suppresses cursor predicate emission so we don't
-        /// generate stale <c>cursor.Current is …</c> checks against the wrong position.
+        /// When true, the dispatch (<c>ownedRelationship</c>) cursor may have advanced
+        /// past position 0 at runtime due to a prior <c>ownedRelationship +=</c> or a
+        /// preceding <c>NonTerminal</c> reference whose target rule may consume the
+        /// cursor. Suppresses ownedRelationship cursor predicate emission.
         /// </param>
         /// <returns>A template clause, or <c>null</c> when no useful clause can be synthesised.</returns>
         private static string BuildCollectionAssignmentClause(AssignmentElement assignment, string propertyAccessor, IXmiElementCache cache, IReadOnlyList<TextualNotationRule> allRules, ref bool firstCursorEmitted, bool cursorMayHaveAdvanced)
@@ -1232,10 +1562,9 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                 }
 
                 firstCursorEmitted = true;
-                return $"writerContext.CursorCache.GetOrCreateCursor({{0}}.Id, \"{assignment.Property}\", {{0}}.{propertyAccessor}).Current is {rhsTargetTypeName}";
             }
 
-            return $"{{0}}.{propertyAccessor}.OfType<{rhsTargetTypeName}>().Any()";
+            return $"writerContext.CursorCache.GetOrCreateCursor({{0}}.Id, \"{assignment.Property}\", {{0}}.{propertyAccessor}).Current is {rhsTargetTypeName}";
         }
     }
 }

--- a/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.cs
+++ b/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleProcessor.cs
@@ -138,6 +138,137 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
         }
 
         /// <summary>
+        /// Collects, in the order they will be consumed at runtime, the <c>+=</c>
+        /// <see cref="AssignmentElement" /> items that target <paramref name="targetPropertyName" />.
+        /// The collected items are: first the <c>+=</c> assignments declared inside the optional
+        /// group itself (<paramref name="optionalGroupElements" />), then the <c>+=</c>
+        /// assignments declared by the parent alternative AFTER <paramref name="optionalElementIndex" />
+        /// (<paramref name="siblingElements" />).
+        /// <para>
+        /// The tail walk stops as soon as it encounters a sibling whose own contribution to the
+        /// target cursor is not statically determinable (an optional or collection
+        /// <see cref="GroupElement" /> that nests a <c>+=</c> on the same property, or a
+        /// <see cref="NonTerminalElement" /> that could indirectly consume the cursor). When the
+        /// tail offset is uncertain, only the optional group's own consumptions are returned —
+        /// callers can then emit a guard that type-checks the optional positions without making
+        /// claims about the tail.
+        /// </para>
+        /// </summary>
+        /// <param name="optionalGroupElements">The optional group's own elements</param>
+        /// <param name="siblingElements">The parent alternative's elements</param>
+        /// <param name="optionalElementIndex">The index of the optional group within <paramref name="siblingElements" /></param>
+        /// <param name="targetPropertyName">The property name whose <c>+=</c> consumptions are collected</param>
+        /// <returns>The ordered list of cursor consumptions the optional path requires</returns>
+        private static List<AssignmentElement> CollectCursorConsumptions(IReadOnlyList<RuleElement> optionalGroupElements, IReadOnlyList<RuleElement> siblingElements, int optionalElementIndex, string targetPropertyName)
+        {
+            var consumptionAssignments = new List<AssignmentElement>();
+
+            if (optionalGroupElements != null)
+            {
+                foreach (var ruleElement in optionalGroupElements)
+                {
+                    if (ruleElement is AssignmentElement { Operator: "+=" } assignmentElement
+                        && string.Equals(assignmentElement.Property, targetPropertyName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        consumptionAssignments.Add(assignmentElement);
+                    }
+                }
+            }
+
+            if (siblingElements == null)
+            {
+                return consumptionAssignments;
+            }
+
+            for (var siblingIndex = optionalElementIndex + 1; siblingIndex < siblingElements.Count; siblingIndex++)
+            {
+                switch (siblingElements[siblingIndex])
+                {
+                    case TerminalElement:
+                    case NonParsingAssignmentElement:
+                    case ValueLiteralElement:
+                        continue;
+
+                    case AssignmentElement { Operator: "+=" } cursorAssignment
+                        when string.Equals(cursorAssignment.Property, targetPropertyName, StringComparison.OrdinalIgnoreCase):
+                        consumptionAssignments.Add(cursorAssignment);
+                        continue;
+
+                    case AssignmentElement:
+                        continue;
+
+                    case GroupElement groupElement when !GroupCanConsumeTargetCursor(groupElement, targetPropertyName):
+                        continue;
+
+                    default:
+                        return consumptionAssignments;
+                }
+            }
+
+            return consumptionAssignments;
+        }
+
+        /// <summary>
+        /// Determines whether the supplied <paramref name="groupElement" /> (recursively) contains
+        /// any <c>+=</c> <see cref="AssignmentElement" /> targeting <paramref name="targetPropertyName" />.
+        /// Used by <see cref="CollectCursorConsumptions" /> to decide whether a sibling group
+        /// could shift the runtime offset of subsequent cursor consumptions.
+        /// </summary>
+        /// <param name="groupElement">The <see cref="GroupElement" /> to inspect</param>
+        /// <param name="targetPropertyName">The property name whose consumption is detected</param>
+        /// <returns><c>true</c> if the group could consume the target cursor; <c>false</c> otherwise</returns>
+        private static bool GroupCanConsumeTargetCursor(GroupElement groupElement, string targetPropertyName)
+        {
+            foreach (var alternative in groupElement.Alternatives)
+            {
+                foreach (var element in alternative.Elements)
+                {
+                    switch (element)
+                    {
+                        case AssignmentElement { Operator: "+=" } cursorAssignment
+                            when string.Equals(cursorAssignment.Property, targetPropertyName, StringComparison.OrdinalIgnoreCase):
+                            return true;
+
+                        case GroupElement nestedGroup when GroupCanConsumeTargetCursor(nestedGroup, targetPropertyName):
+                            return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Resolves the fully-qualified runtime type name (e.g.
+        /// <c>SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership</c>) that an
+        /// <see cref="AssignmentElement" />'s consumed cursor element is expected to satisfy.
+        /// Returns <c>null</c> when the assignment's value is not a <see cref="NonTerminalElement" />
+        /// or when the referenced rule has no resolvable target class.
+        /// </summary>
+        /// <param name="assignmentElement">The <c>+=</c> assignment to resolve the target type of</param>
+        /// <param name="umlClass">The class hosting the current rule (provides the UML cache)</param>
+        /// <param name="ruleGenerationContext">The current <see cref="RuleGenerationContext" /></param>
+        /// <returns>The fully-qualified target type name, or <c>null</c> if it cannot be resolved</returns>
+        private static string ResolveAssignmentTargetTypeName(AssignmentElement assignmentElement, IClass umlClass, RuleGenerationContext ruleGenerationContext)
+        {
+            if (assignmentElement.Value is not NonTerminalElement nonTerminalElement)
+            {
+                return null;
+            }
+
+            var referencedRule = ruleGenerationContext.FindRule(nonTerminalElement.Name);
+            var typeTarget = referencedRule?.EffectiveTarget;
+
+            if (typeTarget == null)
+            {
+                return null;
+            }
+
+            var targetClass = RuleQueryUtilities.FindClass(umlClass.Cache, typeTarget);
+            return targetClass?.QueryFullyQualifiedTypeName();
+        }
+
+        /// <summary>
         /// Processes a single alternative (no branching needed). Handles optional guard emission
         /// and iterates through the alternative's elements.
         /// </summary>
@@ -171,7 +302,39 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                         {
                             var assigment = elements.OfType<AssignmentElement>().First(x => x.Property == targetPropertyName);
                             var iterator = ruleGenerationContext.DefinedCursors.FirstOrDefault(x => x.ApplicableRuleElements.Contains(assigment));
-                            ifStatementContent.Add(iterator == null ? $"BuildGroupConditionFor{assigment.TextualNotationRule.RuleName}(poco)" : property.QueryIfStatementContentForNonEmpty(iterator.CursorVariableName));
+
+                            if (iterator == null)
+                            {
+                                ifStatementContent.Add($"BuildGroupConditionFor{assigment.TextualNotationRule.RuleName}(poco)");
+                            }
+                            else
+                            {
+                                var consumptionAssignments = CollectCursorConsumptions(elements, ruleGenerationContext.CurrentSiblingElements, ruleGenerationContext.CurrentElementIndex, targetPropertyName);
+
+                                if (consumptionAssignments.Count > 1)
+                                {
+                                    var conditionParts = new List<string>();
+
+                                    for (var consumptionIndex = 0; consumptionIndex < consumptionAssignments.Count; consumptionIndex++)
+                                    {
+                                        var cursorAccess = consumptionIndex == 0
+                                            ? $"{iterator.CursorVariableName}.Current"
+                                            : $"{iterator.CursorVariableName}.GetNext({consumptionIndex})";
+
+                                        var typeName = ResolveAssignmentTargetTypeName(consumptionAssignments[consumptionIndex], umlClass, ruleGenerationContext);
+
+                                        conditionParts.Add(typeName == null
+                                            ? $"{cursorAccess} != null"
+                                            : $"{cursorAccess} is {typeName}");
+                                    }
+
+                                    ifStatementContent.Add(string.Join(" && ", conditionParts));
+                                }
+                                else
+                                {
+                                    ifStatementContent.Add(property.QueryIfStatementContentForNonEmpty(iterator.CursorVariableName));
+                                }
+                            }
                         }
                         else
                         {
@@ -209,7 +372,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
                         if (referencedRule != null)
                         {
-                            var condition = this.GenerateInlineOptionalCondition(referencedRule, umlClass, ruleGenerationContext.AllRules, "poco");
+                            var condition = this.GenerateInlineOptionalCondition(writer, referencedRule, umlClass, ruleGenerationContext, "poco");
 
                             if (condition != null)
                             {

--- a/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleQueryUtilities.cs
+++ b/SysML2.NET.CodeGenerator/HandleBarHelpers/RuleQueryUtilities.cs
@@ -112,7 +112,19 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
         }
 
         /// <summary>
-        /// Extracts all boolean property names assigned via the conditional operator from a grammar rule.
+        /// Extracts all boolean property names assigned via the conditional operator
+        /// (<c>?=</c>) from a grammar rule, restricted to assignments that are
+        /// <em>guaranteed to fire</em> whenever the rule matches. A <c>?=</c> at the
+        /// top level of the rule body is guaranteed; one inside an optional
+        /// (<c>?</c>), repeating (<c>*</c>/<c>+</c>), or alternation
+        /// (<c>(A | B)</c>) group — or reached through a NonTerminal whose
+        /// referenced rule itself has multiple top-level alternatives — is
+        /// <em>conditional</em> and is excluded, because <c>IsX</c> would be
+        /// <c>true</c> only for the subset of inputs that took that path. The
+        /// conditional-position filter prevents the duplicate-class
+        /// discriminator pass (<c>RuleProcessor.PatternHandlers.cs</c>) from
+        /// emitting unreliable <c>when poco.IsX</c> guards that silently drop
+        /// runtime instances where the keyword was not matched.
         /// </summary>
         /// <param name="rule">The <see cref="TextualNotationRule" /> to inspect</param>
         /// <param name="allRules">All available rules for recursive lookup</param>
@@ -120,42 +132,79 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
         internal static List<string> QueryBooleanAssignmentProperties(TextualNotationRule rule, IReadOnlyList<TextualNotationRule> allRules)
         {
             var result = new List<string>();
-            CollectBooleanAssignmentProperties(rule.Alternatives.SelectMany(x => x.Elements).ToList(), allRules, result, new HashSet<string>());
+
+            // A rule with multiple top-level alternatives is itself an alternation
+            // choice — `?=` reached through any single alternative is conditional.
+            var topLevelIsConditional = rule.Alternatives.Count > 1;
+
+            foreach (var alternative in rule.Alternatives)
+            {
+                CollectBooleanAssignmentProperties(alternative.Elements, allRules, result, new HashSet<string>(), topLevelIsConditional);
+            }
+
             return result;
         }
 
         /// <summary>
-        /// Recursively collects boolean <c>?=</c> assignment property names from a list of <see cref="RuleElement" />
+        /// Recursively collects boolean <c>?=</c> assignment property names from a
+        /// list of <see cref="RuleElement" />. Only assignments at
+        /// <em>unconditional</em> positions (<paramref name="isConditional" />
+        /// <c>== false</c>) are collected — see
+        /// <see cref="QueryBooleanAssignmentProperties" /> for why.
         /// </summary>
         /// <param name="elements">The elements to inspect</param>
         /// <param name="allRules">All available rules for resolving NonTerminal references</param>
         /// <param name="result">The accumulated list of boolean property names</param>
         /// <param name="visited">Set of already-visited rule names to prevent infinite recursion</param>
-        internal static void CollectBooleanAssignmentProperties(IReadOnlyList<RuleElement> elements, IReadOnlyList<TextualNotationRule> allRules, List<string> result, HashSet<string> visited)
+        /// <param name="isConditional">
+        /// <c>true</c> when the current walk position is inside an optional /
+        /// repeating / alternation group (directly or transitively) so any
+        /// <c>?=</c> reached from here cannot serve as a guaranteed discriminator.
+        /// </param>
+        internal static void CollectBooleanAssignmentProperties(IReadOnlyList<RuleElement> elements, IReadOnlyList<TextualNotationRule> allRules, List<string> result, HashSet<string> visited, bool isConditional)
         {
             foreach (var element in elements)
             {
                 switch (element)
                 {
-                    case AssignmentElement { Operator: "?=" } assignment:
+                    case AssignmentElement { Operator: "?=" } assignment when !isConditional:
                         result.Add(assignment.Property);
                         break;
+
                     case GroupElement groupElement:
+                    {
+                        var groupIsConditional = isConditional
+                            || groupElement.IsOptional
+                            || groupElement.IsCollection
+                            || groupElement.Alternatives.Count > 1;
+
                         foreach (var groupAlternative in groupElement.Alternatives)
                         {
-                            CollectBooleanAssignmentProperties(groupAlternative.Elements, allRules, result, visited);
+                            CollectBooleanAssignmentProperties(groupAlternative.Elements, allRules, result, visited, groupIsConditional);
                         }
 
                         break;
+                    }
+
                     case NonTerminalElement nonTerminal:
+                    {
                         var referencedRule = allRules.SingleOrDefault(x => x.RuleName == nonTerminal.Name);
 
                         if (referencedRule != null && visited.Add(referencedRule.RuleName))
                         {
-                            CollectBooleanAssignmentProperties(referencedRule.Alternatives.SelectMany(x => x.Elements).ToList(), allRules, result, visited);
+                            var nonTerminalIsConditional = isConditional
+                                || nonTerminal.IsOptional
+                                || nonTerminal.IsCollection
+                                || referencedRule.Alternatives.Count > 1;
+
+                            foreach (var alternative in referencedRule.Alternatives)
+                            {
+                                CollectBooleanAssignmentProperties(alternative.Elements, allRules, result, visited, nonTerminalIsConditional);
+                            }
                         }
 
                         break;
+                    }
                 }
             }
         }

--- a/SysML2.NET.CodeGenerator/HandleBarHelpers/RulesHelper.cs
+++ b/SysML2.NET.CodeGenerator/HandleBarHelpers/RulesHelper.cs
@@ -99,7 +99,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
 
                     if (isOwnedExpressionRule)
                     {
-                        writer.WriteSafeString("var operatorParensNeeded = writerContext.OperatorContextStack.Count > 0 && SysML2.NET.Serializer.TextualNotation.Writers.OperatorPrecedence.NeedsParenthesesAsOperand(writerContext.OperatorContextStack.Peek(), poco);" + Environment.NewLine);
+                        writer.WriteSafeString("var operatorParensNeeded = writerContext.EmitOperatorParentheses && writerContext.OperatorContextStack.Count > 0 && SysML2.NET.Serializer.TextualNotation.Writers.OperatorPrecedence.NeedsParenthesesAsOperand(writerContext.OperatorContextStack.Peek(), poco);" + Environment.NewLine);
                         writer.WriteSafeString("if (operatorParensNeeded) { stringBuilder.Append('('); }" + Environment.NewLine);
                     }
 

--- a/SysML2.NET.CodeGenerator/HandleBarHelpers/RulesHelper.cs
+++ b/SysML2.NET.CodeGenerator/HandleBarHelpers/RulesHelper.cs
@@ -29,6 +29,7 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
     using SysML2.NET.CodeGenerator.Grammar.Model;
 
     using uml4net.CommonStructure;
+    using uml4net.Extensions;
     using uml4net.StructuredClassifiers;
 
     /// <summary>
@@ -92,9 +93,67 @@ namespace SysML2.NET.CodeGenerator.HandleBarHelpers
                     };
 
                     ruleGenerationContext.AllRules.AddRange(allRules);
+
+                    var isOperatorExpressionRule = IsOperatorExpressionRule(textualRule, umlClass);
+                    var isOwnedExpressionRule = string.Equals(textualRule.RuleName, "OwnedExpression", StringComparison.Ordinal);
+
+                    if (isOwnedExpressionRule)
+                    {
+                        writer.WriteSafeString("var operatorParensNeeded = writerContext.OperatorContextStack.Count > 0 && SysML2.NET.Serializer.TextualNotation.Writers.OperatorPrecedence.NeedsParenthesesAsOperand(writerContext.OperatorContextStack.Peek(), poco);" + Environment.NewLine);
+                        writer.WriteSafeString("if (operatorParensNeeded) { stringBuilder.Append('('); }" + Environment.NewLine);
+                    }
+
+                    if (isOperatorExpressionRule)
+                    {
+                        writer.WriteSafeString("writerContext.OperatorContextStack.Push(poco);" + Environment.NewLine);
+                        writer.WriteSafeString("try" + Environment.NewLine + "{" + Environment.NewLine);
+                    }
+
                     processor.ProcessAlternatives(writer, umlClass, textualRule.Alternatives, ruleGenerationContext);
+
+                    if (isOperatorExpressionRule)
+                    {
+                        writer.WriteSafeString("}" + Environment.NewLine + "finally" + Environment.NewLine + "{" + Environment.NewLine + "writerContext.OperatorContextStack.Pop();" + Environment.NewLine + "}" + Environment.NewLine);
+                    }
+
+                    if (isOwnedExpressionRule)
+                    {
+                        writer.WriteSafeString("if (operatorParensNeeded) { stringBuilder.Append(')'); }" + Environment.NewLine);
+                    }
                 }
             });
+        }
+
+        /// <summary>
+        /// Determines whether <paramref name="rule"/> targets an <c>IOperatorExpression</c>
+        /// (or any of its subclasses) as the rule's effective metaclass. Used by
+        /// <c>WriteRule</c> to wrap the generated builder body with a precedence-stack
+        /// push/pop so operand-rendering can decide on parens.
+        /// </summary>
+        /// <param name="rule">The textual notation rule being generated.</param>
+        /// <param name="umlClass">The rule's target <see cref="IClass"/>.</param>
+        /// <returns><c>true</c> when the target is <c>OperatorExpression</c> or a subclass.</returns>
+        private static bool IsOperatorExpressionRule(TextualNotationRule rule, IClass umlClass)
+        {
+            if (umlClass == null)
+            {
+                return false;
+            }
+
+            if (string.Equals(umlClass.Name, "OperatorExpression", StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            foreach (var general in umlClass.QueryAllGeneralClassifiers())
+            {
+                if (string.Equals(general.Name, "OperatorExpression", StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/SysML2.NET.Serializer.TextualNotation.Tests/Writers/TextualNotationBuilderTestFixture.cs
+++ b/SysML2.NET.Serializer.TextualNotation.Tests/Writers/TextualNotationBuilderTestFixture.cs
@@ -81,6 +81,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Tests.Writers
         public void Verify_that_textual_notation_is_produced_from_Quantities_root_namespace()
         {
             using var writerContext = new TextualNotationWriterContext(this.rootNamespace);
+            writerContext.EmitOperatorParentheses = false;
             var stringBuilder = new StringBuilder();
 
             try

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/AcceptActionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/AcceptActionUsageTextualNotationBuilder.cs
@@ -58,8 +58,9 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         public static void BuildAcceptNodeDeclaration(SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
+            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership) || poco.IsOrdered)
             {
                 ActionUsageTextualNotationBuilder.BuildActionNodeUsageDeclaration(poco, writerContext, stringBuilder);
             }
@@ -85,10 +86,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildPayloadParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             if (ownedRelationshipCursor.Current != null)
             {
@@ -146,12 +147,12 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         public static void BuildTransitionAcceptActionUsage(SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             BuildAcceptNodeDeclaration(poco, writerContext, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (poco.OwnedRelationship.Count != 0 || poco.importedMembership.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsVariation || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.isReference || poco.IsIndividual || poco.PortionKind.HasValue || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if ((ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IImport || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IVariantMembership || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership) || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsVariation || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.isReference || poco.IsIndividual || poco.PortionKind.HasValue || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
-                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 while (ownedRelationshipCursor.Current != null)
                 {
                     TypeTextualNotationBuilder.BuildActionBodyItem(poco, writerContext, stringBuilder);

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ActionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ActionUsageTextualNotationBuilder.cs
@@ -44,8 +44,9 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         public static void BuildActionUsageDeclaration(SysML2.NET.Core.POCO.Systems.Actions.IActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }
@@ -101,8 +102,9 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         public static void BuildActionNodeUsageDeclaration(SysML2.NET.Core.POCO.Systems.Actions.IActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             stringBuilder.Append("action ");
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
+            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership) || poco.IsOrdered)
             {
                 UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
             }
@@ -119,8 +121,9 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         public static void BuildActionNodePrefix(SysML2.NET.Core.POCO.Systems.Actions.IActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
+            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership) || poco.IsOrdered)
             {
                 BuildActionNodeUsageDeclaration(poco, writerContext, stringBuilder);
             }
@@ -138,7 +141,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         {
             var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
+            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership) || poco.IsOrdered)
             {
                 BuildActionNodeUsageDeclaration(poco, writerContext, stringBuilder);
                 stringBuilder.Append(' ');
@@ -152,10 +155,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildAssignmentTargetMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             if (ownedRelationshipCursor.Current != null)
             {
@@ -163,10 +166,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership elementAsMembership)
                 {
                     MembershipTextualNotationBuilder.BuildFeatureChainMember(elementAsMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append(":= ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -175,10 +178,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildNodeParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -191,12 +194,13 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         public static void BuildActionBodyParameter(SysML2.NET.Core.POCO.Systems.Actions.IActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
+            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership) || poco.IsOrdered)
             {
                 stringBuilder.Append("action ");
 
-                if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
+                if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership) || poco.IsOrdered)
                 {
                     UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
                 }
@@ -204,7 +208,6 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
 
             stringBuilder.Append(' ');
             stringBuilder.AppendLine("{");
-            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             while (ownedRelationshipCursor.Current != null)
             {
                 TypeTextualNotationBuilder.BuildActionBodyItem(poco, writerContext, stringBuilder);

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ActorMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ActorMembershipTextualNotationBuilder.cs
@@ -52,10 +52,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Parts.IPartUsage elementAsPartUsage)
                 {
                     PartUsageTextualNotationBuilder.BuildActorUsage(elementAsPartUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/AnalysisCaseUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/AnalysisCaseUsageTextualNotationBuilder.cs
@@ -46,8 +46,9 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
             OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("analysis ");
             UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/AnnotationTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/AnnotationTextualNotationBuilder.cs
@@ -51,10 +51,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Root.Annotations.IAnnotatingElement elementAsAnnotatingElement)
                 {
                     AnnotatingElementTextualNotationBuilder.BuildAnnotatingElement(elementAsAnnotatingElement, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/AssertConstraintUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/AssertConstraintUsageTextualNotationBuilder.cs
@@ -62,12 +62,12 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting elementAsReferenceSubsetting)
                     {
                         ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
 
-
-                if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
+                if ((ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership) || poco.IsOrdered)
                 {
                     FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, writerContext, stringBuilder);
                 }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/AssignmentActionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/AssignmentActionUsageTextualNotationBuilder.cs
@@ -73,12 +73,12 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         public static void BuildTransitionAssignmentActionUsage(SysML2.NET.Core.POCO.Systems.Actions.IAssignmentActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             ActionUsageTextualNotationBuilder.BuildAssignmentNodeDeclaration(poco, writerContext, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (poco.OwnedRelationship.Count != 0 || poco.importedMembership.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsVariation || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.isReference || poco.IsIndividual || poco.PortionKind.HasValue || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if ((ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IImport || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IVariantMembership || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership) || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsVariation || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.isReference || poco.IsIndividual || poco.PortionKind.HasValue || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
-                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 while (ownedRelationshipCursor.Current != null)
                 {
                     TypeTextualNotationBuilder.BuildActionBodyItem(poco, writerContext, stringBuilder);

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/BindingConnectorAsUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/BindingConnectorAsUsageTextualNotationBuilder.cs
@@ -46,7 +46,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
             var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             UsageTextualNotationBuilder.BuildUsagePrefix(poco, writerContext, stringBuilder);
 
-            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.OwnedRelatedElement.Count != 0 || poco.IsOrdered)
+            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership) || poco.IsOrdered)
             {
                 stringBuilder.Append("binding ");
                 UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
@@ -61,10 +61,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
                     EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append("= ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -73,10 +73,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
                     EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             UsageTextualNotationBuilder.BuildUsageBody(poco, writerContext, stringBuilder);
 
         }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/BooleanExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/BooleanExpressionTextualNotationBuilder.cs
@@ -46,8 +46,9 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
             SharedTextualNotationBuilder.BuildFeaturePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("bool ");
             FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, writerContext, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/CaseUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/CaseUsageTextualNotationBuilder.cs
@@ -46,8 +46,9 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
             OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("case ");
             UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ClassifierTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ClassifierTextualNotationBuilder.cs
@@ -52,10 +52,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Classifiers.ISubclassification elementAsSubclassification)
                 {
                     SubclassificationTextualNotationBuilder.BuildOwnedSubclassification(elementAsSubclassification, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             while (ownedRelationshipCursor.Current != null && ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Classifiers.ISubclassification)
             {
@@ -137,10 +137,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Classifiers.ISubclassification elementAsSubclassification)
                 {
                     SubclassificationTextualNotationBuilder.BuildOwnedSubclassification(elementAsSubclassification, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             while (ownedRelationshipCursor.Current != null && ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Classifiers.ISubclassification)
             {

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/CollectExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/CollectExpressionTextualNotationBuilder.cs
@@ -43,29 +43,37 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         public static void BuildCollectExpression(SysML2.NET.Core.POCO.Kernel.Expressions.ICollectExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-
-            if (ownedRelationshipCursor.Current != null)
+            writerContext.OperatorContextStack.Push(poco);
+            try
             {
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                if (ownedRelationshipCursor.Current != null)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildPrimaryArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
 
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                    {
+                        ParameterMembershipTextualNotationBuilder.BuildPrimaryArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
+                }
+                stringBuilder.Append(".");
+
+                if (ownedRelationshipCursor.Current != null)
+                {
+
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                    {
+                        ParameterMembershipTextualNotationBuilder.BuildBodyArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
                 }
             }
-            stringBuilder.Append(".");
-
-            if (ownedRelationshipCursor.Current != null)
+            finally
             {
-
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
-                {
-                    ParameterMembershipTextualNotationBuilder.BuildBodyArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
-
-                }
+                writerContext.OperatorContextStack.Pop();
             }
 
         }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/CollectExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/CollectExpressionTextualNotationBuilder.cs
@@ -51,10 +51,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildPrimaryArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append(".");
 
             if (ownedRelationshipCursor.Current != null)
@@ -63,10 +63,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildBodyArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ConjugatedPortDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ConjugatedPortDefinitionTextualNotationBuilder.cs
@@ -51,10 +51,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.Ports.IPortConjugation elementAsPortConjugation)
                 {
                     PortConjugationTextualNotationBuilder.BuildPortConjugation(elementAsPortConjugation, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ConjugatedPortTypingTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ConjugatedPortTypingTextualNotationBuilder.cs
@@ -44,7 +44,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         public static void BuildConjugatedPortTyping(SysML2.NET.Core.POCO.Systems.Ports.IConjugatedPortTyping poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             stringBuilder.Append("~");
-            BuildOriginalPortDefinition(poco, writerContext, stringBuilder);
+            BuildConjugatedPortTypingHandCoded(poco, writerContext, stringBuilder);
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ConnectionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ConnectionUsageTextualNotationBuilder.cs
@@ -72,10 +72,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
                     EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append("to ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -84,10 +84,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
                     EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -109,10 +109,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
                     EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append(", ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -121,10 +121,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
                     EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership endFeatureMembershipGuard && endFeatureMembershipGuard.OwnedRelatedElement.OfType<SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage>().Any())
             {

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ConnectorTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ConnectorTextualNotationBuilder.cs
@@ -73,10 +73,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
                     EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append("to ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -85,10 +85,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
                     EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -102,8 +102,9 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         public static void BuildNaryConnectorDeclaration(SysML2.NET.Core.POCO.Kernel.Connectors.IConnector poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+            var ownedTypeFeaturingCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedTypeFeaturing", poco.ownedTypeFeaturing);
 
-            if (poco.IsSufficient || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if (poco.IsSufficient || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IConjugation || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IDisjoining || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IUnioning || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IIntersecting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IDifferencing || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureChaining || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureInverting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ITypeFeaturing) || poco.IsOrdered || ownedTypeFeaturingCursor.Current is SysML2.NET.Core.POCO.Core.Features.ITypeFeaturing)
             {
                 FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, writerContext, stringBuilder);
             }
@@ -115,10 +116,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
                     EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append(", ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -127,10 +128,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
                     EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership endFeatureMembershipGuard && endFeatureMembershipGuard.OwnedRelatedElement.OfType<SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage>().Any())
             {

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ConstraintUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ConstraintUsageTextualNotationBuilder.cs
@@ -44,8 +44,9 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         public static void BuildConstraintUsageDeclaration(SysML2.NET.Core.POCO.Systems.Constraints.IConstraintUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ConstructorExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ConstructorExpressionTextualNotationBuilder.cs
@@ -52,10 +52,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership elementAsMembership)
                 {
                     MembershipTextualNotationBuilder.BuildInstantiatedTypeMember(elementAsMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             if (ownedRelationshipCursor.Current != null)
             {
@@ -63,10 +63,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
                 {
                     ReturnParameterMembershipTextualNotationBuilder.BuildConstructorResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/DefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/DefinitionTextualNotationBuilder.cs
@@ -51,10 +51,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                 {
                     OwningMembershipTextualNotationBuilder.BuildPrefixMetadataMember(elementAsOwningMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -91,8 +91,9 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         public static void BuildDefinitionDeclaration(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IDefinition poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (poco.OwnedRelationship.Count != 0)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Classifiers.ISubclassification)
             {
                 ClassifierTextualNotationBuilder.BuildSubclassificationPart(poco, writerContext, stringBuilder);
             }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ElementFilterMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ElementFilterMembershipTextualNotationBuilder.cs
@@ -53,10 +53,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IExpression elementAsExpression)
                 {
                     ExpressionTextualNotationBuilder.BuildOwnedExpression(elementAsExpression, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
             stringBuilder.AppendLine(";");
 
         }
@@ -79,10 +79,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IExpression elementAsExpression)
                 {
                     ExpressionTextualNotationBuilder.BuildOwnedExpression(elementAsExpression, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
             stringBuilder.Append("] ");
 
         }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ElementTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ElementTextualNotationBuilder.cs
@@ -138,11 +138,11 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 case SysML2.NET.Core.POCO.Systems.Attributes.IAttributeDefinition pocoAttributeDefinition:
                     AttributeDefinitionTextualNotationBuilder.BuildAttributeDefinition(pocoAttributeDefinition, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceDefinition pocoOccurrenceDefinitionOccurrenceDefinition when pocoOccurrenceDefinitionOccurrenceDefinition.IsValidForOccurrenceDefinition(writerContext):
-                    OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinition(pocoOccurrenceDefinitionOccurrenceDefinition, writerContext, stringBuilder);
+                case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceDefinition pocoOccurrenceDefinitionIndividualDefinition when pocoOccurrenceDefinitionIndividualDefinition.IsIndividual:
+                    OccurrenceDefinitionTextualNotationBuilder.BuildIndividualDefinition(pocoOccurrenceDefinitionIndividualDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceDefinition pocoOccurrenceDefinition:
-                    OccurrenceDefinitionTextualNotationBuilder.BuildIndividualDefinition(pocoOccurrenceDefinition, writerContext, stringBuilder);
+                    OccurrenceDefinitionTextualNotationBuilder.BuildOccurrenceDefinition(pocoOccurrenceDefinition, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IDefinition pocoDefinition:
                     DefinitionTextualNotationBuilder.BuildExtendedDefinition(pocoDefinition, writerContext, stringBuilder);

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ElementTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ElementTextualNotationBuilder.cs
@@ -47,7 +47,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName))
             {
                 stringBuilder.Append("<");
-                stringBuilder.Append(poco.DeclaredShortName);
+                SharedTextualNotationBuilder.AppendName(stringBuilder, poco.DeclaredShortName);
                 stringBuilder.Append(">");
                 stringBuilder.Append(' ');
             }
@@ -55,7 +55,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredName))
             {
-                stringBuilder.Append(poco.DeclaredName);
+                SharedTextualNotationBuilder.AppendName(stringBuilder, poco.DeclaredName);
             }
 
 

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/EndFeatureMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/EndFeatureMembershipTextualNotationBuilder.cs
@@ -51,10 +51,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
                     ReferenceUsageTextualNotationBuilder.BuildSourceEnd(elementAsReferenceUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -75,10 +75,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
                     ReferenceUsageTextualNotationBuilder.BuildConnectorEnd(elementAsReferenceUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -99,10 +99,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Ports.IPortUsage elementAsPortUsage)
                 {
                     PortUsageTextualNotationBuilder.BuildInterfaceEnd(elementAsPortUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -123,10 +123,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Interactions.IFlowEnd elementAsFlowEnd)
                 {
                     FlowEndTextualNotationBuilder.BuildFlowEnd(elementAsFlowEnd, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -147,10 +147,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
                     ReferenceUsageTextualNotationBuilder.BuildEmptyFeature(elementAsReferenceUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/EventOccurrenceUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/EventOccurrenceUsageTextualNotationBuilder.cs
@@ -51,10 +51,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting elementAsReferenceSubsetting)
                 {
                     ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -79,12 +79,12 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting elementAsReferenceSubsetting)
                     {
                         ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
 
-
-                if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
+                if ((ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership) || poco.IsOrdered)
                 {
                     FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, writerContext, stringBuilder);
                 }
@@ -93,7 +93,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
             {
                 stringBuilder.Append("occurrence ");
 
-                if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
+                if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership) || poco.IsOrdered)
                 {
                     UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
                 }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ExhibitStateUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ExhibitStateUsageTextualNotationBuilder.cs
@@ -55,12 +55,12 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting elementAsReferenceSubsetting)
                     {
                         ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
 
-
-                if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
+                if ((ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership) || poco.IsOrdered)
                 {
                     FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, writerContext, stringBuilder);
                 }
@@ -73,7 +73,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
 
             stringBuilder.Append(' ');
 
-            if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ExpressionTextualNotationBuilder.cs
@@ -174,10 +174,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping elementAsFeatureTyping)
                 {
                     FeatureTypingTextualNotationBuilder.BuildReferenceTyping(elementAsFeatureTyping, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -245,8 +245,9 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
             SharedTextualNotationBuilder.BuildFeaturePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("expr ");
             FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, writerContext, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ExpressionTextualNotationBuilder.cs
@@ -43,6 +43,8 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         public static void BuildOwnedExpression(SysML2.NET.Core.POCO.Kernel.Functions.IExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
+            var operatorParensNeeded = writerContext.OperatorContextStack.Count > 0 && SysML2.NET.Serializer.TextualNotation.Writers.OperatorPrecedence.NeedsParenthesesAsOperand(writerContext.OperatorContextStack.Peek(), poco);
+            if (operatorParensNeeded) { stringBuilder.Append('('); }
             switch (poco)
             {
                 case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpressionConditionalExpression when pocoOperatorExpressionConditionalExpression.IsValidForConditionalExpression(writerContext):
@@ -63,13 +65,14 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpressionMetaclassificationExpression when pocoOperatorExpressionMetaclassificationExpression.IsValidForMetaclassificationExpression(writerContext):
                     OperatorExpressionTextualNotationBuilder.BuildMetaclassificationExpression(pocoOperatorExpressionMetaclassificationExpression, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpressionExtentExpression when pocoOperatorExpressionExtentExpression.Operator == "all" && writerContext.CursorCache.GetOrCreateCursor(pocoOperatorExpressionExtentExpression.Id, "ownedRelationship", pocoOperatorExpressionExtentExpression.OwnedRelationship).Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership:
+                case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpressionExtentExpression when (pocoOperatorExpressionExtentExpression.Operator == "all" && writerContext.CursorCache.GetOrCreateCursor(pocoOperatorExpressionExtentExpression.Id, "ownedRelationship", pocoOperatorExpressionExtentExpression.OwnedRelationship).Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership):
                     OperatorExpressionTextualNotationBuilder.BuildExtentExpression(pocoOperatorExpressionExtentExpression, writerContext, stringBuilder);
                     break;
                 default:
                     BuildPrimaryExpression(poco, writerContext, stringBuilder);
                     break;
             }
+            if (operatorParensNeeded) { stringBuilder.Append(')'); }
 
         }
 
@@ -84,8 +87,8 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         {
             switch (poco)
             {
-                case SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureChainExpression pocoFeatureChainExpression:
-                    FeatureChainExpressionTextualNotationBuilder.BuildFeatureChainExpression(pocoFeatureChainExpression, writerContext, stringBuilder);
+                case SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureChainExpression pocoFeatureChainExpressionFeatureChainExpression when writerContext.CursorCache.GetOrCreateCursor(pocoFeatureChainExpressionFeatureChainExpression.Id, "ownedRelationship", pocoFeatureChainExpressionFeatureChainExpression.OwnedRelationship).Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership:
+                    FeatureChainExpressionTextualNotationBuilder.BuildFeatureChainExpression(pocoFeatureChainExpressionFeatureChainExpression, writerContext, stringBuilder);
                     break;
                 default:
                     BuildNonFeatureChainPrimaryExpression(poco, writerContext, stringBuilder);
@@ -105,20 +108,20 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         {
             switch (poco)
             {
-                case SysML2.NET.Core.POCO.Kernel.Expressions.IIndexExpression pocoIndexExpression:
-                    IndexExpressionTextualNotationBuilder.BuildIndexExpression(pocoIndexExpression, writerContext, stringBuilder);
+                case SysML2.NET.Core.POCO.Kernel.Expressions.IIndexExpression pocoIndexExpressionIndexExpression when writerContext.CursorCache.GetOrCreateCursor(pocoIndexExpressionIndexExpression.Id, "ownedRelationship", pocoIndexExpressionIndexExpression.OwnedRelationship).Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership:
+                    IndexExpressionTextualNotationBuilder.BuildIndexExpression(pocoIndexExpressionIndexExpression, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Kernel.Expressions.ISelectExpression pocoSelectExpression:
-                    SelectExpressionTextualNotationBuilder.BuildSelectExpression(pocoSelectExpression, writerContext, stringBuilder);
+                case SysML2.NET.Core.POCO.Kernel.Expressions.ISelectExpression pocoSelectExpressionSelectExpression when writerContext.CursorCache.GetOrCreateCursor(pocoSelectExpressionSelectExpression.Id, "ownedRelationship", pocoSelectExpressionSelectExpression.OwnedRelationship).Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership:
+                    SelectExpressionTextualNotationBuilder.BuildSelectExpression(pocoSelectExpressionSelectExpression, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Kernel.Expressions.ICollectExpression pocoCollectExpression:
-                    CollectExpressionTextualNotationBuilder.BuildCollectExpression(pocoCollectExpression, writerContext, stringBuilder);
+                case SysML2.NET.Core.POCO.Kernel.Expressions.ICollectExpression pocoCollectExpressionCollectExpression when writerContext.CursorCache.GetOrCreateCursor(pocoCollectExpressionCollectExpression.Id, "ownedRelationship", pocoCollectExpressionCollectExpression.OwnedRelationship).Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership:
+                    CollectExpressionTextualNotationBuilder.BuildCollectExpression(pocoCollectExpressionCollectExpression, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpression:
-                    OperatorExpressionTextualNotationBuilder.BuildBracketExpression(pocoOperatorExpression, writerContext, stringBuilder);
+                case SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression pocoOperatorExpressionBracketExpression when (writerContext.CursorCache.GetOrCreateCursor(pocoOperatorExpressionBracketExpression.Id, "ownedRelationship", pocoOperatorExpressionBracketExpression.OwnedRelationship).Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership && pocoOperatorExpressionBracketExpression.Operator == "["):
+                    OperatorExpressionTextualNotationBuilder.BuildBracketExpression(pocoOperatorExpressionBracketExpression, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Kernel.Expressions.IInvocationExpression pocoInvocationExpression:
-                    InvocationExpressionTextualNotationBuilder.BuildFunctionOperationExpression(pocoInvocationExpression, writerContext, stringBuilder);
+                case SysML2.NET.Core.POCO.Kernel.Expressions.IInvocationExpression pocoInvocationExpressionFunctionOperationExpression when writerContext.CursorCache.GetOrCreateCursor(pocoInvocationExpressionFunctionOperationExpression.Id, "ownedRelationship", pocoInvocationExpressionFunctionOperationExpression.OwnedRelationship).Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership:
+                    InvocationExpressionTextualNotationBuilder.BuildFunctionOperationExpression(pocoInvocationExpressionFunctionOperationExpression, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Functions.IExpression pocoExpressionSequenceExpression when pocoExpressionSequenceExpression.IsValidForSequenceExpression(writerContext):
                     BuildSequenceExpression(pocoExpressionSequenceExpression, writerContext, stringBuilder);

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ExpressionTextualNotationBuilder.cs
@@ -43,7 +43,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         public static void BuildOwnedExpression(SysML2.NET.Core.POCO.Kernel.Functions.IExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var operatorParensNeeded = writerContext.OperatorContextStack.Count > 0 && SysML2.NET.Serializer.TextualNotation.Writers.OperatorPrecedence.NeedsParenthesesAsOperand(writerContext.OperatorContextStack.Peek(), poco);
+            var operatorParensNeeded = writerContext.EmitOperatorParentheses && writerContext.OperatorContextStack.Count > 0 && SysML2.NET.Serializer.TextualNotation.Writers.OperatorPrecedence.NeedsParenthesesAsOperand(writerContext.OperatorContextStack.Peek(), poco);
             if (operatorParensNeeded) { stringBuilder.Append('('); }
             switch (poco)
             {

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/FeatureChainExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/FeatureChainExpressionTextualNotationBuilder.cs
@@ -51,10 +51,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildNonFeatureChainPrimaryArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append(".");
 
             if (ownedRelationshipCursor.Current != null)
@@ -63,10 +63,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership elementAsMembership)
                 {
                     MembershipTextualNotationBuilder.BuildFeatureChainMember(elementAsMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/FeatureChainExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/FeatureChainExpressionTextualNotationBuilder.cs
@@ -43,29 +43,37 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         public static void BuildFeatureChainExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureChainExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-
-            if (ownedRelationshipCursor.Current != null)
+            writerContext.OperatorContextStack.Push(poco);
+            try
             {
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                if (ownedRelationshipCursor.Current != null)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildNonFeatureChainPrimaryArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
 
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                    {
+                        ParameterMembershipTextualNotationBuilder.BuildNonFeatureChainPrimaryArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
+                }
+                stringBuilder.Append(".");
+
+                if (ownedRelationshipCursor.Current != null)
+                {
+
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership elementAsMembership)
+                    {
+                        MembershipTextualNotationBuilder.BuildFeatureChainMember(elementAsMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
                 }
             }
-            stringBuilder.Append(".");
-
-            if (ownedRelationshipCursor.Current != null)
+            finally
             {
-
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership elementAsMembership)
-                {
-                    MembershipTextualNotationBuilder.BuildFeatureChainMember(elementAsMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
-
-                }
+                writerContext.OperatorContextStack.Pop();
             }
 
         }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/FeatureMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/FeatureMembershipTextualNotationBuilder.cs
@@ -52,10 +52,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage elementAsUsage)
                 {
                     UsageTextualNotationBuilder.BuildNonOccurrenceUsageElement(elementAsUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -77,10 +77,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage elementAsUsage)
                 {
                     UsageTextualNotationBuilder.BuildOccurrenceUsageElement(elementAsUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -102,10 +102,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage elementAsUsage)
                 {
                     UsageTextualNotationBuilder.BuildStructureUsageElement(elementAsUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -127,10 +127,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage elementAsUsage)
                 {
                     UsageTextualNotationBuilder.BuildBehaviorUsageElement(elementAsUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -152,10 +152,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Connections.ISuccessionAsUsage elementAsSuccessionAsUsage)
                 {
                     SuccessionAsUsageTextualNotationBuilder.BuildSourceSuccession(elementAsSuccessionAsUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -177,10 +177,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage elementAsUsage)
                 {
                     UsageTextualNotationBuilder.BuildInterfaceNonOccurrenceUsageElement(elementAsUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -202,10 +202,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage elementAsUsage)
                 {
                     UsageTextualNotationBuilder.BuildInterfaceOccurrenceUsageElement(elementAsUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -226,10 +226,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Interactions.IPayloadFeature elementAsPayloadFeature)
                 {
                     PayloadFeatureTextualNotationBuilder.BuildFlowPayloadFeature(elementAsPayloadFeature, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -250,10 +250,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
                     ReferenceUsageTextualNotationBuilder.BuildFlowFeature(elementAsReferenceUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -312,10 +312,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Actions.IActionUsage elementAsActionUsage)
                 {
                     ActionUsageTextualNotationBuilder.BuildActionNode(elementAsActionUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -337,10 +337,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage elementAsUsage)
                 {
                     UsageTextualNotationBuilder.BuildActionTargetSuccession(elementAsUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -362,10 +362,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.States.ITransitionUsage elementAsTransitionUsage)
                 {
                     TransitionUsageTextualNotationBuilder.BuildGuardedSuccession(elementAsTransitionUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -386,10 +386,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage elementAsUsage)
                 {
                     UsageTextualNotationBuilder.BuildUsageDeclaration(elementAsUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -427,10 +427,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.States.ITransitionUsage elementAsTransitionUsage)
                 {
                     TransitionUsageTextualNotationBuilder.BuildTransitionUsage(elementAsTransitionUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -452,10 +452,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.States.ITransitionUsage elementAsTransitionUsage)
                 {
                     TransitionUsageTextualNotationBuilder.BuildTargetTransitionUsage(elementAsTransitionUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -498,10 +498,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                 {
                     FeatureTextualNotationBuilder.BuildFeatureElement(elementAsFeature, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -522,10 +522,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression elementAsFeatureReferenceExpression)
                 {
                     FeatureReferenceExpressionTextualNotationBuilder.BuildOwnedExpressionReference(elementAsFeatureReferenceExpression, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -639,10 +639,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                 {
                     FeatureTextualNotationBuilder.BuildPayloadFeature(elementAsFeature, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/FeatureMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/FeatureMembershipTextualNotationBuilder.cs
@@ -289,7 +289,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         {
             MembershipTextualNotationBuilder.BuildMemberPrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("first ");
-            BuildMemberFeature(poco, writerContext, stringBuilder);
+            BuildInitialNodeMemberHandCoded(poco, writerContext, stringBuilder);
             RelationshipTextualNotationBuilder.BuildRelationshipBody(poco, writerContext, stringBuilder);
 
         }
@@ -538,7 +538,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         public static void BuildOwnedExpressionMember(SysML2.NET.Core.POCO.Core.Types.IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            BuildOwnedFeatureMember(poco, writerContext, stringBuilder);
+            BuildOwnedExpressionMemberHandCoded(poco, writerContext, stringBuilder);
 
         }
 

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/FeatureReferenceExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/FeatureReferenceExpressionTextualNotationBuilder.cs
@@ -51,10 +51,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership elementAsMembership)
                 {
                     MembershipTextualNotationBuilder.BuildFeatureChainMember(elementAsMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -75,10 +75,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
                 {
                     FeatureMembershipTextualNotationBuilder.BuildOwnedExpressionMember(elementAsFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -99,10 +99,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
                 {
                     FeatureMembershipTextualNotationBuilder.BuildFunctionReferenceMember(elementAsFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -123,10 +123,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership elementAsMembership)
                 {
                     MembershipTextualNotationBuilder.BuildFeatureReferenceMember(elementAsMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             if (ownedRelationshipCursor.Current != null)
             {
@@ -134,10 +134,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
                 {
                     ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -158,10 +158,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
                 {
                     FeatureMembershipTextualNotationBuilder.BuildExpressionBodyMember(elementAsFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/FeatureTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/FeatureTextualNotationBuilder.cs
@@ -51,10 +51,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                 {
                     FeatureValueTextualNotationBuilder.BuildFeatureValue(elementAsFeatureValue, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -148,10 +148,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping elementAsFeatureTyping)
                 {
                     FeatureTypingTextualNotationBuilder.BuildFeatureTyping(elementAsFeatureTyping, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -203,10 +203,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting elementAsSubsetting)
                 {
                     SubsettingTextualNotationBuilder.BuildOwnedSubsetting(elementAsSubsetting, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -228,10 +228,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting elementAsReferenceSubsetting)
                 {
                     ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -253,10 +253,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting elementAsCrossSubsetting)
                 {
                     CrossSubsettingTextualNotationBuilder.BuildOwnedCrossSubsetting(elementAsCrossSubsetting, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -308,10 +308,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition elementAsRedefinition)
                 {
                     RedefinitionTextualNotationBuilder.BuildOwnedRedefinition(elementAsRedefinition, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -332,10 +332,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureChaining elementAsFeatureChaining)
                 {
                     FeatureChainingTextualNotationBuilder.BuildOwnedFeatureChaining(elementAsFeatureChaining, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             while (ownedRelationshipCursor.Current != null && ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureChaining)
             {
@@ -384,10 +384,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                 {
                     OwningMembershipTextualNotationBuilder.BuildOwnedMultiplicity(elementAsOwningMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -449,10 +449,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureChaining elementAsFeatureChaining)
                 {
                     FeatureChainingTextualNotationBuilder.BuildOwnedFeatureChaining(elementAsFeatureChaining, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append(".");
 
         }
@@ -474,10 +474,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                 {
                     FeatureValueTextualNotationBuilder.BuildTriggerFeatureValue(elementAsFeatureValue, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -498,10 +498,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                 {
                     FeatureValueTextualNotationBuilder.BuildArgumentValue(elementAsFeatureValue, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -522,10 +522,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                 {
                     FeatureValueTextualNotationBuilder.BuildArgumentExpressionValue(elementAsFeatureValue, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -753,10 +753,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureInverting elementAsFeatureInverting)
                 {
                     FeatureInvertingTextualNotationBuilder.BuildOwnedFeatureInverting(elementAsFeatureInverting, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -780,10 +780,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ITypeFeaturing elementAsTypeFeaturing)
                 {
                     TypeFeaturingTextualNotationBuilder.BuildOwnedTypeFeaturing(elementAsTypeFeaturing, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             while (ownedTypeFeaturingCursor.Current != null && ownedTypeFeaturingCursor.Current is SysML2.NET.Core.POCO.Core.Features.ITypeFeaturing)
             {
@@ -820,10 +820,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureChaining elementAsFeatureChaining)
                 {
                     FeatureChainingTextualNotationBuilder.BuildOwnedFeatureChaining(elementAsFeatureChaining, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             while (ownedRelationshipCursor.Current != null && ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureChaining)
             {
@@ -860,10 +860,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                 {
                     FeatureValueTextualNotationBuilder.BuildMetadataValue(elementAsFeatureValue, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -884,10 +884,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping elementAsFeatureTyping)
                 {
                     FeatureTypingTextualNotationBuilder.BuildReferenceTyping(elementAsFeatureTyping, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -908,10 +908,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                 {
                     FeatureValueTextualNotationBuilder.BuildPrimaryArgumentValue(elementAsFeatureValue, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -932,10 +932,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                 {
                     FeatureValueTextualNotationBuilder.BuildNonFeatureChainPrimaryArgumentValue(elementAsFeatureValue, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -956,10 +956,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                 {
                     FeatureValueTextualNotationBuilder.BuildBodyArgumentValue(elementAsFeatureValue, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -980,10 +980,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                 {
                     FeatureValueTextualNotationBuilder.BuildFunctionReferenceArgumentValue(elementAsFeatureValue, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -1055,10 +1055,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             while (ownedRelationshipCursor.Current != null && ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership)
             {
@@ -1095,10 +1095,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
                 {
                     FeatureMembershipTextualNotationBuilder.BuildNamedArgumentMember(elementAsFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             while (ownedRelationshipCursor.Current != null && ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership)
             {
@@ -1135,10 +1135,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition elementAsRedefinition)
                 {
                     RedefinitionTextualNotationBuilder.BuildParameterRedefinition(elementAsRedefinition, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append("= ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -1147,10 +1147,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                 {
                     FeatureValueTextualNotationBuilder.BuildArgumentValue(elementAsFeatureValue, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -1173,17 +1173,17 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition elementAsRedefinition)
                 {
                     RedefinitionTextualNotationBuilder.BuildOwnedRedefinition(elementAsRedefinition, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
 
-
-            if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
+            if ((ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership) || poco.IsOrdered)
             {
                 BuildFeatureSpecializationPart(poco, writerContext, stringBuilder);
             }
 
-            if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 BuildValuePart(poco, writerContext, stringBuilder);
             }
@@ -1204,7 +1204,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
             BuildFeatureHandCoded(poco, writerContext, stringBuilder);
             stringBuilder.Append(' ');
 
-            if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 BuildValuePart(poco, writerContext, stringBuilder);
             }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/FeatureTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/FeatureTextualNotationBuilder.cs
@@ -543,29 +543,29 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 case SysML2.NET.Core.POCO.Kernel.Interactions.ISuccessionFlow pocoSuccessionFlow:
                     SuccessionFlowTextualNotationBuilder.BuildSuccessionFlow(pocoSuccessionFlow, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Kernel.Functions.IInvariant pocoInvariant:
-                    InvariantTextualNotationBuilder.BuildInvariant(pocoInvariant, writerContext, stringBuilder);
+                case SysML2.NET.Core.POCO.Kernel.Functions.IInvariant pocoInvariantInvariant when (pocoInvariantInvariant.DeclaredShortName != null || pocoInvariantInvariant.DeclaredName != null):
+                    InvariantTextualNotationBuilder.BuildInvariant(pocoInvariantInvariant, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Kernel.Interactions.IFlow pocoFlow:
                     FlowTextualNotationBuilder.BuildFlow(pocoFlow, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Kernel.Functions.IBooleanExpression pocoBooleanExpression:
-                    BooleanExpressionTextualNotationBuilder.BuildBooleanExpression(pocoBooleanExpression, writerContext, stringBuilder);
+                case SysML2.NET.Core.POCO.Kernel.Functions.IBooleanExpression pocoBooleanExpressionBooleanExpression when (pocoBooleanExpressionBooleanExpression.DeclaredShortName != null || pocoBooleanExpressionBooleanExpression.DeclaredName != null):
+                    BooleanExpressionTextualNotationBuilder.BuildBooleanExpression(pocoBooleanExpressionBooleanExpression, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Kernel.Connectors.IBindingConnector pocoBindingConnector:
-                    BindingConnectorTextualNotationBuilder.BuildBindingConnector(pocoBindingConnector, writerContext, stringBuilder);
+                case SysML2.NET.Core.POCO.Kernel.Connectors.IBindingConnector pocoBindingConnectorBindingConnector when (pocoBindingConnectorBindingConnector.DeclaredShortName != null || pocoBindingConnectorBindingConnector.DeclaredName != null):
+                    BindingConnectorTextualNotationBuilder.BuildBindingConnector(pocoBindingConnectorBindingConnector, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Kernel.Connectors.ISuccession pocoSuccession:
-                    SuccessionTextualNotationBuilder.BuildSuccession(pocoSuccession, writerContext, stringBuilder);
+                case SysML2.NET.Core.POCO.Kernel.Connectors.ISuccession pocoSuccessionSuccession when (pocoSuccessionSuccession.DeclaredShortName != null || pocoSuccessionSuccession.DeclaredName != null):
+                    SuccessionTextualNotationBuilder.BuildSuccession(pocoSuccessionSuccession, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Kernel.Functions.IExpression pocoExpression:
-                    ExpressionTextualNotationBuilder.BuildExpression(pocoExpression, writerContext, stringBuilder);
+                case SysML2.NET.Core.POCO.Kernel.Functions.IExpression pocoExpressionExpression when (pocoExpressionExpression.DeclaredShortName != null || pocoExpressionExpression.DeclaredName != null):
+                    ExpressionTextualNotationBuilder.BuildExpression(pocoExpressionExpression, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Kernel.Connectors.IConnector pocoConnector:
-                    ConnectorTextualNotationBuilder.BuildConnector(pocoConnector, writerContext, stringBuilder);
+                case SysML2.NET.Core.POCO.Kernel.Connectors.IConnector pocoConnectorConnector when (pocoConnectorConnector.DeclaredShortName != null || pocoConnectorConnector.DeclaredName != null):
+                    ConnectorTextualNotationBuilder.BuildConnector(pocoConnectorConnector, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Kernel.Behaviors.IStep pocoStep:
-                    StepTextualNotationBuilder.BuildStep(pocoStep, writerContext, stringBuilder);
+                case SysML2.NET.Core.POCO.Kernel.Behaviors.IStep pocoStepStep when (pocoStepStep.DeclaredShortName != null || pocoStepStep.DeclaredName != null):
+                    StepTextualNotationBuilder.BuildStep(pocoStepStep, writerContext, stringBuilder);
                     break;
                 default:
                     BuildFeature(poco, writerContext, stringBuilder);
@@ -694,7 +694,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeatureInvertingPart when pocoFeatureInvertingPart.IsValidForInvertingPart(writerContext):
                     BuildInvertingPart(pocoFeatureInvertingPart, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeatureTypeFeaturingPart when writerContext.CursorCache.GetOrCreateCursor(pocoFeatureTypeFeaturingPart.Id, "ownedRelationship", pocoFeatureTypeFeaturingPart.OwnedRelationship).Current is SysML2.NET.Core.POCO.Core.Features.ITypeFeaturing && pocoFeatureTypeFeaturingPart.ownedTypeFeaturing.OfType<SysML2.NET.Core.POCO.Core.Features.ITypeFeaturing>().Any():
+                case SysML2.NET.Core.POCO.Core.Features.IFeature pocoFeatureTypeFeaturingPart when writerContext.CursorCache.GetOrCreateCursor(pocoFeatureTypeFeaturingPart.Id, "ownedRelationship", pocoFeatureTypeFeaturingPart.OwnedRelationship).Current is SysML2.NET.Core.POCO.Core.Features.ITypeFeaturing:
                     BuildTypeFeaturingPart(pocoFeatureTypeFeaturingPart, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Core.Types.IType pocoType:

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/FeatureValueTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/FeatureValueTextualNotationBuilder.cs
@@ -51,10 +51,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Actions.ITriggerInvocationExpression elementAsTriggerInvocationExpression)
                 {
                     TriggerInvocationExpressionTextualNotationBuilder.BuildTriggerExpression(elementAsTriggerInvocationExpression, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -92,10 +92,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression elementAsFeatureReferenceExpression)
                 {
                     FeatureReferenceExpressionTextualNotationBuilder.BuildOwnedExpressionReference(elementAsFeatureReferenceExpression, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -116,10 +116,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IExpression elementAsExpression)
                 {
                     ExpressionTextualNotationBuilder.BuildOwnedExpression(elementAsExpression, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -140,10 +140,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IExpression elementAsExpression)
                 {
                     ExpressionTextualNotationBuilder.BuildNonFeatureChainPrimaryExpression(elementAsExpression, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -164,10 +164,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Expressions.IFeatureReferenceExpression elementAsFeatureReferenceExpression)
                 {
                     FeatureReferenceExpressionTextualNotationBuilder.BuildSatisfactionReferenceExpression(elementAsFeatureReferenceExpression, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -287,10 +287,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IExpression elementAsExpression)
                 {
                     ExpressionTextualNotationBuilder.BuildOwnedExpression(elementAsExpression, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/FlowEndTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/FlowEndTextualNotationBuilder.cs
@@ -45,7 +45,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         {
             var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (ownedRelationshipCursor.Current != null)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting && ownedRelationshipCursor.GetNext(1) is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership)
             {
 
                 if (ownedRelationshipCursor.Current != null)
@@ -68,10 +68,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
                 {
                     FeatureMembershipTextualNotationBuilder.BuildFlowFeatureMember(elementAsFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ForLoopActionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ForLoopActionUsageTextualNotationBuilder.cs
@@ -53,10 +53,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
                 {
                     FeatureMembershipTextualNotationBuilder.BuildForVariableDeclarationMember(elementAsFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append("in ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -65,10 +65,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildNodeParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             if (ownedRelationshipCursor.Current != null)
             {
@@ -76,10 +76,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildActionBodyParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/FramedConcernMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/FramedConcernMembershipTextualNotationBuilder.cs
@@ -57,10 +57,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Requirements.IConcernUsage elementAsConcernUsage)
                 {
                     ConcernUsageTextualNotationBuilder.BuildFramedConcernUsage(elementAsConcernUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/IfActionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/IfActionUsageTextualNotationBuilder.cs
@@ -53,10 +53,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildExpressionParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             if (ownedRelationshipCursor.Current != null)
             {
@@ -64,10 +64,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildActionBodyParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             if (ownedRelationshipCursor.Current != null)
             {

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/IncludeUseCaseUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/IncludeUseCaseUsageTextualNotationBuilder.cs
@@ -55,12 +55,12 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting elementAsReferenceSubsetting)
                     {
                         ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
 
-
-                if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
+                if ((ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership) || poco.IsOrdered)
                 {
                     FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, writerContext, stringBuilder);
                 }
@@ -74,7 +74,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
 
             stringBuilder.Append(' ');
 
-            if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/IndexExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/IndexExpressionTextualNotationBuilder.cs
@@ -43,32 +43,40 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         public static void BuildIndexExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IIndexExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-
-            if (ownedRelationshipCursor.Current != null)
+            writerContext.OperatorContextStack.Push(poco);
+            try
             {
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                if (ownedRelationshipCursor.Current != null)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildPrimaryArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
 
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                    {
+                        ParameterMembershipTextualNotationBuilder.BuildPrimaryArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
                 }
-            }
-            stringBuilder.Append("#");
-            stringBuilder.Append("(");
+                stringBuilder.Append("#");
+                stringBuilder.Append("(");
 
-            if (ownedRelationshipCursor.Current != null)
+                if (ownedRelationshipCursor.Current != null)
+                {
+
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
+                    {
+                        FeatureMembershipTextualNotationBuilder.BuildSequenceExpressionListMember(elementAsFeatureMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
+                }
+                stringBuilder.Append(") ");
+            }
+            finally
             {
-
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
-                {
-                    FeatureMembershipTextualNotationBuilder.BuildSequenceExpressionListMember(elementAsFeatureMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
-
-                }
+                writerContext.OperatorContextStack.Pop();
             }
-            stringBuilder.Append(") ");
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/IndexExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/IndexExpressionTextualNotationBuilder.cs
@@ -51,10 +51,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildPrimaryArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append("#");
             stringBuilder.Append("(");
 
@@ -64,10 +64,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
                 {
                     FeatureMembershipTextualNotationBuilder.BuildSequenceExpressionListMember(elementAsFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append(") ");
 
         }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/InterfaceUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/InterfaceUsageTextualNotationBuilder.cs
@@ -84,10 +84,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
                     EndFeatureMembershipTextualNotationBuilder.BuildInterfaceEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append("to ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -96,10 +96,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
                     EndFeatureMembershipTextualNotationBuilder.BuildInterfaceEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -121,10 +121,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
                     EndFeatureMembershipTextualNotationBuilder.BuildInterfaceEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append(", ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -133,10 +133,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
                     EndFeatureMembershipTextualNotationBuilder.BuildInterfaceEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership endFeatureMembershipGuard && endFeatureMembershipGuard.OwnedRelatedElement.OfType<SysML2.NET.Core.POCO.Systems.Ports.IPortUsage>().Any())
             {

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/InvariantTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/InvariantTextualNotationBuilder.cs
@@ -55,8 +55,9 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 stringBuilder.Append(" false ");
             }
             FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, writerContext, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/InvocationExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/InvocationExpressionTextualNotationBuilder.cs
@@ -51,18 +51,18 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildPrimaryArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append("-> ");
 
             if (ownedRelationshipCursor.Current != null)
             {
                 BuildInvocationTypeMember(poco, writerContext, stringBuilder);
-            }
-            ownedRelationshipCursor.Move();
+                ownedRelationshipCursor.Move();
 
+            }
             if (ownedRelationshipCursor.Current != null)
             {
 
@@ -99,10 +99,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
                 {
                     ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -123,10 +123,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership elementAsMembership)
                 {
                     MembershipTextualNotationBuilder.BuildInstantiatedTypeMember(elementAsMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             FeatureTextualNotationBuilder.BuildArgumentList(poco, writerContext, stringBuilder);
 
             if (ownedRelationshipCursor.Current != null)
@@ -135,10 +135,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
                 {
                     ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/MembershipTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/MembershipTextualNotationBuilder.cs
@@ -68,7 +68,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
             if (!string.IsNullOrWhiteSpace(poco.MemberShortName))
             {
                 stringBuilder.Append("<");
-                stringBuilder.Append(poco.MemberShortName);
+                SharedTextualNotationBuilder.AppendName(stringBuilder, poco.MemberShortName);
                 stringBuilder.Append(">");
                 stringBuilder.Append(' ');
             }
@@ -76,7 +76,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
 
             if (!string.IsNullOrWhiteSpace(poco.MemberName))
             {
-                stringBuilder.Append(poco.MemberName);
+                SharedTextualNotationBuilder.AppendName(stringBuilder, poco.MemberName);
                 stringBuilder.Append(' ');
             }
 
@@ -116,10 +116,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                     if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                     {
                         FeatureTextualNotationBuilder.BuildOwnedFeatureChain(elementAsFeature, writerContext, stringBuilder);
+                        ownedRelatedElementCursor.Move();
+
                     }
                 }
-                ownedRelatedElementCursor.Move();
-
 
             }
         }
@@ -191,10 +191,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                     if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                     {
                         FeatureTextualNotationBuilder.BuildOwnedFeatureChain(elementAsFeature, writerContext, stringBuilder);
+                        ownedRelatedElementCursor.Move();
+
                     }
                 }
-                ownedRelatedElementCursor.Move();
-
 
             }
         }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/MembershipTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/MembershipTextualNotationBuilder.cs
@@ -210,11 +210,11 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         {
             switch (poco)
             {
-                case SysML2.NET.Core.POCO.Core.Types.IFeatureMembership pocoFeatureMembership:
-                    FeatureMembershipTextualNotationBuilder.BuildMetadataBodyFeatureMember(pocoFeatureMembership, writerContext, stringBuilder);
+                case SysML2.NET.Core.POCO.Core.Types.IFeatureMembership pocoFeatureMembershipMetadataBodyFeatureMember when pocoFeatureMembershipMetadataBodyFeatureMember.ownedMemberFeature is SysML2.NET.Core.POCO.Core.Features.IFeature:
+                    FeatureMembershipTextualNotationBuilder.BuildMetadataBodyFeatureMember(pocoFeatureMembershipMetadataBodyFeatureMember, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership pocoOwningMembership:
-                    OwningMembershipTextualNotationBuilder.BuildNonFeatureMember(pocoOwningMembership, writerContext, stringBuilder);
+                case SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership pocoOwningMembershipNonFeatureMember when writerContext.CursorCache.GetOrCreateCursor(pocoOwningMembershipNonFeatureMember.Id, "ownedRelatedElement", pocoOwningMembershipNonFeatureMember.OwnedRelatedElement).Current is SysML2.NET.Core.POCO.Root.Elements.IElement:
+                    OwningMembershipTextualNotationBuilder.BuildNonFeatureMember(pocoOwningMembershipNonFeatureMember, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Root.Namespaces.IImport pocoImport:
                     ImportTextualNotationBuilder.BuildImport(pocoImport, writerContext, stringBuilder);

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/MetadataAccessExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/MetadataAccessExpressionTextualNotationBuilder.cs
@@ -51,10 +51,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership elementAsMembership)
                 {
                     MembershipTextualNotationBuilder.BuildElementReferenceMember(elementAsMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -75,10 +75,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership elementAsMembership)
                 {
                     MembershipTextualNotationBuilder.BuildElementReferenceMember(elementAsMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append(".");
             stringBuilder.Append("metadata ");
 

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/MetadataFeatureTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/MetadataFeatureTextualNotationBuilder.cs
@@ -51,10 +51,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping elementAsFeatureTyping)
                 {
                     FeatureTypingTextualNotationBuilder.BuildOwnedFeatureTyping(elementAsFeatureTyping, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -83,10 +83,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping elementAsFeatureTyping)
                 {
                     FeatureTypingTextualNotationBuilder.BuildOwnedFeatureTyping(elementAsFeatureTyping, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/MetadataUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/MetadataUsageTextualNotationBuilder.cs
@@ -51,10 +51,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping elementAsFeatureTyping)
                 {
                     FeatureTypingTextualNotationBuilder.BuildOwnedFeatureTyping(elementAsFeatureTyping, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -83,10 +83,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping elementAsFeatureTyping)
                 {
                     FeatureTypingTextualNotationBuilder.BuildOwnedFeatureTyping(elementAsFeatureTyping, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/MultiplicityRangeTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/MultiplicityRangeTextualNotationBuilder.cs
@@ -59,7 +59,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
             var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append("[");
 
-            if (ownedRelationshipCursor.Current != null)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership && ownedRelationshipCursor.GetNext(1) is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership)
             {
 
                 if (ownedRelationshipCursor.Current != null)
@@ -83,10 +83,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                 {
                     OwningMembershipTextualNotationBuilder.BuildMultiplicityExpressionMember(elementAsOwningMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append("] ");
 
         }
@@ -103,7 +103,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
             var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append("[");
 
-            if (ownedRelationshipCursor.Current != null)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership && ownedRelationshipCursor.GetNext(1) is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership)
             {
 
                 if (ownedRelationshipCursor.Current != null)
@@ -127,10 +127,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                 {
                     OwningMembershipTextualNotationBuilder.BuildMultiplicityExpressionMember(elementAsOwningMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append("] ");
 
         }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/MultiplicityTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/MultiplicityTextualNotationBuilder.cs
@@ -73,8 +73,8 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         {
             switch (poco)
             {
-                case SysML2.NET.Core.POCO.Kernel.Multiplicities.IMultiplicityRange pocoMultiplicityRange:
-                    MultiplicityRangeTextualNotationBuilder.BuildMultiplicityRange(pocoMultiplicityRange, writerContext, stringBuilder);
+                case SysML2.NET.Core.POCO.Kernel.Multiplicities.IMultiplicityRange pocoMultiplicityRangeMultiplicityRange when writerContext.CursorCache.GetOrCreateCursor(pocoMultiplicityRangeMultiplicityRange.Id, "ownedRelationship", pocoMultiplicityRangeMultiplicityRange.OwnedRelationship).Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership:
+                    MultiplicityRangeTextualNotationBuilder.BuildMultiplicityRange(pocoMultiplicityRangeMultiplicityRange, writerContext, stringBuilder);
                     break;
                 default:
                     BuildMultiplicitySubset(poco, writerContext, stringBuilder);

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ObjectiveMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ObjectiveMembershipTextualNotationBuilder.cs
@@ -53,10 +53,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Requirements.IRequirementUsage elementAsRequirementUsage)
                 {
                     RequirementUsageTextualNotationBuilder.BuildObjectiveRequirementUsage(elementAsRequirementUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/OccurrenceDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/OccurrenceDefinitionTextualNotationBuilder.cs
@@ -108,10 +108,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                 {
                     OwningMembershipTextualNotationBuilder.BuildEmptyMultiplicityMember(elementAsOwningMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/OperatorExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/OperatorExpressionTextualNotationBuilder.cs
@@ -52,10 +52,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append("? ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -64,10 +64,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildArgumentExpressionMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append("else ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -76,10 +76,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildArgumentExpressionMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             if (ownedRelationshipCursor.Current != null)
             {
@@ -87,10 +87,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
                 {
                     ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -111,10 +111,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append(poco.Operator);
 
             if (ownedRelationshipCursor.Current != null)
@@ -123,10 +123,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildArgumentExpressionMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             if (ownedRelationshipCursor.Current != null)
             {
@@ -134,10 +134,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
                 {
                     ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -158,10 +158,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append(poco.Operator);
 
             if (ownedRelationshipCursor.Current != null)
@@ -170,10 +170,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             if (ownedRelationshipCursor.Current != null)
             {
@@ -181,10 +181,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
                 {
                     ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -206,10 +206,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             if (ownedRelationshipCursor.Current != null)
             {
@@ -217,10 +217,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
                 {
                     ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -260,10 +260,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
                 {
                     ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -284,10 +284,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildMetadataArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             BuildMetaclassificationExpressionHandCoded(poco, writerContext, stringBuilder);
             stringBuilder.Append(' ');
 
@@ -297,10 +297,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
                 {
                     ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -322,10 +322,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildTypeReferenceMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -346,10 +346,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildPrimaryArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append(poco.Operator);
 
             if (ownedRelationshipCursor.Current != null)
@@ -358,10 +358,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
                 {
                     FeatureMembershipTextualNotationBuilder.BuildSequenceExpressionListMember(elementAsFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append("] ");
 
         }
@@ -383,10 +383,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
                 {
                     FeatureMembershipTextualNotationBuilder.BuildOwnedExpressionMember(elementAsFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append(poco.Operator);
 
             if (ownedRelationshipCursor.Current != null)
@@ -395,10 +395,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
                 {
                     FeatureMembershipTextualNotationBuilder.BuildSequenceExpressionListMember(elementAsFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/OperatorExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/OperatorExpressionTextualNotationBuilder.cs
@@ -43,53 +43,62 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         public static void BuildConditionalExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-            stringBuilder.Append(poco.Operator);
-
-            if (ownedRelationshipCursor.Current != null)
+            writerContext.OperatorContextStack.Push(poco);
+            try
             {
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                stringBuilder.Append(poco.Operator);
+                stringBuilder.Append(' ');
 
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                if (ownedRelationshipCursor.Current != null)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
 
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                    {
+                        ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
+                }
+                stringBuilder.Append("? ");
+
+                if (ownedRelationshipCursor.Current != null)
+                {
+
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                    {
+                        ParameterMembershipTextualNotationBuilder.BuildArgumentExpressionMember(elementAsParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
+                }
+                stringBuilder.Append("else ");
+
+                if (ownedRelationshipCursor.Current != null)
+                {
+
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                    {
+                        ParameterMembershipTextualNotationBuilder.BuildArgumentExpressionMember(elementAsParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
+                }
+
+                if (ownedRelationshipCursor.Current != null)
+                {
+
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
+                    {
+                        ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
                 }
             }
-            stringBuilder.Append("? ");
-
-            if (ownedRelationshipCursor.Current != null)
+            finally
             {
-
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
-                {
-                    ParameterMembershipTextualNotationBuilder.BuildArgumentExpressionMember(elementAsParameterMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
-
-                }
-            }
-            stringBuilder.Append("else ");
-
-            if (ownedRelationshipCursor.Current != null)
-            {
-
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
-                {
-                    ParameterMembershipTextualNotationBuilder.BuildArgumentExpressionMember(elementAsParameterMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
-
-                }
-            }
-
-            if (ownedRelationshipCursor.Current != null)
-            {
-
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
-                {
-                    ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
-
-                }
+                writerContext.OperatorContextStack.Pop();
             }
 
         }
@@ -103,40 +112,49 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         public static void BuildConditionalBinaryOperatorExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-
-            if (ownedRelationshipCursor.Current != null)
+            writerContext.OperatorContextStack.Push(poco);
+            try
             {
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                if (ownedRelationshipCursor.Current != null)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
 
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                    {
+                        ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
+                }
+                stringBuilder.Append(poco.Operator);
+                stringBuilder.Append(' ');
+
+                if (ownedRelationshipCursor.Current != null)
+                {
+
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                    {
+                        ParameterMembershipTextualNotationBuilder.BuildArgumentExpressionMember(elementAsParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
+                }
+
+                if (ownedRelationshipCursor.Current != null)
+                {
+
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
+                    {
+                        ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
                 }
             }
-            stringBuilder.Append(poco.Operator);
-
-            if (ownedRelationshipCursor.Current != null)
+            finally
             {
-
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
-                {
-                    ParameterMembershipTextualNotationBuilder.BuildArgumentExpressionMember(elementAsParameterMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
-
-                }
-            }
-
-            if (ownedRelationshipCursor.Current != null)
-            {
-
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
-                {
-                    ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
-
-                }
+                writerContext.OperatorContextStack.Pop();
             }
 
         }
@@ -150,40 +168,49 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         public static void BuildBinaryOperatorExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-
-            if (ownedRelationshipCursor.Current != null)
+            writerContext.OperatorContextStack.Push(poco);
+            try
             {
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                if (ownedRelationshipCursor.Current != null)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
 
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                    {
+                        ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
+                }
+                stringBuilder.Append(poco.Operator);
+                stringBuilder.Append(' ');
+
+                if (ownedRelationshipCursor.Current != null)
+                {
+
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                    {
+                        ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
+                }
+
+                if (ownedRelationshipCursor.Current != null)
+                {
+
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
+                    {
+                        ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
                 }
             }
-            stringBuilder.Append(poco.Operator);
-
-            if (ownedRelationshipCursor.Current != null)
+            finally
             {
-
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
-                {
-                    ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
-
-                }
-            }
-
-            if (ownedRelationshipCursor.Current != null)
-            {
-
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
-                {
-                    ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
-
-                }
+                writerContext.OperatorContextStack.Pop();
             }
 
         }
@@ -197,29 +224,38 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         public static void BuildUnaryOperatorExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-            stringBuilder.Append(poco.Operator);
-
-            if (ownedRelationshipCursor.Current != null)
+            writerContext.OperatorContextStack.Push(poco);
+            try
             {
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                stringBuilder.Append(poco.Operator);
+                stringBuilder.Append(' ');
 
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                if (ownedRelationshipCursor.Current != null)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
 
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                    {
+                        ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
+                }
+
+                if (ownedRelationshipCursor.Current != null)
+                {
+
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
+                    {
+                        ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
                 }
             }
-
-            if (ownedRelationshipCursor.Current != null)
+            finally
             {
-
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
-                {
-                    ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
-
-                }
+                writerContext.OperatorContextStack.Pop();
             }
 
         }
@@ -233,36 +269,44 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         public static void BuildClassificationExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-
-            if (ownedRelationshipCursor.Current != null)
+            writerContext.OperatorContextStack.Push(poco);
+            try
             {
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
                 if (ownedRelationshipCursor.Current != null)
                 {
 
-                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                    if (ownedRelationshipCursor.Current != null)
                     {
-                        ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+
+                        if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                        {
+                            ParameterMembershipTextualNotationBuilder.BuildArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                            ownedRelationshipCursor.Move();
+
+                        }
+                    }
+                    stringBuilder.Append(' ');
+                }
+
+                BuildClassificationExpressionHandCoded(poco, writerContext, stringBuilder);
+                stringBuilder.Append(' ');
+
+                if (ownedRelationshipCursor.Current != null)
+                {
+
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
+                    {
+                        ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
                         ownedRelationshipCursor.Move();
 
                     }
                 }
-                stringBuilder.Append(' ');
             }
-
-            BuildClassificationExpressionHandCoded(poco, writerContext, stringBuilder);
-            stringBuilder.Append(' ');
-
-            if (ownedRelationshipCursor.Current != null)
+            finally
             {
-
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
-                {
-                    ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
-
-                }
+                writerContext.OperatorContextStack.Pop();
             }
 
         }
@@ -276,30 +320,38 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         public static void BuildMetaclassificationExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-
-            if (ownedRelationshipCursor.Current != null)
+            writerContext.OperatorContextStack.Push(poco);
+            try
             {
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                if (ownedRelationshipCursor.Current != null)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildMetadataArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
 
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                    {
+                        ParameterMembershipTextualNotationBuilder.BuildMetadataArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
+                }
+                BuildMetaclassificationExpressionHandCoded(poco, writerContext, stringBuilder);
+                stringBuilder.Append(' ');
+
+                if (ownedRelationshipCursor.Current != null)
+                {
+
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
+                    {
+                        ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
                 }
             }
-            BuildMetaclassificationExpressionHandCoded(poco, writerContext, stringBuilder);
-            stringBuilder.Append(' ');
-
-            if (ownedRelationshipCursor.Current != null)
+            finally
             {
-
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IReturnParameterMembership elementAsReturnParameterMembership)
-                {
-                    ReturnParameterMembershipTextualNotationBuilder.BuildEmptyResultMember(elementAsReturnParameterMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
-
-                }
+                writerContext.OperatorContextStack.Pop();
             }
 
         }
@@ -313,18 +365,27 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         public static void BuildExtentExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-            stringBuilder.Append(poco.Operator);
-
-            if (ownedRelationshipCursor.Current != null)
+            writerContext.OperatorContextStack.Push(poco);
+            try
             {
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
+                stringBuilder.Append(poco.Operator);
+                stringBuilder.Append(' ');
 
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                if (ownedRelationshipCursor.Current != null)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildTypeReferenceMember(elementAsParameterMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
 
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                    {
+                        ParameterMembershipTextualNotationBuilder.BuildTypeReferenceMember(elementAsParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
                 }
+            }
+            finally
+            {
+                writerContext.OperatorContextStack.Pop();
             }
 
         }
@@ -338,31 +399,40 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         public static void BuildBracketExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-
-            if (ownedRelationshipCursor.Current != null)
+            writerContext.OperatorContextStack.Push(poco);
+            try
             {
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                if (ownedRelationshipCursor.Current != null)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildPrimaryArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
 
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                    {
+                        ParameterMembershipTextualNotationBuilder.BuildPrimaryArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
                 }
-            }
-            stringBuilder.Append(poco.Operator);
+                stringBuilder.Append(poco.Operator);
+                stringBuilder.Append(' ');
 
-            if (ownedRelationshipCursor.Current != null)
+                if (ownedRelationshipCursor.Current != null)
+                {
+
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
+                    {
+                        FeatureMembershipTextualNotationBuilder.BuildSequenceExpressionListMember(elementAsFeatureMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
+                }
+                stringBuilder.Append("] ");
+            }
+            finally
             {
-
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
-                {
-                    FeatureMembershipTextualNotationBuilder.BuildSequenceExpressionListMember(elementAsFeatureMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
-
-                }
+                writerContext.OperatorContextStack.Pop();
             }
-            stringBuilder.Append("] ");
 
         }
 
@@ -375,29 +445,38 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         public static void BuildSequenceOperatorExpression(SysML2.NET.Core.POCO.Kernel.Expressions.IOperatorExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-
-            if (ownedRelationshipCursor.Current != null)
+            writerContext.OperatorContextStack.Push(poco);
+            try
             {
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
+                if (ownedRelationshipCursor.Current != null)
                 {
-                    FeatureMembershipTextualNotationBuilder.BuildOwnedExpressionMember(elementAsFeatureMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
 
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
+                    {
+                        FeatureMembershipTextualNotationBuilder.BuildOwnedExpressionMember(elementAsFeatureMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
+                }
+                stringBuilder.Append(poco.Operator);
+                stringBuilder.Append(' ');
+
+                if (ownedRelationshipCursor.Current != null)
+                {
+
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
+                    {
+                        FeatureMembershipTextualNotationBuilder.BuildSequenceExpressionListMember(elementAsFeatureMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
                 }
             }
-            stringBuilder.Append(poco.Operator);
-
-            if (ownedRelationshipCursor.Current != null)
+            finally
             {
-
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership elementAsFeatureMembership)
-                {
-                    FeatureMembershipTextualNotationBuilder.BuildSequenceExpressionListMember(elementAsFeatureMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
-
-                }
+                writerContext.OperatorContextStack.Pop();
             }
 
         }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/OwningMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/OwningMembershipTextualNotationBuilder.cs
@@ -410,8 +410,8 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         {
             switch (poco)
             {
-                case SysML2.NET.Core.POCO.Core.Types.IFeatureMembership pocoFeatureMembership:
-                    FeatureMembershipTextualNotationBuilder.BuildOwnedFeatureMember(pocoFeatureMembership, writerContext, stringBuilder);
+                case SysML2.NET.Core.POCO.Core.Types.IFeatureMembership pocoFeatureMembershipOwnedFeatureMember when writerContext.CursorCache.GetOrCreateCursor(pocoFeatureMembershipOwnedFeatureMember.Id, "ownedRelatedElement", pocoFeatureMembershipOwnedFeatureMember.OwnedRelatedElement).Current is SysML2.NET.Core.POCO.Core.Features.IFeature:
+                    FeatureMembershipTextualNotationBuilder.BuildOwnedFeatureMember(pocoFeatureMembershipOwnedFeatureMember, writerContext, stringBuilder);
                     break;
                 default:
                     BuildTypeFeatureMember(poco, writerContext, stringBuilder);

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/OwningMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/OwningMembershipTextualNotationBuilder.cs
@@ -51,10 +51,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Root.Annotations.IAnnotatingElement elementAsAnnotatingElement)
                 {
                     AnnotatingElementTextualNotationBuilder.BuildAnnotatingElement(elementAsAnnotatingElement, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -104,10 +104,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Root.Elements.IElement elementAsElement)
                 {
                     ElementTextualNotationBuilder.BuildDefinitionElement(elementAsElement, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -128,10 +128,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
                     ReferenceUsageTextualNotationBuilder.BuildOwnedCrossFeature(elementAsReferenceUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -152,10 +152,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Multiplicities.IMultiplicityRange elementAsMultiplicityRange)
                 {
                     MultiplicityRangeTextualNotationBuilder.BuildMultiplicityRange(elementAsMultiplicityRange, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -200,10 +200,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Types.IMultiplicity elementAsMultiplicity)
                 {
                     MultiplicityTextualNotationBuilder.BuildEmptyMultiplicity(elementAsMultiplicity, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -224,10 +224,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Ports.IConjugatedPortDefinition elementAsConjugatedPortDefinition)
                 {
                     ConjugatedPortDefinitionTextualNotationBuilder.BuildConjugatedPortDefinition(elementAsConjugatedPortDefinition, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -248,10 +248,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                 {
                     FeatureTextualNotationBuilder.BuildOwnedCrossMultiplicity(elementAsFeature, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -272,10 +272,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                 {
                     FeatureTextualNotationBuilder.BuildOwnedFeatureChain(elementAsFeature, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -296,10 +296,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Connectors.ISuccession elementAsSuccession)
                 {
                     SuccessionTextualNotationBuilder.BuildTransitionSuccession(elementAsSuccession, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -321,10 +321,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Metadata.IMetadataUsage elementAsMetadataUsage)
                 {
                     MetadataUsageTextualNotationBuilder.BuildPrefixMetadataUsage(elementAsMetadataUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -367,10 +367,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Root.Elements.IElement elementAsElement)
                 {
                     ElementTextualNotationBuilder.BuildMemberElement(elementAsElement, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -392,10 +392,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                 {
                     FeatureTextualNotationBuilder.BuildFeatureElement(elementAsFeature, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -439,10 +439,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                 {
                     FeatureTextualNotationBuilder.BuildFeatureElement(elementAsFeature, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/PackageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/PackageTextualNotationBuilder.cs
@@ -124,9 +124,9 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
             if (ownedRelationshipCursor.Current != null)
             {
                 BuildFilterPackageImport(poco, writerContext, stringBuilder);
-            }
-            ownedRelationshipCursor.Move();
+                ownedRelationshipCursor.Move();
 
+            }
 
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Packages.IElementFilterMembership elementFilterMembershipGuard && elementFilterMembershipGuard.OwnedRelatedElement.OfType<SysML2.NET.Core.POCO.Kernel.Functions.IExpression>().Any())
             {

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ParameterMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ParameterMembershipTextualNotationBuilder.cs
@@ -51,10 +51,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Occurrences.IEventOccurrenceUsage elementAsEventOccurrenceUsage)
                 {
                     EventOccurrenceUsageTextualNotationBuilder.BuildMessageEvent(elementAsEventOccurrenceUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -75,10 +75,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
                     ReferenceUsageTextualNotationBuilder.BuildPayloadParameter(elementAsReferenceUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -116,10 +116,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                 {
                     FeatureTextualNotationBuilder.BuildArgumentExpression(elementAsFeature, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -140,10 +140,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
                     ReferenceUsageTextualNotationBuilder.BuildNodeParameter(elementAsReferenceUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -164,10 +164,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
                     ReferenceUsageTextualNotationBuilder.BuildEmptyUsage(elementAsReferenceUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -188,10 +188,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
                     ReferenceUsageTextualNotationBuilder.BuildAssignmentTargetParameter(elementAsReferenceUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -212,10 +212,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IExpression elementAsExpression)
                 {
                     ExpressionTextualNotationBuilder.BuildOwnedExpression(elementAsExpression, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -236,10 +236,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Actions.IActionUsage elementAsActionUsage)
                 {
                     ActionUsageTextualNotationBuilder.BuildActionBodyParameter(elementAsActionUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -260,10 +260,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Actions.IIfActionUsage elementAsIfActionUsage)
                 {
                     IfActionUsageTextualNotationBuilder.BuildIfNode(elementAsIfActionUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -284,10 +284,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                 {
                     FeatureTextualNotationBuilder.BuildMetadataArgument(elementAsFeature, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/PerformActionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/PerformActionUsageTextualNotationBuilder.cs
@@ -53,12 +53,12 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting elementAsReferenceSubsetting)
                     {
                         ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
 
-
-                if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
+                if ((ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership) || poco.IsOrdered)
                 {
                     FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, writerContext, stringBuilder);
                 }
@@ -71,7 +71,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
 
             stringBuilder.Append(' ');
 
-            if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }
@@ -102,12 +102,12 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         public static void BuildTransitionPerformActionUsage(SysML2.NET.Core.POCO.Systems.Actions.IPerformActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             BuildPerformActionUsageDeclaration(poco, writerContext, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (poco.OwnedRelationship.Count != 0 || poco.importedMembership.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsVariation || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.isReference || poco.IsIndividual || poco.PortionKind.HasValue || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if ((ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IImport || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IVariantMembership || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership) || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsVariation || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.isReference || poco.IsIndividual || poco.PortionKind.HasValue || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
-                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 while (ownedRelationshipCursor.Current != null)
                 {
                     TypeTextualNotationBuilder.BuildActionBodyItem(poco, writerContext, stringBuilder);

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/PortDefinitionTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/PortDefinitionTextualNotationBuilder.cs
@@ -55,10 +55,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                 {
                     OwningMembershipTextualNotationBuilder.BuildConjugatedPortDefinitionMember(elementAsOwningMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             // NonParsing Assignment Element : conjugatedPortDefinition.ownedPortConjugator.originalPortDefinition = this => Does not have to be process
 
         }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/PortUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/PortUsageTextualNotationBuilder.cs
@@ -62,7 +62,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         {
             var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (ownedRelationshipCursor.Current != null)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership && ownedRelationshipCursor.GetNext(1) is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting)
             {
 
                 if (ownedRelationshipCursor.Current != null)
@@ -81,7 +81,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredName))
             {
-                stringBuilder.Append(poco.DeclaredName);
+                SharedTextualNotationBuilder.AppendName(stringBuilder, poco.DeclaredName);
                 stringBuilder.Append(" ::> ");
                 stringBuilder.Append(' ');
             }
@@ -93,10 +93,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting elementAsReferenceSubsetting)
                 {
                     ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ReferenceUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ReferenceUsageTextualNotationBuilder.cs
@@ -389,11 +389,11 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         {
             switch (poco)
             {
-                case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage pocoUsageRefPrefix when pocoUsageRefPrefix.IsDerived:
-                    UsageTextualNotationBuilder.BuildRefPrefix(pocoUsageRefPrefix, writerContext, stringBuilder);
+                case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage pocoUsageEndUsagePrefix when pocoUsageEndUsagePrefix.IsEnd:
+                    UsageTextualNotationBuilder.BuildEndUsagePrefix(pocoUsageEndUsagePrefix, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage pocoUsage:
-                    UsageTextualNotationBuilder.BuildEndUsagePrefix(pocoUsage, writerContext, stringBuilder);
+                    UsageTextualNotationBuilder.BuildRefPrefix(pocoUsage, writerContext, stringBuilder);
                     break;
             }
 

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ReferenceUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ReferenceUsageTextualNotationBuilder.cs
@@ -79,10 +79,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting elementAsReferenceSubsetting)
                 {
                     ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             while (ownedRelationshipCursor.Current is not null and not SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage)
             {
                 FeatureTextualNotationBuilder.BuildFeatureSpecialization(poco, writerContext, stringBuilder);
@@ -132,7 +132,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         {
             var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (ownedRelationshipCursor.Current != null)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership && ownedRelationshipCursor.GetNext(1) is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting)
             {
 
                 if (ownedRelationshipCursor.Current != null)
@@ -151,7 +151,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
 
             if (!string.IsNullOrWhiteSpace(poco.DeclaredName))
             {
-                stringBuilder.Append(poco.DeclaredName);
+                SharedTextualNotationBuilder.AppendName(stringBuilder, poco.DeclaredName);
                 stringBuilder.Append(" ::> ");
                 stringBuilder.Append(' ');
             }
@@ -163,10 +163,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting elementAsReferenceSubsetting)
                 {
                     ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -187,10 +187,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition elementAsRedefinition)
                 {
                     RedefinitionTextualNotationBuilder.BuildFlowFeatureRedefinition(elementAsRedefinition, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -223,10 +223,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                 {
                     FeatureValueTextualNotationBuilder.BuildFeatureBinding(elementAsFeatureValue, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -334,10 +334,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue elementAsFeatureValue)
                 {
                     FeatureValueTextualNotationBuilder.BuildSatisfactionFeatureValue(elementAsFeatureValue, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -360,17 +360,17 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition elementAsRedefinition)
                 {
                     RedefinitionTextualNotationBuilder.BuildOwnedRedefinition(elementAsRedefinition, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
 
-
-            if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
+            if ((ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership) || poco.IsOrdered)
             {
                 FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, writerContext, stringBuilder);
             }
 
-            if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/RequirementConstraintMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/RequirementConstraintMembershipTextualNotationBuilder.cs
@@ -57,10 +57,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Constraints.IConstraintUsage elementAsConstraintUsage)
                 {
                     ConstraintUsageTextualNotationBuilder.BuildRequirementConstraintUsage(elementAsConstraintUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/RequirementVerificationMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/RequirementVerificationMembershipTextualNotationBuilder.cs
@@ -54,10 +54,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Requirements.IRequirementUsage elementAsRequirementUsage)
                 {
                     RequirementUsageTextualNotationBuilder.BuildRequirementVerificationUsage(elementAsRequirementUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ResultExpressionMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ResultExpressionMembershipTextualNotationBuilder.cs
@@ -56,10 +56,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IExpression elementAsExpression)
                 {
                     ExpressionTextualNotationBuilder.BuildOwnedExpression(elementAsExpression, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ReturnParameterMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ReturnParameterMembershipTextualNotationBuilder.cs
@@ -57,10 +57,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage elementAsUsage)
                 {
                     UsageTextualNotationBuilder.BuildUsageElement(elementAsUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -83,10 +83,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                 {
                     FeatureTextualNotationBuilder.BuildFeatureElement(elementAsFeature, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -107,10 +107,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
                     ReferenceUsageTextualNotationBuilder.BuildEmptyFeature(elementAsReferenceUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -131,10 +131,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeature elementAsFeature)
                 {
                     FeatureTextualNotationBuilder.BuildConstructorResult(elementAsFeature, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/SatisfyRequirementUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/SatisfyRequirementUsageTextualNotationBuilder.cs
@@ -62,12 +62,12 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting elementAsReferenceSubsetting)
                     {
                         ReferenceSubsettingTextualNotationBuilder.BuildOwnedReferenceSubsetting(elementAsReferenceSubsetting, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
 
-
-                if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
+                if ((ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership) || poco.IsOrdered)
                 {
                     FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, writerContext, stringBuilder);
                 }
@@ -80,7 +80,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
 
             stringBuilder.Append(' ');
 
-            if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/SelectExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/SelectExpressionTextualNotationBuilder.cs
@@ -51,10 +51,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildPrimaryArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append(".? ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -63,10 +63,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildBodyArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/SelectExpressionTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/SelectExpressionTextualNotationBuilder.cs
@@ -43,29 +43,37 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         public static void BuildSelectExpression(SysML2.NET.Core.POCO.Kernel.Expressions.ISelectExpression poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
-            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
-
-            if (ownedRelationshipCursor.Current != null)
+            writerContext.OperatorContextStack.Push(poco);
+            try
             {
+                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                if (ownedRelationshipCursor.Current != null)
                 {
-                    ParameterMembershipTextualNotationBuilder.BuildPrimaryArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
 
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                    {
+                        ParameterMembershipTextualNotationBuilder.BuildPrimaryArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
+                }
+                stringBuilder.Append(".? ");
+
+                if (ownedRelationshipCursor.Current != null)
+                {
+
+                    if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
+                    {
+                        ParameterMembershipTextualNotationBuilder.BuildBodyArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
+                    }
                 }
             }
-            stringBuilder.Append(".? ");
-
-            if (ownedRelationshipCursor.Current != null)
+            finally
             {
-
-                if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
-                {
-                    ParameterMembershipTextualNotationBuilder.BuildBodyArgumentMember(elementAsParameterMembership, writerContext, stringBuilder);
-                    ownedRelationshipCursor.Move();
-
-                }
+                writerContext.OperatorContextStack.Pop();
             }
 
         }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/SendActionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/SendActionUsageTextualNotationBuilder.cs
@@ -46,7 +46,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
             var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
 
-            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsVariation || poco.IsConstant || poco.IsEnd || poco.isReference || poco.IsIndividual || poco.PortionKind.HasValue || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue) || poco.IsOrdered || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsVariation || poco.IsConstant || poco.IsEnd || poco.isReference || poco.IsIndividual || poco.PortionKind.HasValue || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 ActionUsageTextualNotationBuilder.BuildActionUsageDeclaration(poco, writerContext, stringBuilder);
             }
@@ -67,7 +67,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         {
             var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
+            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership) || poco.IsOrdered)
             {
                 ActionUsageTextualNotationBuilder.BuildActionNodeUsageDeclaration(poco, writerContext, stringBuilder);
             }
@@ -79,12 +79,12 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildNodeParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
 
-
-            if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsVariation || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.isReference || poco.IsIndividual || poco.PortionKind.HasValue || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsVariation || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.isReference || poco.IsIndividual || poco.PortionKind.HasValue || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 BuildSenderReceiverPart(poco, writerContext, stringBuilder);
             }
@@ -127,12 +127,12 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         public static void BuildTransitionSendActionUsage(SysML2.NET.Core.POCO.Systems.Actions.ISendActionUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             BuildSendNodeDeclaration(poco, writerContext, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (poco.OwnedRelationship.Count != 0 || poco.importedMembership.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsVariation || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.isReference || poco.IsIndividual || poco.PortionKind.HasValue || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if ((ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IImport || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IVariantMembership || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IFeatureMembership) || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsVariation || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.isReference || poco.IsIndividual || poco.PortionKind.HasValue || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 stringBuilder.Append(' ');
                 stringBuilder.AppendLine("{");
-                var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
                 while (ownedRelationshipCursor.Current != null)
                 {
                     TypeTextualNotationBuilder.BuildActionBodyItem(poco, writerContext, stringBuilder);

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/StakeholderMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/StakeholderMembershipTextualNotationBuilder.cs
@@ -52,10 +52,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Parts.IPartUsage elementAsPartUsage)
                 {
                     PartUsageTextualNotationBuilder.BuildStakeholderUsage(elementAsPartUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/StateSubactionMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/StateSubactionMembershipTextualNotationBuilder.cs
@@ -54,10 +54,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Actions.IActionUsage elementAsActionUsage)
                 {
                     ActionUsageTextualNotationBuilder.BuildStateActionUsage(elementAsActionUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -81,10 +81,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Actions.IActionUsage elementAsActionUsage)
                 {
                     ActionUsageTextualNotationBuilder.BuildStateActionUsage(elementAsActionUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -108,10 +108,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Actions.IActionUsage elementAsActionUsage)
                 {
                     ActionUsageTextualNotationBuilder.BuildStateActionUsage(elementAsActionUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/StepTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/StepTextualNotationBuilder.cs
@@ -46,8 +46,9 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
             SharedTextualNotationBuilder.BuildFeaturePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("step ");
             FeatureTextualNotationBuilder.BuildFeatureDeclaration(poco, writerContext, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/SubjectMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/SubjectMembershipTextualNotationBuilder.cs
@@ -52,10 +52,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
                     ReferenceUsageTextualNotationBuilder.BuildSubjectUsage(elementAsReferenceUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -76,10 +76,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage elementAsReferenceUsage)
                 {
                     ReferenceUsageTextualNotationBuilder.BuildSatisfactionParameter(elementAsReferenceUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/SuccessionAsUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/SuccessionAsUsageTextualNotationBuilder.cs
@@ -51,10 +51,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
                     EndFeatureMembershipTextualNotationBuilder.BuildSourceEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -75,10 +75,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
                     EndFeatureMembershipTextualNotationBuilder.BuildSourceEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append("then ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -87,10 +87,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
                     EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -106,7 +106,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
             var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             UsageTextualNotationBuilder.BuildUsagePrefix(poco, writerContext, stringBuilder);
 
-            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.OwnedRelatedElement.Count != 0 || poco.IsOrdered)
+            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership) || poco.IsOrdered)
             {
                 stringBuilder.Append("succession ");
                 UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
@@ -121,10 +121,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
                     EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append("then ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -133,10 +133,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
                     EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             UsageTextualNotationBuilder.BuildUsageBody(poco, writerContext, stringBuilder);
 
         }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/SuccessionTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/SuccessionTextualNotationBuilder.cs
@@ -51,10 +51,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
                     EndFeatureMembershipTextualNotationBuilder.BuildEmptyEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             if (ownedRelationshipCursor.Current != null)
             {
@@ -62,10 +62,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IEndFeatureMembership elementAsEndFeatureMembership)
                 {
                     EndFeatureMembershipTextualNotationBuilder.BuildConnectorEndMember(elementAsEndFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/TerminateActionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/TerminateActionUsageTextualNotationBuilder.cs
@@ -46,7 +46,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
             var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
 
-            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
+            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership) || poco.IsOrdered)
             {
                 ActionUsageTextualNotationBuilder.BuildActionNodeUsageDeclaration(poco, writerContext, stringBuilder);
             }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/TransitionFeatureMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/TransitionFeatureMembershipTextualNotationBuilder.cs
@@ -53,10 +53,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Actions.IAcceptActionUsage elementAsAcceptActionUsage)
                 {
                     AcceptActionUsageTextualNotationBuilder.BuildTriggerAction(elementAsAcceptActionUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -79,10 +79,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Kernel.Functions.IExpression elementAsExpression)
                 {
                     ExpressionTextualNotationBuilder.BuildOwnedExpression(elementAsExpression, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
 
@@ -105,10 +105,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Actions.IActionUsage elementAsActionUsage)
                 {
                     ActionUsageTextualNotationBuilder.BuildEffectBehaviorUsage(elementAsActionUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/TransitionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/TransitionUsageTextualNotationBuilder.cs
@@ -51,10 +51,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.States.ITransitionFeatureMembership elementAsTransitionFeatureMembership)
                 {
                     TransitionFeatureMembershipTextualNotationBuilder.BuildGuardExpressionMember(elementAsTransitionFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append("then ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -63,10 +63,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                 {
                     OwningMembershipTextualNotationBuilder.BuildTransitionSuccessionMember(elementAsOwningMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -88,10 +88,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                 {
                     OwningMembershipTextualNotationBuilder.BuildTransitionSuccessionMember(elementAsOwningMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -106,7 +106,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         {
             var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
+            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership) || poco.IsOrdered)
             {
                 stringBuilder.Append("succession ");
                 UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
@@ -121,10 +121,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership elementAsMembership)
                 {
                     MembershipTextualNotationBuilder.BuildFeatureChainMember(elementAsMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             if (ownedRelationshipCursor.Current != null)
             {
@@ -132,10 +132,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.States.ITransitionFeatureMembership elementAsTransitionFeatureMembership)
                 {
                     TransitionFeatureMembershipTextualNotationBuilder.BuildGuardExpressionMember(elementAsTransitionFeatureMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             stringBuilder.Append("then ");
 
             if (ownedRelationshipCursor.Current != null)
@@ -144,10 +144,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                 {
                     OwningMembershipTextualNotationBuilder.BuildTransitionSuccessionMember(elementAsOwningMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             UsageTextualNotationBuilder.BuildUsageBody(poco, writerContext, stringBuilder);
 
         }
@@ -169,10 +169,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildEmptyParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             BuildTargetTransitionUsageHandCoded(poco, writerContext, stringBuilder);
             stringBuilder.Append("then ");
 
@@ -182,10 +182,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                 {
                     OwningMembershipTextualNotationBuilder.BuildTransitionSuccessionMember(elementAsOwningMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             TypeTextualNotationBuilder.BuildActionBody(poco, writerContext, stringBuilder);
 
         }
@@ -202,7 +202,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
             var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
             stringBuilder.Append("transition ");
 
-            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
+            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership) || poco.IsOrdered)
             {
                 UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
                 stringBuilder.Append("first ");
@@ -216,10 +216,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IMembership elementAsMembership)
                 {
                     MembershipTextualNotationBuilder.BuildFeatureChainMember(elementAsMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             if (ownedRelationshipCursor.Current != null)
             {
@@ -227,12 +227,12 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildEmptyParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
 
-
-            if (ownedRelationshipCursor.Current != null)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership && ownedRelationshipCursor.GetNext(1) is SysML2.NET.Core.POCO.Systems.States.ITransitionFeatureMembership)
             {
 
                 if (ownedRelationshipCursor.Current != null)
@@ -277,7 +277,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
             }
 
 
-            if (ownedRelationshipCursor.Current != null)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Systems.States.ITransitionFeatureMembership && ownedRelationshipCursor.GetNext(1) is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership)
             {
 
                 if (ownedRelationshipCursor.Current != null)
@@ -301,10 +301,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                 {
                     OwningMembershipTextualNotationBuilder.BuildTransitionSuccessionMember(elementAsOwningMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
             TypeTextualNotationBuilder.BuildActionBody(poco, writerContext, stringBuilder);
 
         }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/TypeTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/TypeTextualNotationBuilder.cs
@@ -538,10 +538,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.ISpecialization elementAsSpecialization)
                 {
                     SpecializationTextualNotationBuilder.BuildOwnedSpecialization(elementAsSpecialization, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             while (ownedRelationshipCursor.Current != null && ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.ISpecialization)
             {
@@ -579,10 +579,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IConjugation elementAsConjugation)
                 {
                     ConjugationTextualNotationBuilder.BuildOwnedConjugation(elementAsConjugation, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -632,10 +632,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IDisjoining elementAsDisjoining)
                 {
                     DisjoiningTextualNotationBuilder.BuildOwnedDisjoining(elementAsDisjoining, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             while (ownedRelationshipCursor.Current != null && ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IDisjoining)
             {
@@ -673,10 +673,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IUnioning elementAsUnioning)
                 {
                     UnioningTextualNotationBuilder.BuildUnioning(elementAsUnioning, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IUnioning unioningGuard && unioningGuard.OwnedRelatedElement.OfType<SysML2.NET.Core.POCO.Core.Features.IFeature>().Any())
             {
@@ -714,10 +714,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IIntersecting elementAsIntersecting)
                 {
                     IntersectingTextualNotationBuilder.BuildIntersecting(elementAsIntersecting, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IIntersecting intersectingGuard && intersectingGuard.OwnedRelatedElement.OfType<SysML2.NET.Core.POCO.Core.Features.IFeature>().Any())
             {
@@ -755,10 +755,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IDifferencing elementAsDifferencing)
                 {
                     DifferencingTextualNotationBuilder.BuildDifferencing(elementAsDifferencing, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             while (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Types.IDifferencing differencingGuard && differencingGuard.OwnedRelatedElement.OfType<SysML2.NET.Core.POCO.Core.Features.IFeature>().Any())
             {

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/UsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/UsageTextualNotationBuilder.cs
@@ -166,10 +166,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership elementAsOwningMembership)
                 {
                     OwningMembershipTextualNotationBuilder.BuildPrefixMetadataMember(elementAsOwningMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
         }
 
@@ -223,8 +223,9 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         public static void BuildUsageDeclaration(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
             ElementTextualNotationBuilder.BuildIdentification(poco, writerContext, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
+            if ((ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership) || poco.IsOrdered)
             {
                 FeatureTextualNotationBuilder.BuildFeatureSpecializationPart(poco, writerContext, stringBuilder);
             }
@@ -240,8 +241,9 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
         public static void BuildUsageCompletion(SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/UsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/UsageTextualNotationBuilder.cs
@@ -45,7 +45,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         {
             switch (poco)
             {
-                case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage pocoUsageNonOccurrenceUsageElement when pocoUsageNonOccurrenceUsageElement.IsEnd:
+                case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage pocoUsageNonOccurrenceUsageElement when pocoUsageNonOccurrenceUsageElement.IsValidForNonOccurrenceUsageElement(writerContext):
                     BuildNonOccurrenceUsageElement(pocoUsageNonOccurrenceUsageElement, writerContext, stringBuilder);
                     break;
                 default:
@@ -184,11 +184,11 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         {
             switch (poco)
             {
-                case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage pocoUsageBasicUsagePrefix when pocoUsageBasicUsagePrefix.IsDerived:
-                    BuildBasicUsagePrefix(pocoUsageBasicUsagePrefix, writerContext, stringBuilder);
+                case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IUsage pocoUsageEndUsagePrefix when pocoUsageEndUsagePrefix.IsEnd:
+                    BuildEndUsagePrefix(pocoUsageEndUsagePrefix, writerContext, stringBuilder);
                     break;
                 default:
-                    BuildEndUsagePrefix(poco, writerContext, stringBuilder);
+                    BuildBasicUsagePrefix(poco, writerContext, stringBuilder);
                     break;
             }
 
@@ -284,11 +284,11 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 case SysML2.NET.Core.POCO.Systems.Enumerations.IEnumerationUsage pocoEnumerationUsage:
                     EnumerationUsageTextualNotationBuilder.BuildEnumerationUsage(pocoEnumerationUsage, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage pocoReferenceUsageReferenceUsage when pocoReferenceUsageReferenceUsage.IsEnd:
-                    ReferenceUsageTextualNotationBuilder.BuildReferenceUsage(pocoReferenceUsageReferenceUsage, writerContext, stringBuilder);
+                case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage pocoReferenceUsageDefaultReferenceUsage when pocoReferenceUsageDefaultReferenceUsage.IsValidForDefaultReferenceUsage(writerContext):
+                    ReferenceUsageTextualNotationBuilder.BuildDefaultReferenceUsage(pocoReferenceUsageDefaultReferenceUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage pocoReferenceUsage:
-                    ReferenceUsageTextualNotationBuilder.BuildDefaultReferenceUsage(pocoReferenceUsage, writerContext, stringBuilder);
+                    ReferenceUsageTextualNotationBuilder.BuildReferenceUsage(pocoReferenceUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Attributes.IAttributeUsage pocoAttributeUsage:
                     AttributeUsageTextualNotationBuilder.BuildAttributeUsage(pocoAttributeUsage, writerContext, stringBuilder);
@@ -368,11 +368,11 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 case SysML2.NET.Core.POCO.Systems.Ports.IPortUsage pocoPortUsage:
                     PortUsageTextualNotationBuilder.BuildPortUsage(pocoPortUsage, writerContext, stringBuilder);
                     break;
+                case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage pocoOccurrenceUsageIndividualUsage when pocoOccurrenceUsageIndividualUsage.IsIndividual:
+                    OccurrenceUsageTextualNotationBuilder.BuildIndividualUsage(pocoOccurrenceUsageIndividualUsage, writerContext, stringBuilder);
+                    break;
                 case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage pocoOccurrenceUsageOccurrenceUsage when pocoOccurrenceUsageOccurrenceUsage.IsValidForOccurrenceUsage(writerContext):
                     OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsage(pocoOccurrenceUsageOccurrenceUsage, writerContext, stringBuilder);
-                    break;
-                case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage pocoOccurrenceUsageIndividualUsage when pocoOccurrenceUsageIndividualUsage.IsValidForIndividualUsage(writerContext):
-                    OccurrenceUsageTextualNotationBuilder.BuildIndividualUsage(pocoOccurrenceUsageIndividualUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage pocoOccurrenceUsage:
                     OccurrenceUsageTextualNotationBuilder.BuildPortionUsage(pocoOccurrenceUsage, writerContext, stringBuilder);
@@ -497,16 +497,16 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 case SysML2.NET.Core.POCO.Systems.Ports.IPortUsage pocoPortUsage:
                     PortUsageTextualNotationBuilder.BuildPortUsage(pocoPortUsage, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage pocoReferenceUsageReferenceUsage when pocoReferenceUsageReferenceUsage.IsEnd:
-                    ReferenceUsageTextualNotationBuilder.BuildReferenceUsage(pocoReferenceUsageReferenceUsage, writerContext, stringBuilder);
-                    break;
-                case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage pocoReferenceUsageVariantReference when writerContext.CursorCache.GetOrCreateCursor(pocoReferenceUsageVariantReference.Id, "ownedRelationship", pocoReferenceUsageVariantReference.OwnedRelationship).Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting:
+                case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage pocoReferenceUsageVariantReference when pocoReferenceUsageVariantReference.IsValidForVariantReference(writerContext):
                     ReferenceUsageTextualNotationBuilder.BuildVariantReference(pocoReferenceUsageVariantReference, writerContext, stringBuilder);
+                    break;
+                case SysML2.NET.Core.POCO.Systems.DefinitionAndUsage.IReferenceUsage pocoReferenceUsage:
+                    ReferenceUsageTextualNotationBuilder.BuildReferenceUsage(pocoReferenceUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Attributes.IAttributeUsage pocoAttributeUsage:
                     AttributeUsageTextualNotationBuilder.BuildAttributeUsage(pocoAttributeUsage, writerContext, stringBuilder);
                     break;
-                case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage pocoOccurrenceUsageIndividualUsage when pocoOccurrenceUsageIndividualUsage.IsValidForIndividualUsage(writerContext):
+                case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage pocoOccurrenceUsageIndividualUsage when pocoOccurrenceUsageIndividualUsage.IsIndividual:
                     OccurrenceUsageTextualNotationBuilder.BuildIndividualUsage(pocoOccurrenceUsageIndividualUsage, writerContext, stringBuilder);
                     break;
                 case SysML2.NET.Core.POCO.Systems.Occurrences.IOccurrenceUsage pocoOccurrenceUsageOccurrenceUsage when pocoOccurrenceUsageOccurrenceUsage.IsValidForOccurrenceUsage(writerContext):

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/UseCaseUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/UseCaseUsageTextualNotationBuilder.cs
@@ -47,8 +47,9 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
             stringBuilder.Append("use ");
             stringBuilder.Append("case ");
             UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/VariantMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/VariantMembershipTextualNotationBuilder.cs
@@ -71,10 +71,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Enumerations.IEnumerationUsage elementAsEnumerationUsage)
                 {
                     EnumerationUsageTextualNotationBuilder.BuildEnumeratedValue(elementAsEnumerationUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/VerificationCaseUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/VerificationCaseUsageTextualNotationBuilder.cs
@@ -46,8 +46,9 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
             OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("verification ");
             UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ViewRenderingMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ViewRenderingMembershipTextualNotationBuilder.cs
@@ -53,10 +53,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelatedElementCursor.Current is SysML2.NET.Core.POCO.Systems.Views.IRenderingUsage elementAsRenderingUsage)
                 {
                     RenderingUsageTextualNotationBuilder.BuildViewRenderingUsage(elementAsRenderingUsage, writerContext, stringBuilder);
+                    ownedRelatedElementCursor.Move();
+
                 }
             }
-            ownedRelatedElementCursor.Move();
-
 
         }
     }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ViewUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/ViewUsageTextualNotationBuilder.cs
@@ -104,13 +104,14 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         {
             OccurrenceUsageTextualNotationBuilder.BuildOccurrenceUsagePrefix(poco, writerContext, stringBuilder);
             stringBuilder.Append("view ");
+            var ownedRelationshipCursor = writerContext.CursorCache.GetOrCreateCursor(poco.Id, "ownedRelationship", poco.OwnedRelationship);
 
-            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || poco.IsOrdered)
+            if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IFeatureTyping || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ISubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IReferenceSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.ICrossSubsetting || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Core.Features.IRedefinition || ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Root.Namespaces.IOwningMembership) || poco.IsOrdered)
             {
                 UsageTextualNotationBuilder.BuildUsageDeclaration(poco, writerContext, stringBuilder);
             }
 
-            if (poco.OwnedRelationship.Count != 0 || poco.type.Count != 0 || poco.chainingFeature.Count != 0 || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.importedMembership.Count != 0 || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient || poco.unioningType.Count != 0 || poco.intersectingType.Count != 0 || poco.differencingType.Count != 0 || poco.featuringType.Count != 0 || poco.ownedTypeFeaturing.Count != 0)
+            if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.FeatureValues.IFeatureValue || !string.IsNullOrWhiteSpace(poco.DeclaredShortName) || !string.IsNullOrWhiteSpace(poco.DeclaredName) || poco.Direction.HasValue || poco.IsDerived || poco.IsAbstract || poco.IsConstant || poco.IsOrdered || poco.IsEnd || poco.IsComposite || poco.IsPortion || poco.IsVariable || poco.IsSufficient)
             {
                 FeatureTextualNotationBuilder.BuildValuePart(poco, writerContext, stringBuilder);
             }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/WhileLoopActionUsageTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/AutoGenTextualNotationBuilder/WhileLoopActionUsageTextualNotationBuilder.cs
@@ -55,10 +55,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                     {
                         ParameterMembershipTextualNotationBuilder.BuildEmptyParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
             }
             else if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership)
             {
@@ -70,10 +70,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                     if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                     {
                         ParameterMembershipTextualNotationBuilder.BuildExpressionParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
+                        ownedRelationshipCursor.Move();
+
                     }
                 }
-                ownedRelationshipCursor.Move();
-
             }
 
             stringBuilder.Append(' ');
@@ -84,10 +84,10 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 if (ownedRelationshipCursor.Current is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership elementAsParameterMembership)
                 {
                     ParameterMembershipTextualNotationBuilder.BuildActionBodyParameterMember(elementAsParameterMembership, writerContext, stringBuilder);
+                    ownedRelationshipCursor.Move();
+
                 }
             }
-            ownedRelationshipCursor.Move();
-
 
             if (ownedRelationshipCursor.Current != null)
             {

--- a/SysML2.NET.Serializer.TextualNotation/Writers/ConjugatedPortTypingTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/ConjugatedPortTypingTextualNotationBuilder.cs
@@ -30,13 +30,26 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
     public static partial class ConjugatedPortTypingTextualNotationBuilder
     {
         /// <summary>
-        /// Build the originalPortDefinition=~[QualifiedName] rule part
+        /// Builds the Textual Notation string for the rule ConjugatedPortTyping.
+        /// <remarks>ConjugatedPortTyping:ConjugatedPortTyping='~'originalPortDefinition=~[QualifiedName]</remarks>
+        /// <para>The grammar's <c>originalPortDefinition</c> property does not resolve
+        /// against <see cref="IConjugatedPortTyping"/> — the metamodel exposes
+        /// <c>portDefinition</c> (the derived port-definition reference) instead.
+        /// The leading <c>'~'</c> token is already emitted by the autogen wrapper;
+        /// this hand-coded sibling carries the <c>~[QualifiedName]</c> emission as
+        /// a stub (matches the previous empty-stub behavior of
+        /// <c>BuildOriginalPortDefinition</c>).</para>
         /// </summary>
         /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Systems.Ports.IConjugatedPortTyping" /> from which the rule should be build</param>
         /// <param name="writerContext"> The <see cref="ICursorCache" /> used to get access to CursorCollection for the current <paramref name="poco"/></param>
         /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
-        private static void BuildOriginalPortDefinition(IConjugatedPortTyping poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
+        private static void BuildConjugatedPortTypingHandCoded(IConjugatedPortTyping poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
         {
+            // Preserves the previous empty-stub behavior of BuildOriginalPortDefinition
+            // for this call site. Full ~[QualifiedName] emission via the
+            // conjugated-resolution rule documented in SysML-textual-bnf.kebnf
+            // lines 651-658 still requires a dedicated implementation; left as a
+            // follow-up.
         }
     }
 }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/FeatureMembershipTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/FeatureMembershipTextualNotationBuilder.cs
@@ -41,6 +41,47 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         }
 
         /// <summary>
+        /// Builds the Textual Notation string for the rule InitialNodeMember.
+        /// <remarks>InitialNodeMember:FeatureMembership=MemberPrefix'first'memberFeature=[QualifiedName]RelationshipBody</remarks>
+        /// <para>The grammar's <c>memberFeature</c> property does not resolve against
+        /// <see cref="IFeatureMembership"/> — the metamodel only exposes
+        /// <c>ownedMemberFeature</c> on <c>IFeatureMembership</c> and <c>MemberElement</c>
+        /// on its parent <c>IMembership</c>. This hand-coded sibling carries the
+        /// remaining <c>[QualifiedName]</c> emission as a stub; the surrounding
+        /// <c>MemberPrefix</c>, <c>'first'</c>, and <c>RelationshipBody</c> tokens are
+        /// already emitted by the autogen wrapper.</para>
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
+        /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
+        private static void BuildInitialNodeMemberHandCoded(IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
+        {
+            // Preserves the previous empty-stub behavior of BuildMemberFeature for this
+            // call site. The full QualifiedName-emission still requires a dedicated
+            // implementation; left as a follow-up.
+        }
+
+        /// <summary>
+        /// Builds the Textual Notation string for the rule OwnedExpressionMember.
+        /// <remarks>OwnedExpressionMember:FeatureMembership=ownedFeatureMember=OwnedExpression</remarks>
+        /// <para>The grammar property name <c>ownedFeatureMember</c> does not exist on
+        /// <see cref="IFeatureMembership"/> — the OMG kebnf carries a one-off typo and
+        /// the real metamodel property is <c>ownedMemberFeature</c>. This hand-coded
+        /// sibling resolves the typo at emission time, dispatching the membership's
+        /// <c>OwnedMemberFeature</c> through <c>BuildOwnedExpression</c>.</para>
+        /// </summary>
+        /// <param name="poco">The <see cref="SysML2.NET.Core.POCO.Core.Types.IFeatureMembership" /> from which the rule should be build</param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext" /> providing the serialization context for the current <paramref name="poco"/></param>
+        /// <param name="stringBuilder">The <see cref="StringBuilder" /> that contains the entire textual notation</param>
+        private static void BuildOwnedExpressionMemberHandCoded(IFeatureMembership poco, TextualNotationWriterContext writerContext, StringBuilder stringBuilder)
+        {
+            if (poco.ownedMemberFeature is SysML2.NET.Core.POCO.Kernel.Functions.IExpression elementAsExpression)
+            {
+                ExpressionTextualNotationBuilder.BuildOwnedExpression(elementAsExpression, writerContext, stringBuilder);
+            }
+        }
+
+        /// <summary>
         /// Builds the Textual Notation string for the rule EntryTransitionMember
         /// <remarks>EntryTransitionMember:FeatureMembership=MemberPrefix(ownedRelatedElement+=GuardedTargetSuccession|'then'ownedRelatedElement+=TargetSuccession)';'</remarks>
         /// </summary>

--- a/SysML2.NET.Serializer.TextualNotation/Writers/FeatureTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/FeatureTextualNotationBuilder.cs
@@ -197,20 +197,20 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
             if (!string.IsNullOrWhiteSpace(poco.DeclaredShortName))
             {
                 stringBuilder.Append('<');
-                stringBuilder.Append(poco.DeclaredShortName);
+                SharedTextualNotationBuilder.AppendName(stringBuilder, poco.DeclaredShortName);
                 stringBuilder.Append('>');
 
                 if (!string.IsNullOrWhiteSpace(poco.DeclaredName))
                 {
                     stringBuilder.Append(' ');
-                    stringBuilder.Append(poco.DeclaredName);
+                    SharedTextualNotationBuilder.AppendName(stringBuilder, poco.DeclaredName);
                 }
 
                 stringBuilder.Append(' ');
             }
             else if (!string.IsNullOrWhiteSpace(poco.DeclaredName))
             {
-                stringBuilder.Append(poco.DeclaredName);
+                SharedTextualNotationBuilder.AppendName(stringBuilder, poco.DeclaredName);
                 stringBuilder.Append(' ');
             }
         }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/NameResolutionCache.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/NameResolutionCache.cs
@@ -540,7 +540,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 return;
             }
 
-            foreach (var supertype in supertypes.Where(supertype => supertype != null && !ReferenceEquals(supertype, type)))
+            foreach (var supertype in supertypes.Where(s => s != null && !ReferenceEquals(s, type)))
             {
                 if (supertype is INamespace supertypeAsNamespace)
                 {

--- a/SysML2.NET.Serializer.TextualNotation/Writers/NameResolutionCache.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/NameResolutionCache.cs
@@ -1,0 +1,615 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="NameResolutionCache.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.TextualNotation.Writers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using SysML2.NET.Core.POCO.Core.Features;
+    using SysML2.NET.Core.POCO.Core.Types;
+    using SysML2.NET.Core.POCO.Kernel.Behaviors;
+    using SysML2.NET.Core.POCO.Kernel.Expressions;
+    using SysML2.NET.Core.POCO.Root.Elements;
+    using SysML2.NET.Core.POCO.Root.Namespaces;
+    using SysML2.NET.Extensions;
+
+    /// <summary>
+    /// Performant single-place cache for textual-notation qualified-name resolution.
+    /// <para>Owns three caches:</para>
+    /// <list type="number">
+    ///   <item><description>Eager structural: per-namespace simple-name → member set, populated
+    ///   by a single walk of the model on construction. Keys are the namespaces reachable
+    ///   transitively from the root namespace via containment and imports.</description></item>
+    ///   <item><description>Lazy source-scope chain: per-source-POCO upward walk result. The
+    ///   chain is materialised on first encounter of the source and cached for subsequent
+    ///   references rooted at the same source.</description></item>
+    ///   <item><description>Lazy resolved emission: per-<c>(target, sourceLocalScope)</c>
+    ///   pair, the final string to emit (bare simple name, escaped unrestricted name, or full
+    ///   qualified name). Reused on every subsequent reference that hits the same pair.</description></item>
+    /// </list>
+    /// <para>Resolution policy mirrors KerML §8.2.3.5 with two short-circuits:</para>
+    /// <list type="bullet">
+    ///   <item><description><see cref="IMembership"/> targets (import declarations) keep their full
+    ///   qualified path — the path identifies WHAT is being imported.</description></item>
+    ///   <item><description>Chain accessors (the <c>.X</c> of a feature-chain expression / multi-segment
+    ///   feature chain) resolve <c>X</c> against the target's own owning namespace so the bare
+    ///   simple name is emitted, since the parser establishes the resolution scope from the
+    ///   preceding chain segment's type.</description></item>
+    /// </list>
+    /// </summary>
+    public sealed class NameResolutionCache
+    {
+        /// <summary>
+        /// Shared empty index returned for unknown / null namespaces.
+        /// </summary>
+        private static readonly IReadOnlyDictionary<string, HashSet<IElement>> EmptyIndex
+            = new Dictionary<string, HashSet<IElement>>(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Eager structural cache: namespace → (simple-name → member set). Populated once on
+        /// construction by <see cref="BuildSimpleNameIndices" />.
+        /// </summary>
+        private readonly Dictionary<INamespace, IReadOnlyDictionary<string, HashSet<IElement>>> simpleNameIndices;
+
+        /// <summary>
+        /// Lazy upward-walk cache: source-POCO id → containment-chain of <see cref="INamespace" />s
+        /// terminated at the root namespace (or wherever the upward walk first hits an empty
+        /// <c>owningNamespace</c>). Populated by <see cref="GetSourceScopeChain" />.
+        /// </summary>
+        private readonly Dictionary<Guid, IReadOnlyList<INamespace>> sourceScopeChains
+            = new ();
+
+        /// <summary>
+        /// Lazy resolved-emission cache: <c>(target.Id, sourceLocalScope.Id)</c> → emitted string.
+        /// </summary>
+        private readonly Dictionary<(Guid TargetId, Guid SourceScopeId), string> resolvedReferences
+            = new ();
+
+        /// <summary>
+        /// Initializes a new <see cref="NameResolutionCache" /> rooted at
+        /// <paramref name="rootNamespace" /> and eagerly populates the per-namespace simple-name
+        /// index for every namespace reachable from the root.
+        /// </summary>
+        /// <param name="rootNamespace">The root <see cref="INamespace" /> being serialized.</param>
+        public NameResolutionCache(INamespace rootNamespace)
+        {
+            this.RootNamespace = rootNamespace ?? throw new ArgumentNullException(nameof(rootNamespace));
+            this.simpleNameIndices = BuildSimpleNameIndices(rootNamespace);
+        }
+
+        /// <summary>
+        /// Gets the root <see cref="INamespace" /> the cache was rooted at — used as the fallback
+        /// local scope when a source POCO has no resolvable enclosing namespace.
+        /// </summary>
+        public INamespace RootNamespace { get; }
+
+        /// <summary>
+        /// Resolves the textual notation for a reference to <paramref name="target" /> at the
+        /// site of <paramref name="sourcePoco" />. The result is cached by
+        /// <c>(target.Id, sourceLocalScope.Id)</c> — repeat calls with the same pair are O(1)
+        /// dictionary lookups.
+        /// </summary>
+        /// <param name="target">The referenced <see cref="IElement" />; may be <see langword="null" />.</param>
+        /// <param name="sourcePoco">The POCO at whose syntactic position the reference appears.</param>
+        /// <returns>The string to emit; empty when <paramref name="target" /> is <see langword="null" />.</returns>
+        public string Resolve(IElement target, IElement sourcePoco)
+        {
+            switch (target)
+            {
+                case null:
+                    return string.Empty;
+
+                // Short-circuit 1 — IMembership targets: import declarations keep their full path.
+                case IMembership membership:
+                    return membership.MemberElement?.qualifiedName ?? string.Empty;
+            }
+
+            // Short-circuit 2 — no usable simple name on the target: emit the qualified name.
+            var escapedName = target.EscapedName();
+
+            if (string.IsNullOrWhiteSpace(escapedName))
+            {
+                return target.qualifiedName ?? string.Empty;
+            }
+
+            // Short-circuit 3 — chain accessor: the parser establishes the resolution scope
+            // from the preceding chain segment's type at parse time, so the simple name is
+            // sufficient. We do NOT cache this because the chain accessor's resolution is a
+            // function of (target, sourcePoco) — and sourcePoco changes per reference site.
+            // The work is cheap (one type test + EscapedName already computed above).
+            if (IsChainAccessor(sourcePoco))
+            {
+                return ResolveChainAccessor(target, escapedName);
+            }
+
+            // Memoised path — look up by (target.Id, sourceLocalScope.Id).
+            var sourceLocalScope = this.GetSourceLocalScope(sourcePoco);
+            var cacheKey = (target.Id, sourceLocalScope?.Id ?? Guid.Empty);
+
+            if (this.resolvedReferences.TryGetValue(cacheKey, out var cached))
+            {
+                return cached;
+            }
+
+            var resolved = this.ResolveFresh(target, sourcePoco, sourceLocalScope, escapedName);
+            this.resolvedReferences[cacheKey] = resolved;
+            return resolved;
+        }
+
+        /// <summary>
+        /// First-time resolution: walks the cached source-scope chain and probes each scope's
+        /// simple-name index. Falls back to <see cref="IElement.qualifiedName" />.
+        /// </summary>
+        /// <param name="target">The referenced element.</param>
+        /// <param name="sourcePoco">The reference site's source POCO.</param>
+        /// <param name="sourceLocalScope">The previously-computed local scope (may be <see langword="null" />).</param>
+        /// <param name="escapedName">The target's escaped raw <c>name</c>.</param>
+        /// <returns>The resolved emission string.</returns>
+        private string ResolveFresh(IElement target, IElement sourcePoco, INamespace sourceLocalScope, string escapedName)
+        {
+            var rawName = target.name;
+            var rawShortName = target.shortName;
+
+            var escapedShortName = string.IsNullOrWhiteSpace(rawShortName)
+                ? null
+                : (rawShortName.QueryIsValidBasicName() ? rawShortName : rawShortName.ToUnrestrictedName());
+
+            // Walk the cached source-scope chain. First hit wins.
+            foreach (var scope in this.GetSourceScopeChain(sourcePoco, sourceLocalScope))
+            {
+                if (this.TryResolveSimpleNameInScope(scope, target, rawName, escapedName, rawShortName, escapedShortName, out var matched))
+                {
+                    return matched;
+                }
+            }
+
+            // Fall back to the fully-qualified name.
+            return target.qualifiedName ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Returns the resolved simple name for a chain accessor: tries the target's own
+        /// <c>name</c> first, then its <c>shortName</c>. Both go through the same KEBNF
+        /// basic-name / unrestricted-name escape as a non-chain reference.
+        /// </summary>
+        /// <param name="target">The chain-accessor target element.</param>
+        /// <param name="escapedName">The pre-computed escaped <c>name</c> form (long-form preference).</param>
+        /// <returns>The escaped simple name, or <c>target.qualifiedName</c> as a last resort.</returns>
+        private static string ResolveChainAccessor(IElement target, string escapedName)
+        {
+            if (!string.IsNullOrWhiteSpace(target.name))
+            {
+                return escapedName;
+            }
+
+            var rawShortName = target.shortName;
+
+            if (!string.IsNullOrWhiteSpace(rawShortName))
+            {
+                return rawShortName.QueryIsValidBasicName() ? rawShortName : rawShortName.ToUnrestrictedName();
+            }
+
+            return target.qualifiedName ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Returns the per-scope simple-name index that was built eagerly on construction.
+        /// Returns <see cref="EmptyIndex" /> for namespaces the eager pass did not reach.
+        /// </summary>
+        /// <param name="scope">The <see cref="INamespace" /> whose index is requested.</param>
+        /// <returns>The simple-name → member-set lookup.</returns>
+        private IReadOnlyDictionary<string, HashSet<IElement>> GetSimpleNameIndex(INamespace scope)
+        {
+            return scope == null ? EmptyIndex : this.simpleNameIndices.GetValueOrDefault(scope, EmptyIndex);
+        }
+
+        /// <summary>
+        /// Returns the cached upward-walk chain for <paramref name="sourcePoco" />, building it
+        /// on first encounter. The chain starts at <paramref name="sourceLocalScope" /> (the
+        /// reference's local scope) and walks <c>owningNamespace</c> up to the root.
+        /// </summary>
+        /// <param name="sourcePoco">The source POCO bearing the reference; may be <see langword="null" />.</param>
+        /// <param name="sourceLocalScope">The pre-computed local scope (may be <see langword="null" />).</param>
+        /// <returns>The cached chain.</returns>
+        private IReadOnlyList<INamespace> GetSourceScopeChain(IElement sourcePoco, INamespace sourceLocalScope)
+        {
+            if (sourcePoco == null)
+            {
+                return BuildChain(sourceLocalScope ?? this.RootNamespace);
+            }
+
+            if (this.sourceScopeChains.TryGetValue(sourcePoco.Id, out var cached))
+            {
+                return cached;
+            }
+
+            var chain = BuildChain(sourceLocalScope ?? this.RootNamespace);
+            this.sourceScopeChains[sourcePoco.Id] = chain;
+
+            return chain;
+        }
+
+        /// <summary>
+        /// Walks <paramref name="start" /> up via <c>owningNamespace</c> and materialises the
+        /// chain. Stops at the first <c>NotSupportedException</c> or null.
+        /// </summary>
+        /// <param name="start">The starting namespace.</param>
+        /// <returns>The chain.</returns>
+        private static IReadOnlyList<INamespace> BuildChain(INamespace start)
+        {
+            if (start == null)
+            {
+                return [];
+            }
+
+            var chain = new List<INamespace>();
+            var current = start;
+
+            while (current != null)
+            {
+                chain.Add(current);
+
+                INamespace next;
+
+                try
+                {
+                    next = current.owningNamespace;
+                }
+                catch (NotSupportedException)
+                {
+                    break;
+                }
+
+                current = next;
+            }
+
+            return chain;
+        }
+
+        /// <summary>
+        /// Resolves the local scope of <paramref name="sourcePoco" />: the first
+        /// <see cref="INamespace" /> reached by climbing
+        /// <see cref="IRelationship.OwningRelatedElement" />, then
+        /// <see cref="IElement.owningNamespace" />, then <see cref="IElement.owner" />. Falls
+        /// back to <see cref="RootNamespace" /> when nothing is reachable.
+        /// </summary>
+        /// <param name="sourcePoco">The source POCO; may be <see langword="null" />.</param>
+        /// <returns>The local scope or <see cref="RootNamespace" />.</returns>
+        private INamespace GetSourceLocalScope(IElement sourcePoco)
+        {
+            if (sourcePoco == null)
+            {
+                return this.RootNamespace;
+            }
+
+            var visited = new HashSet<IElement>();
+            var current = sourcePoco;
+
+            while (current != null && visited.Add(current))
+            {
+                switch (current)
+                {
+                    case INamespace asNamespace:
+                        return asNamespace;
+                    case IRelationship { OwningRelatedElement: not null } relationship:
+                        current = relationship.OwningRelatedElement;
+                        continue;
+                }
+
+                INamespace owningNs = null;
+
+                try
+                {
+                    owningNs = current.owningNamespace;
+                }
+                catch (NotSupportedException)
+                {
+                    // owningNamespace not implemented — fall through to owner walk.
+                }
+
+                if (owningNs != null)
+                {
+                    return owningNs;
+                }
+
+                IElement nextOwner;
+
+                try
+                {
+                    nextOwner = current.owner;
+                }
+                catch (NotSupportedException)
+                {
+                    nextOwner = null;
+                }
+
+                current = nextOwner;
+            }
+
+            return this.RootNamespace;
+        }
+
+        /// <summary>
+        /// Tests the simple-name index of <paramref name="scope" /> for a hit on
+        /// <paramref name="target" />. Tries the raw <c>name</c> key first, then the raw
+        /// <c>shortName</c> key. On a hit, <paramref name="matchedSimpleName" /> receives the
+        /// corresponding escaped form.
+        /// </summary>
+        /// <param name="scope">The scope whose index is inspected.</param>
+        /// <param name="target">The element to look up.</param>
+        /// <param name="rawName">The target's raw <c>name</c>; may be <see langword="null" /> / whitespace.</param>
+        /// <param name="escapedName">The escaped form emitted on a long-form hit.</param>
+        /// <param name="rawShortName">The target's raw <c>shortName</c>; may be <see langword="null" /> / whitespace.</param>
+        /// <param name="escapedShortName">The escaped form emitted on a short-form hit.</param>
+        /// <param name="matchedSimpleName">On <see langword="true" />, the simple name to emit.</param>
+        /// <returns><see langword="true" /> when a hit was found.</returns>
+        private bool TryResolveSimpleNameInScope(INamespace scope, IElement target, string rawName, string escapedName, string rawShortName, string escapedShortName, out string matchedSimpleName)
+        {
+            var index = this.GetSimpleNameIndex(scope);
+
+            if (!string.IsNullOrWhiteSpace(rawName)
+                && index.TryGetValue(rawName, out var elements)
+                && elements.Contains(target))
+            {
+                matchedSimpleName = escapedName;
+                return true;
+            }
+
+            if (!string.IsNullOrWhiteSpace(rawShortName)
+                && index.TryGetValue(rawShortName, out var shortElements)
+                && shortElements.Contains(target))
+            {
+                matchedSimpleName = escapedShortName;
+                return true;
+            }
+
+            matchedSimpleName = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Determines whether <paramref name="sourcePoco" /> is the right-hand side of a chain
+        /// accessor — see grammar rules <c>FeatureChainExpression</c> (KerML §8.2.4.X) and
+        /// <c>FeatureChain</c> (KerML §8.2.4.3.5). Two patterns match:
+        /// <list type="bullet">
+        ///   <item><description>An <see cref="IMembership" /> sitting as the chain-accessor RHS
+        ///   of a <see cref="IFeatureChainExpression" />.</description></item>
+        ///   <item><description>An <see cref="IFeatureChaining" /> at any index after the FIRST
+        ///   in its container's <c>OwnedRelationship</c> list.</description></item>
+        /// </list>
+        /// </summary>
+        /// <param name="sourcePoco">The source POCO at the reference site.</param>
+        /// <returns><see langword="true" /> when the source is a chain accessor.</returns>
+        private static bool IsChainAccessor(IElement sourcePoco)
+        {
+            if (sourcePoco is IMembership { OwningRelatedElement: IFeatureChainExpression } and not IParameterMembership)
+            {
+                return true;
+            }
+
+            if (sourcePoco is not IFeatureChaining { OwningRelatedElement: IFeature chainOwner } chaining)
+            {
+                return false;
+            }
+
+            var siblings = chainOwner.OwnedRelationship.OfType<IFeatureChaining>().ToList();
+            var index = siblings.IndexOf(chaining);
+            return index > 0;
+        }
+
+        /// <summary>
+        /// Eagerly walks the model rooted at <paramref name="rootNamespace" /> and builds the
+        /// simple-name index for every reachable <see cref="INamespace" />. Reachability follows
+        /// <see cref="INamespace.ownedMembership" />.<see cref="IMembership.MemberElement" /> for
+        /// nested namespaces, plus direct <c>ownedImport</c> targets (so imported namespaces are
+        /// also indexed once).
+        /// </summary>
+        /// <param name="rootNamespace">The root namespace.</param>
+        /// <returns>The full structural cache.</returns>
+        private static Dictionary<INamespace, IReadOnlyDictionary<string, HashSet<IElement>>> BuildSimpleNameIndices(INamespace rootNamespace)
+        {
+            var result = new Dictionary<INamespace, IReadOnlyDictionary<string, HashSet<IElement>>>();
+            var pending = new Queue<INamespace>();
+            var visited = new HashSet<INamespace>();
+
+            pending.Enqueue(rootNamespace);
+
+            while (pending.Count != 0)
+            {
+                var scope = pending.Dequeue();
+
+                if (scope == null || !visited.Add(scope))
+                {
+                    continue;
+                }
+
+                var index = new Dictionary<string, HashSet<IElement>>(StringComparer.Ordinal);
+
+                BuildOwnedAndImportedEntries(scope, index, pending);
+
+                if (scope is IType type)
+                {
+                    BuildInheritedEntries(type, index, pending);
+                }
+
+                result[scope] = index;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Populates <paramref name="index" /> with entries for <paramref name="scope" />'s
+        /// owned memberships and direct imports. Imported namespaces are enqueued onto
+        /// <paramref name="pending" /> so they too are indexed in the eager pass.
+        /// </summary>
+        /// <param name="scope">The namespace whose entries are populated.</param>
+        /// <param name="index">The destination index.</param>
+        /// <param name="pending">Queue of namespaces yet to be indexed.</param>
+        private static void BuildOwnedAndImportedEntries(INamespace scope, Dictionary<string, HashSet<IElement>> index, Queue<INamespace> pending)
+        {
+            try
+            {
+                foreach (var ownedMember in scope.ownedMembership)
+                {
+                    AddMembershipEntry(index, ownedMember, pending);
+                }
+            }
+            catch (NotSupportedException)
+            {
+                // ownedMembership may not be implemented; skip.
+            }
+
+            try
+            {
+                foreach (var ownedImport in scope.ownedImport)
+                {
+                    switch (ownedImport)
+                    {
+                        case IMembershipImport { ImportedMembership: { } importedMembership }:
+                            AddMembershipEntry(index, importedMembership, pending);
+                            break;
+                        case INamespaceImport { ImportedNamespace: not null } namespaceImport:
+                        {
+                            pending.Enqueue(namespaceImport.ImportedNamespace);
+
+                            // Isolate the inner ownedMembership walk in its own try/catch so a
+                            // NotSupportedException from one imported namespace does not abort
+                            // the outer ownedImport loop and lose every remaining import.
+                            try
+                            {
+                                foreach (var importedMember in namespaceImport.ImportedNamespace.ownedMembership)
+                                {
+                                    AddMembershipEntry(index, importedMember, pending);
+                                }
+                            }
+                            catch (NotSupportedException)
+                            {
+                                // ownedMembership not implemented for this imported namespace; skip it.
+                            }
+
+                            break;
+                        }
+                    }
+                }
+            }
+            catch (NotSupportedException)
+            {
+                // ownedImport may not be implemented; skip.
+            }
+        }
+
+        /// <summary>
+        /// Indexes the entries inherited from the transitive supertypes of
+        /// <paramref name="type" />. Bypasses the <c>RemoveRedefinedFeatures</c> filter so
+        /// references such as <c>:&gt;&gt; elements</c> remain reachable.
+        /// </summary>
+        /// <param name="type">The type whose inherited memberships are indexed.</param>
+        /// <param name="index">The destination index.</param>
+        /// <param name="pending">Queue of namespaces yet to be indexed (so supertypes that are
+        /// also namespaces get their own index built).</param>
+        private static void BuildInheritedEntries(IType type, Dictionary<string, HashSet<IElement>> index, Queue<INamespace> pending)
+        {
+            List<IType> supertypes;
+
+            try
+            {
+                supertypes = type.AllSupertypes();
+            }
+            catch (NotSupportedException)
+            {
+                return;
+            }
+
+            foreach (var supertype in supertypes.Where(supertype => supertype != null && !ReferenceEquals(supertype, type)))
+            {
+                if (supertype is INamespace supertypeAsNamespace)
+                {
+                    pending.Enqueue(supertypeAsNamespace);
+                }
+
+                try
+                {
+                    foreach (var ownedMember in supertype.ownedMembership)
+                    {
+                        AddMembershipEntry(index, ownedMember, pending);
+                    }
+                }
+                catch (NotSupportedException)
+                {
+                    // ownedMembership not implemented for this supertype; skip.
+                }
+            }
+        }
+
+        /// <summary>
+        /// Adds the <see cref="IMembership.MemberElement" /> of <paramref name="membership" />
+        /// to <paramref name="index" /> under both its <see cref="IMembership.MemberShortName" />
+        /// and <see cref="IMembership.MemberName" />, and enqueues the target onto
+        /// <paramref name="pending" /> if it is itself an <see cref="INamespace" /> (so nested
+        /// namespaces are indexed too).
+        /// </summary>
+        /// <param name="index">The destination index.</param>
+        /// <param name="membership">The membership whose target is indexed.</param>
+        /// <param name="pending">Queue of namespaces yet to be indexed.</param>
+        private static void AddMembershipEntry(Dictionary<string, HashSet<IElement>> index, IMembership membership, Queue<INamespace> pending)
+        {
+            var target = membership?.MemberElement;
+
+            if (target == null)
+            {
+                return;
+            }
+
+            AddIndexEntry(index, membership.MemberShortName, target);
+            AddIndexEntry(index, membership.MemberName, target);
+
+            if (target is INamespace targetAsNamespace)
+            {
+                pending.Enqueue(targetAsNamespace);
+            }
+        }
+
+        /// <summary>
+        /// Adds <paramref name="element" /> to <paramref name="index" /> under
+        /// <paramref name="simpleName" /> when the name is non-blank.
+        /// </summary>
+        /// <param name="index">The destination index.</param>
+        /// <param name="simpleName">The simple name to use as the index key.</param>
+        /// <param name="element">The element to record under <paramref name="simpleName" />.</param>
+        private static void AddIndexEntry(Dictionary<string, HashSet<IElement>> index, string simpleName, IElement element)
+        {
+            if (string.IsNullOrWhiteSpace(simpleName) || element == null)
+            {
+                return;
+            }
+
+            if (!index.TryGetValue(simpleName, out var bucket))
+            {
+                bucket = [];
+                index[simpleName] = bucket;
+            }
+
+            bucket.Add(element);
+        }
+    }
+}

--- a/SysML2.NET.Serializer.TextualNotation/Writers/OperatorPrecedence.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/OperatorPrecedence.cs
@@ -1,0 +1,279 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="OperatorPrecedence.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Serializer.TextualNotation.Writers
+{
+    using SysML2.NET.Core.POCO.Kernel.Expressions;
+    using SysML2.NET.Core.POCO.Kernel.Functions;
+
+    /// <summary>
+    /// Precedence-aware parenthesization helpers for operator-expression operands.
+    /// <para>
+    /// The KEBNF grammar uses <c>SequenceExpression : Expression = '(' SequenceExpressionList ')'</c>
+    /// as its parenthesization rule, but the SysML metamodel has no <c>SequenceExpression</c>
+    /// class — parens are a grammar-only artifact that collapses to the inner
+    /// <see cref="IOperatorExpression"/> at parse time. When writing back, the textual notation
+    /// writers must therefore decide AT EMISSION TIME whether to wrap a nested operator
+    /// expression in <c>(…)</c>. This class provides the precedence table that drives the
+    /// decision: each operator-expression family / operator gets a precedence level, and
+    /// <see cref="NeedsParenthesesAsOperand"/> returns <c>true</c> when the inner expression
+    /// would be ambiguous without parens.
+    /// </para>
+    /// </summary>
+    internal static class OperatorPrecedence
+    {
+        /// <summary>
+        /// Levels are inferred from the <c>OwnedExpression</c> rule alternative ordering
+        /// in <c>Resources/KerML-textual-bnf.kebnf</c> and tuned to reproduce the
+        /// canonical parenthesization in <c>Resources/Quantities.sysml</c>. Lower = binds
+        /// less tightly.
+        /// </summary>
+        private const int LevelConditional = 1;
+        private const int LevelConditionalBinary = 2;
+        private const int LevelBitwise = 3;
+        private const int LevelEquality = 4;
+        private const int LevelRelational = 5;
+        private const int LevelClassification = 6;
+        private const int LevelAdditive = 7;
+        private const int LevelMultiplicative = 8;
+        private const int LevelPower = 9;
+        private const int LevelUnary = 10;
+        private const int LevelExtent = 11;
+        private const int LevelPrimary = int.MaxValue;
+
+        /// <summary>
+        /// Coarse-grained operator families used by the cross-family wrap rule.
+        /// </summary>
+        private enum PrecedenceBucket
+        {
+            Conditional,
+            Binary,
+            Classification,
+            Unary,
+            Extent,
+            Primary,
+        }
+
+        /// <summary>
+        /// Returns the precedence level of <paramref name="expression"/>. Lower = binds less
+        /// tightly. Primary forms (literals, feature references, invocations, etc.) return
+        /// <see cref="int.MaxValue"/> — they are self-contained and never need wrapping.
+        /// </summary>
+        /// <param name="expression">The expression to classify, or <c>null</c>.</param>
+        /// <returns>The precedence level.</returns>
+        internal static int GetExpressionPrecedence(IExpression expression)
+        {
+            // Order matters in the metamodel inheritance chain:
+            //   IExpression ← IInstantiationExpression ← IInvocationExpression ← IOperatorExpression ← {IFeatureChainExpression, IIndexExpression, ICollectExpression, ISelectExpression}.
+            // Several "primary forms" (member-access `.`, index `[..]`, collect `.`,
+            // select `.?`) are technically IOperatorExpression-typed in the metamodel
+            // but render as self-contained tokens — they must be classified as primary
+            // BEFORE the generic IOperatorExpression check.
+            if (expression is IFeatureChainExpression
+                || expression is IIndexExpression
+                || expression is ICollectExpression
+                || expression is ISelectExpression)
+            {
+                return LevelPrimary;
+            }
+
+            if (expression is IOperatorExpression op)
+            {
+                // BracketExpression (`[`) and SequenceOperatorExpression (`,`) are
+                // OperatorExpression-typed metamodel-wise but render as primary forms
+                // (`a[…]`, `(a, b)`). They are distinguished by their `operator`
+                // discriminator; no separate interface exists.
+                if (op.Operator is "[" or ",")
+                {
+                    return LevelPrimary;
+                }
+
+                return GetOperatorExpressionPrecedence(op);
+            }
+
+            // Non-operator-expression primary forms (literals, references, invocations,
+            // etc.) are always self-contained tokens.
+            if (expression is IInvocationExpression
+                || expression is IFeatureReferenceExpression
+                || expression is IMetadataAccessExpression
+                || expression is INullExpression
+                || expression is ILiteralExpression
+                || expression is IConstructorExpression)
+            {
+                return LevelPrimary;
+            }
+
+            return LevelPrimary;
+        }
+
+        /// <summary>
+        /// Returns the precedence level of an <see cref="IOperatorExpression"/> based on
+        /// its <c>Operator</c> discriminator.
+        /// </summary>
+        /// <param name="op">The operator expression.</param>
+        /// <returns>The precedence level.</returns>
+        private static int GetOperatorExpressionPrecedence(IOperatorExpression op)
+        {
+            var @operator = op.Operator;
+
+            if (@operator == "if")
+            {
+                return LevelConditional;
+            }
+
+            if (@operator is "or" or "and" or "implies" or "??")
+            {
+                return LevelConditionalBinary;
+            }
+
+            if (@operator is "|" or "&" or "xor")
+            {
+                return LevelBitwise;
+            }
+
+            if (@operator is "==" or "!=" or "===" or "!==")
+            {
+                return LevelEquality;
+            }
+
+            if (@operator is "<" or ">" or "<=" or ">=" or "..")
+            {
+                return LevelRelational;
+            }
+
+            if (@operator is "as" or "istype" or "hastype" or "@" or "@@" or "meta")
+            {
+                return LevelClassification;
+            }
+
+            if (@operator is "*" or "/" or "%")
+            {
+                return LevelMultiplicative;
+            }
+
+            if (@operator is "^" or "**")
+            {
+                return LevelPower;
+            }
+
+            if (@operator is "+" or "-")
+            {
+                // + and - are both binary (additive) and unary (sign). Distinguish by the
+                // count of argument-member relationships on the operator expression: two
+                // means additive (LHS + RHS); fewer means unary (sign).
+                return HasTwoArguments(op) ? LevelAdditive : LevelUnary;
+            }
+
+            if (@operator is "~" or "not")
+            {
+                return LevelUnary;
+            }
+
+            if (@operator == "all")
+            {
+                return LevelExtent;
+            }
+
+            // Unknown operator: treat as unary-level (conservative — wraps when nested).
+            return LevelUnary;
+        }
+
+        /// <summary>
+        /// Determines whether <paramref name="operand"/> needs to be wrapped in
+        /// <c>(…)</c> when it appears as an operand of <paramref name="outer"/>. The rule:
+        /// cross-family nesting always wraps (binary inside conditional, etc.); same-family
+        /// nesting wraps only when the inner has same-or-lower precedence than the outer.
+        /// </summary>
+        /// <param name="outer">The enclosing operator expression.</param>
+        /// <param name="operand">The candidate operand expression.</param>
+        /// <returns><c>true</c> when parens are required for unambiguous rendering.</returns>
+        internal static bool NeedsParenthesesAsOperand(IExpression outer, IExpression operand)
+        {
+            if (operand == null || outer == null)
+            {
+                return false;
+            }
+
+            var innerPrecedence = GetExpressionPrecedence(operand);
+
+            if (innerPrecedence == LevelPrimary)
+            {
+                return false;
+            }
+
+            var outerPrecedence = GetExpressionPrecedence(outer);
+
+            var innerBucket = GetBucket(innerPrecedence);
+            var outerBucket = GetBucket(outerPrecedence);
+
+            if (innerBucket != outerBucket)
+            {
+                return true;
+            }
+
+            return innerPrecedence <= outerPrecedence;
+        }
+
+        /// <summary>
+        /// Counts the IOperatorExpression's argument-members to distinguish binary additive
+        /// (<c>a + b</c>) from unary sign (<c>+ a</c>). Two argument-members indicate the
+        /// binary form.
+        /// </summary>
+        /// <param name="op">The operator expression.</param>
+        /// <returns><c>true</c> when at least two argument-members are present.</returns>
+        private static bool HasTwoArguments(IOperatorExpression op)
+        {
+            var count = 0;
+
+            foreach (var relationship in op.OwnedRelationship)
+            {
+                if (relationship is SysML2.NET.Core.POCO.Kernel.Behaviors.IParameterMembership)
+                {
+                    count++;
+
+                    if (count >= 2)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Maps a precedence level to its coarse-grained operator family bucket.
+        /// </summary>
+        /// <param name="precedence">The precedence level.</param>
+        /// <returns>The bucket.</returns>
+        private static PrecedenceBucket GetBucket(int precedence)
+        {
+            return precedence switch
+            {
+                LevelConditional or LevelConditionalBinary => PrecedenceBucket.Conditional,
+                LevelBitwise or LevelEquality or LevelRelational or LevelAdditive or LevelMultiplicative or LevelPower => PrecedenceBucket.Binary,
+                LevelClassification => PrecedenceBucket.Classification,
+                LevelUnary => PrecedenceBucket.Unary,
+                LevelExtent => PrecedenceBucket.Extent,
+                _ => PrecedenceBucket.Primary,
+            };
+        }
+    }
+}

--- a/SysML2.NET.Serializer.TextualNotation/Writers/OperatorPrecedence.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/OperatorPrecedence.cs
@@ -223,6 +223,15 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
             var innerBucket = GetBucket(innerPrecedence);
             var outerBucket = GetBucket(outerPrecedence);
 
+            // Unary prefix operators (`~`, `not`, unary `+`/`-`) bind tighter than any binary
+            // operator and have no LHS to confuse with — they are unambiguous as operands and
+            // never need parenthesization, even when crossing operator-family buckets. E.g.
+            // `not a and b` re-parses unambiguously as `(not a) and b`.
+            if (innerBucket == PrecedenceBucket.Unary)
+            {
+                return false;
+            }
+
             if (innerBucket != outerBucket)
             {
                 return true;

--- a/SysML2.NET.Serializer.TextualNotation/Writers/SharedTextualNotationBuilder.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/SharedTextualNotationBuilder.cs
@@ -21,19 +21,21 @@
 namespace SysML2.NET.Serializer.TextualNotation.Writers
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
     using System.Text;
 
     using SysML2.NET.Core.POCO.Core.Features;
     using SysML2.NET.Core.POCO.Core.Types;
+    using SysML2.NET.Core.POCO.Kernel.Behaviors;
     using SysML2.NET.Core.POCO.Kernel.Expressions;
+    using SysML2.NET.Core.POCO.Kernel.FeatureValues;
     using SysML2.NET.Core.POCO.Kernel.Functions;
     using SysML2.NET.Core.POCO.Kernel.Interactions;
     using SysML2.NET.Core.POCO.Root.Elements;
     using SysML2.NET.Core.POCO.Root.Namespaces;
     using SysML2.NET.Core.POCO.Systems.DefinitionAndUsage;
     using SysML2.NET.Core.POCO.Systems.Metadata;
+    using SysML2.NET.Extensions;
 
     /// <summary>
     /// Hand-coded part of the <see cref="SharedTextualNotationBuilder" />.
@@ -545,6 +547,28 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         }
 
         /// <summary>
+        /// Appends a name token in its textual-notation form: emit the raw identifier when it
+        /// satisfies the KEBNF basic-name production (and is not a reserved keyword), otherwise
+        /// emit the unrestricted-name form (single-quoted, with internal special characters
+        /// escaped per Section 8.2.2.3 of the KerML specification).
+        /// <para>This helper is intended for code-generated assignments of the form
+        /// <c>property = NAME</c> (e.g. <c>declaredName</c>, <c>declaredShortName</c>), where
+        /// the raw string is stored on the POCO but the emitted token must respect the
+        /// lexical-rule constraints of the grammar.</para>
+        /// </summary>
+        /// <param name="stringBuilder">The <see cref="StringBuilder"/> to append to</param>
+        /// <param name="name">The raw name string as stored on the POCO; <see langword="null"/> or whitespace is a no-op</param>
+        internal static void AppendName(StringBuilder stringBuilder, string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return;
+            }
+
+            stringBuilder.Append(name.QueryIsValidBasicName() ? name : name.ToUnrestrictedName());
+        }
+
+        /// <summary>
         /// Appends a body text formatted as a REGULAR_COMMENT (<c>/* ... */</c>).
         /// <para>The grammar defines <c>REGULAR_COMMENT = '/*' COMMENT_TEXT '*/'</c>.
         /// During parsing, the <c>/*</c> and <c>*/</c> delimiters are stripped and each
@@ -555,6 +579,8 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         /// <param name="body">The body text to format as a REGULAR_COMMENT</param>
         internal static void AppendRegularComment(StringBuilder stringBuilder, string body)
         {
+            stringBuilder.AppendLine();
+            
             if (string.IsNullOrWhiteSpace(body))
             {
                 stringBuilder.AppendLine("/* */");
@@ -588,23 +614,21 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         /// Appends the shortest resolvable name of the <paramref name="target"/>
         /// <see cref="IElement"/> for the textual notation, per KerML specification section
         /// 8.2.3.5.
-        /// <para>The local scope of the reference is derived as
-        /// <c>sourcePoco?.owningNamespace ?? writerContext.ContextNamespace</c>. The resolver
-        /// walks <em>up</em> from that local scope through each containing namespace, asking
-        /// the per-scope simple-name index cached on <paramref name="writerContext"/> whether
-        /// the target's <see cref="IElement.EscapedName"/> resolves locally. The first hit
-        /// wins. If no scope along the chain resolves the simple name to the target, the full
-        /// <see cref="IElement.qualifiedName"/> is emitted as a fallback.</para>
-        /// <para>Membership references in import declarations bypass shortening — the path
-        /// identifies WHAT is imported and must remain fully qualified.</para>
+        /// <para>This method is a thin facade over
+        /// <see cref="NameResolutionCache.Resolve" /> on the writer context's
+        /// <see cref="TextualNotationWriterContext.NameResolutionCache" />. The cache owns all
+        /// resolution state: the eager per-namespace simple-name indices, the lazy
+        /// source-POCO scope chains, and the lazy memoised resolved-emission strings. Repeated
+        /// references to the same <c>(target, source-scope)</c> pair are returned from the
+        /// memo without re-walking any chain.</para>
         /// </summary>
         /// <param name="stringBuilder">The <see cref="StringBuilder"/> to append to</param>
         /// <param name="target">The referenced <see cref="IElement"/> whose name is appended</param>
-        /// <param name="writerContext">The <see cref="TextualNotationWriterContext"/> providing the cache + root</param>
+        /// <param name="writerContext">The <see cref="TextualNotationWriterContext"/> providing the cache</param>
         /// <param name="sourcePoco">
         /// The <see cref="IElement"/> at whose syntactic position the reference appears (typically the
-        /// relationship POCO whose property is being unparsed). Its <c>owningNamespace</c> is the
-        /// local scope of the reference. Pass the enclosing-builder's <c>poco</c> at every call site.
+        /// relationship POCO whose property is being unparsed). Its local scope drives the
+        /// memoisation key. Pass the enclosing-builder's <c>poco</c> at every call site.
         /// </param>
         internal static void AppendQualifiedName(StringBuilder stringBuilder, IElement target, TextualNotationWriterContext writerContext, IElement sourcePoco)
         {
@@ -613,126 +637,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
                 return;
             }
 
-            if (target is IMembership membership)
-            {
-                // Membership references (used in import declarations) must retain
-                // their full qualified name — the path identifies WHAT is being imported.
-                stringBuilder.Append(membership.MemberElement?.qualifiedName);
-                return;
-            }
-
-            var simpleName = target.EscapedName();
-
-            if (string.IsNullOrWhiteSpace(simpleName))
-            {
-                stringBuilder.Append(target.qualifiedName ?? string.Empty);
-                return;
-            }
-
-            var scope = QueryLocalScope(sourcePoco) ?? writerContext?.ContextNamespace;
-
-            while (scope != null)
-            {
-                var index = writerContext.GetOrBuildSimpleNameIndex(scope);
-
-                if (index.TryGetValue(simpleName, out var elements) && elements.Contains(target))
-                {
-                    stringBuilder.Append(simpleName);
-                    return;
-                }
-
-                INamespace nextScope;
-
-                try
-                {
-                    nextScope = scope.owningNamespace;
-                }
-                catch (NotSupportedException)
-                {
-                    // owningNamespace not implemented for this scope — stop the upward walk
-                    // and fall through to the qualifiedName fallback below.
-                    break;
-                }
-
-                scope = nextScope;
-            }
-
-            stringBuilder.Append(target.qualifiedName ?? string.Empty);
-        }
-
-        /// <summary>
-        /// Returns the local <see cref="INamespace"/> where a reference rooted at
-        /// <paramref name="sourcePoco"/> syntactically appears, by climbing the source's
-        /// containment chain until a Namespace is reached.
-        /// <para>The chain is followed in this priority order at each hop:</para>
-        /// <list type="number">
-        ///   <item><description>The current element itself, if it is already an <see cref="INamespace"/>.</description></item>
-        ///   <item><description>The <see cref="IRelationship.OwningRelatedElement"/> when the
-        ///   current element is an <see cref="IRelationship"/>. Required for relationship POCOs
-        ///   such as <see cref="IRedefinition"/> / <see cref="ISubsetting"/> / <see cref="IFeatureTyping"/>
-        ///   whose <see cref="IElement.owningNamespace"/> is null because they are owned via
-        ///   <c>ownedRelationship</c>, not via a membership.</description></item>
-        ///   <item><description><see cref="IElement.owningNamespace"/> when non-null.</description></item>
-        ///   <item><description><see cref="IElement.owner"/> as a final fallback.</description></item>
-        /// </list>
-        /// <para>A visited set guards against accidental cycles in malformed models.</para>
-        /// </summary>
-        /// <param name="sourcePoco">The source <see cref="IElement"/> bearing the reference, or <see langword="null"/>.</param>
-        /// <returns>The local <see cref="INamespace"/>, or <see langword="null"/> when none can be derived.</returns>
-        private static INamespace QueryLocalScope(IElement sourcePoco)
-        {
-            if (sourcePoco == null)
-            {
-                return null;
-            }
-
-            var visited = new HashSet<IElement>();
-            var current = sourcePoco;
-
-            while (current != null && visited.Add(current))
-            {
-                if (current is INamespace asNamespace)
-                {
-                    return asNamespace;
-                }
-
-                if (current is IRelationship relationship && relationship.OwningRelatedElement != null)
-                {
-                    current = relationship.OwningRelatedElement;
-                    continue;
-                }
-
-                INamespace owningNs = null;
-
-                try
-                {
-                    owningNs = current.owningNamespace;
-                }
-                catch (NotSupportedException)
-                {
-                    // owningNamespace not implemented — fall through to owner walk.
-                }
-
-                if (owningNs != null)
-                {
-                    return owningNs;
-                }
-
-                IElement nextOwner = null;
-
-                try
-                {
-                    nextOwner = current.owner;
-                }
-                catch (NotSupportedException)
-                {
-                    nextOwner = null;
-                }
-
-                current = nextOwner;
-            }
-
-            return null;
+            stringBuilder.Append(writerContext.NameResolutionCache.Resolve(target, sourcePoco));
         }
     }
 }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/TextualNotationValidationExtensions.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/TextualNotationValidationExtensions.cs
@@ -30,6 +30,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
     using SysML2.NET.Core.POCO.Kernel.Connectors;
     using SysML2.NET.Core.POCO.Kernel.Expressions;
     using SysML2.NET.Core.POCO.Kernel.Functions;
+    using SysML2.NET.Core.POCO.Kernel.Interactions;
     using SysML2.NET.Core.POCO.Root.Elements;
     using SysML2.NET.Core.POCO.Root.Namespaces;
     using SysML2.NET.Core.POCO.Systems.Actions;
@@ -229,16 +230,8 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         internal static bool IsValidForBehaviorUsageMember(this IFeatureMembership featureMembership, TextualNotationWriterContext writerContext)
         {
             return featureMembership?.OwnedRelatedElement.Any(element =>
-                (element is IActionUsage or IStateUsage or IConstraintUsage
-                    or IRequirementUsage or ICaseUsage)
-                && element is not IControlNode
-                && element is not ISendActionUsage
-                && element is not IAcceptActionUsage
-                && element is not IAssignmentActionUsage
-                && element is not ITerminateActionUsage
-                && element is not IIfActionUsage
-                && element is not ILoopActionUsage
-                && element is not ITransitionUsage) == true;
+                (element is (IActionUsage or IStateUsage or IConstraintUsage
+                    or IRequirementUsage or ICaseUsage) and not IControlNode and not ISendActionUsage and not IAcceptActionUsage and not IAssignmentActionUsage and not ITerminateActionUsage and not IIfActionUsage and not ILoopActionUsage and not ITransitionUsage)) == true;
         }
 
         /// <summary>
@@ -310,11 +303,9 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         /// <returns>True if the usage is a structural-usage metaclass (and not a behavior-usage subtype routed by a sibling rule)</returns>
         internal static bool IsValidForStructureUsageElement(this IUsage usage, TextualNotationWriterContext writerContext)
         {
-            return (usage is IOccurrenceUsage or IItemUsage or IPartUsage or IViewUsage
-                    or IRenderingUsage or IPortUsage or IConnectionUsage or IInterfaceUsage
-                    or IAllocationUsage or IFlowUsage)
-                && usage is not IConstraintUsage
-                && (usage is not IActionUsage || usage is IFlowUsage);
+            return (usage is (IOccurrenceUsage or IItemUsage or IPartUsage or IViewUsage
+                or IRenderingUsage or IPortUsage or IConnectionUsage or IInterfaceUsage
+                or IAllocationUsage or IFlowUsage) and not IConstraintUsage and (not IActionUsage or IFlowUsage));
         }
 
         /// <summary>
@@ -334,12 +325,7 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         /// <returns>True if the usage is a plain occurrence (no individual, no portion kind, and not routed by a more specific sibling rule)</returns>
         internal static bool IsValidForOccurrenceUsage(this IOccurrenceUsage occurrenceUsage, TextualNotationWriterContext writerContext)
         {
-            return occurrenceUsage is { IsIndividual: false, PortionKind: null }
-                && occurrenceUsage is not IItemUsage
-                && occurrenceUsage is not IPortUsage
-                && occurrenceUsage is not IActionUsage
-                && occurrenceUsage is not IConstraintUsage
-                && occurrenceUsage is not IEventOccurrenceUsage;
+            return occurrenceUsage is { IsIndividual: false, PortionKind: null } and not IItemUsage and not IPortUsage and not IActionUsage and not IConstraintUsage and not IEventOccurrenceUsage;
         }
 
         /// <summary>

--- a/SysML2.NET.Serializer.TextualNotation/Writers/TextualNotationValidationExtensions.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/TextualNotationValidationExtensions.cs
@@ -278,6 +278,59 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         }
 
         /// <summary>
+        /// Asserts that the <see cref="IUsage"/> is valid for the NonOccurrenceUsageElement rule.
+        /// <para><c>NonOccurrenceUsageElement : Usage = DefaultReferenceUsage | ReferenceUsage |
+        /// AttributeUsage | EnumerationUsage | BindingConnectorAsUsage | SuccessionAsUsage | ExtendedUsage</c></para>
+        /// <para>None of these alternatives target <see cref="IOccurrenceUsage"/> or its
+        /// subclasses. The sibling rule <c>OccurrenceUsageElement</c> handles
+        /// <see cref="IOccurrenceUsage"/> instances (items, parts, actions, etc.). Thus the
+        /// runtime discriminator is purely class-based: anything that is NOT an
+        /// <see cref="IOccurrenceUsage"/> flows to the non-occurrence branch.</para>
+        /// </summary>
+        /// <param name="usage">The <see cref="IUsage"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
+        /// <returns>True if the usage is not an <see cref="IOccurrenceUsage"/></returns>
+        internal static bool IsValidForNonOccurrenceUsageElement(this IUsage usage, TextualNotationWriterContext writerContext)
+        {
+            return usage is not IOccurrenceUsage;
+        }
+
+        /// <summary>
+        /// Asserts that the <see cref="IReferenceUsage"/> is valid for the DefaultReferenceUsage rule.
+        /// <para><c>DefaultReferenceUsage : ReferenceUsage = RefPrefix Usage</c> — the form
+        /// WITHOUT the <c>'ref'</c> keyword.</para>
+        /// <para><c>ReferenceUsage = ( EndUsagePrefix | RefPrefix ) 'ref' Usage</c> — the form
+        /// WITH the <c>'ref'</c> keyword, which sets <see cref="IUsage.IsReference"/> to <c>true</c>
+        /// via <c>BasicUsagePrefix</c>'s <c>isReference ?= 'ref'</c>.</para>
+        /// <para>Distinguishes the two by the <see cref="IUsage.IsReference"/> property:
+        /// <c>!IsReference</c> means no <c>'ref'</c> keyword → default form.</para>
+        /// </summary>
+        /// <param name="referenceUsage">The <see cref="IReferenceUsage"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
+        /// <returns>True if the reference usage has no <c>'ref'</c> keyword (i.e. default form)</returns>
+        internal static bool IsValidForDefaultReferenceUsage(this IReferenceUsage referenceUsage, TextualNotationWriterContext writerContext)
+        {
+            return !referenceUsage.isReference;
+        }
+
+        /// <summary>
+        /// Asserts that the <see cref="IReferenceUsage"/> is valid for the VariantReference rule.
+        /// <para><c>VariantReference : ReferenceUsage = ownedRelationship += OwnedReferenceSubsetting
+        /// FeatureSpecialization* UsageBody</c> — a reference-usage form that carries an owned
+        /// <see cref="IReferenceSubsetting"/> in its relationships.</para>
+        /// <para>The sibling alternative <c>ReferenceUsage = ( EndUsagePrefix | RefPrefix ) 'ref' Usage</c>
+        /// does not produce an <see cref="IReferenceSubsetting"/> at the reference-usage's own
+        /// relationship level, so the presence of one discriminates the variant form.</para>
+        /// </summary>
+        /// <param name="referenceUsage">The <see cref="IReferenceUsage"/></param>
+        /// <param name="writerContext">The active <see cref="TextualNotationWriterContext"/> (unused for this guard)</param>
+        /// <returns>True if the reference usage has an owned <see cref="IReferenceSubsetting"/></returns>
+        internal static bool IsValidForVariantReference(this IReferenceUsage referenceUsage, TextualNotationWriterContext writerContext)
+        {
+            return referenceUsage.OwnedRelationship.OfType<IReferenceSubsetting>().Any();
+        }
+
+        /// <summary>
         /// Asserts that the <see cref="IUsage"/> is valid for the StructureUsageElement rule.
         /// <para><c>StructureUsageElement : Usage = OccurrenceUsage | IndividualUsage | PortionUsage
         /// | EventOccurrenceUsage | ItemUsage | PartUsage | ViewUsage | RenderingUsage | PortUsage

--- a/SysML2.NET.Serializer.TextualNotation/Writers/TextualNotationWriterContext.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/TextualNotationWriterContext.cs
@@ -52,7 +52,24 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
             this.ContextNamespace = contextNamespace ?? throw new ArgumentNullException(nameof(contextNamespace));
             this.NameResolutionCache = new NameResolutionCache(contextNamespace);
             this.OperatorContextStack = new Stack<IExpression>();
+            this.EmitOperatorParentheses = true;
         }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the writer should emit precedence-aware
+        /// parentheses around operator-expression operands. Defaults to <c>true</c>, which
+        /// produces the spec-canonical form (KerML §8.2.5.8.1 / SysML §8.4.3.2) where
+        /// nested operator expressions are wrapped in <c>(…)</c> to guarantee round-trip
+        /// fidelity against the precedence-climbing parser.
+        /// <para>
+        /// Set to <c>false</c> to suppress the writer-side disambiguation parens entirely.
+        /// The resulting output is more compact and matches the idiomatic shorthand used
+        /// throughout the SysML tutorials (e.g. <c>a and b or c</c>), but a model whose
+        /// operand nesting does not align with the parser's default precedence ordering may
+        /// re-parse to a structurally-different AST in that mode.
+        /// </para>
+        /// </summary>
+        public bool EmitOperatorParentheses { get; set; }
 
         /// <summary>
         /// Gets the stack of currently-active enclosing operator expressions. The textual

--- a/SysML2.NET.Serializer.TextualNotation/Writers/TextualNotationWriterContext.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/TextualNotationWriterContext.cs
@@ -21,44 +21,34 @@
 namespace SysML2.NET.Serializer.TextualNotation.Writers
 {
     using System;
-    using System.Collections.Generic;
 
-    using SysML2.NET.Core.POCO.Core.Features;
-    using SysML2.NET.Core.POCO.Core.Types;
-    using SysML2.NET.Core.POCO.Root.Elements;
     using SysML2.NET.Core.POCO.Root.Namespaces;
 
     /// <summary>
-    /// Provides the serialization context for the textual notation builders.
-    /// Carries the <see cref="ICursorCache"/> for cursor-based element traversal,
-    /// the <see cref="INamespace"/> context for qualified name resolution (KerML 8.2.3.5),
-    /// a per-namespace simple-name index cache used by
-    /// <see cref="SharedTextualNotationBuilder.AppendQualifiedName"/>, and future writer
-    /// settings (indentation, short/long notation preferences, etc.).
+    /// Provides the serialization context for the textual notation builders. Carries the
+    /// <see cref="ICursorCache"/> for cursor-based element traversal, the root
+    /// <see cref="INamespace"/> being serialized, and the <see cref="NameResolutionCache"/>
+    /// that owns all name-resolution state used by
+    /// <see cref="SharedTextualNotationBuilder.AppendQualifiedName"/>.
     /// </summary>
     public class TextualNotationWriterContext : IDisposable
     {
         /// <summary>
-        /// Lazily-populated per-namespace simple-name index. For each <see cref="INamespace"/>
-        /// scope previously queried, maps each visible simple name (member shortName / name)
-        /// to the set of <see cref="IElement"/>s reachable by that simple name from that scope.
-        /// Built on demand in <see cref="GetOrBuildSimpleNameIndex"/>.
-        /// </summary>
-        private readonly Dictionary<INamespace, Dictionary<string, HashSet<IElement>>> simpleNameIndex
-            = new Dictionary<INamespace, Dictionary<string, HashSet<IElement>>>();
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="TextualNotationWriterContext"/> class.
+        /// Eagerly builds the per-namespace simple-name index for every namespace reachable
+        /// from <paramref name="contextNamespace"/> via owned-relationship containment and
+        /// direct imports.
         /// </summary>
         /// <param name="contextNamespace">
         /// The root <see cref="INamespace"/> being serialized. Used as the upper-bound of the
-        /// upward-walk in <see cref="SharedTextualNotationBuilder.AppendQualifiedName"/>, and
-        /// as the fallback local scope when a source POCO has no <c>owningNamespace</c>.
+        /// upward-walk in qualified name resolution per KerML §8.2.3.5 and as the fallback
+        /// local scope when a source POCO has no <c>owningNamespace</c>.
         /// </param>
         public TextualNotationWriterContext(INamespace contextNamespace)
         {
             this.CursorCache = new CursorCache();
             this.ContextNamespace = contextNamespace ?? throw new ArgumentNullException(nameof(contextNamespace));
+            this.NameResolutionCache = new NameResolutionCache(contextNamespace);
         }
 
         /// <summary>
@@ -67,53 +57,17 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         public ICursorCache CursorCache { get; }
 
         /// <summary>
-        /// Gets the root <see cref="INamespace"/> being serialized, providing the
-        /// upper bound for the upward-walk performed in qualified name resolution
-        /// per KerML specification section 8.2.3.5.
+        /// Gets the root <see cref="INamespace"/> being serialized, providing the upper bound
+        /// for the upward-walk performed in qualified name resolution per KerML §8.2.3.5.
         /// </summary>
         public INamespace ContextNamespace { get; }
 
         /// <summary>
-        /// Returns the cached simple-name index for the given <paramref name="scope"/>, building
-        /// it on first access. The index maps every simple name that resolves locally in
-        /// <paramref name="scope"/> to the set of <see cref="IElement"/>s reachable by that
-        /// simple name. The set covers:
-        /// <list type="bullet">
-        ///   <item><description>Owned memberships (<c>scope.ownedMembership</c>).</description></item>
-        ///   <item><description>Direct imports (<c>scope.ownedImport</c>) — both <c>IMembershipImport</c>
-        ///   and <c>INamespaceImport</c>.</description></item>
-        ///   <item><description>Inherited feature memberships when <paramref name="scope"/> is an
-        ///   <c>IType</c>, by walking <c>type.featureMembership</c> (which already unions owned
-        ///   and inherited per <c>TypeExtensions.ComputeFeatureMembership</c>).</description></item>
-        /// </list>
+        /// Gets the <see cref="NameResolutionCache"/> that owns all name-resolution state for
+        /// this serialization context: eager per-namespace simple-name indices, lazy
+        /// source-POCO scope chains, and lazy memoised resolved-emission strings.
         /// </summary>
-        /// <param name="scope">The <see cref="INamespace"/> whose simple-name index is requested.</param>
-        /// <returns>The simple-name → <see cref="IElement"/> set lookup for <paramref name="scope"/>.</returns>
-        internal IReadOnlyDictionary<string, HashSet<IElement>> GetOrBuildSimpleNameIndex(INamespace scope)
-        {
-            if (scope == null)
-            {
-                return EmptyIndex;
-            }
-
-            if (this.simpleNameIndex.TryGetValue(scope, out var cached))
-            {
-                return cached;
-            }
-
-            var index = new Dictionary<string, HashSet<IElement>>(StringComparer.Ordinal);
-
-            BuildOwnedAndImportedEntries(scope, index);
-
-            if (scope is IType type)
-            {
-                BuildInheritedEntries(type, index);
-            }
-
-            this.simpleNameIndex[scope] = index;
-
-            return index;
-        }
+        public NameResolutionCache NameResolutionCache { get; }
 
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting
@@ -122,160 +76,6 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
         public void Dispose()
         {
             this.CursorCache.Dispose();
-        }
-
-        /// <summary>
-        /// Single shared empty result returned by <see cref="GetOrBuildSimpleNameIndex"/> when
-        /// the requested scope is <see langword="null"/>.
-        /// </summary>
-        private static readonly IReadOnlyDictionary<string, HashSet<IElement>> EmptyIndex
-            = new Dictionary<string, HashSet<IElement>>(StringComparer.Ordinal);
-
-        /// <summary>
-        /// Adds entries for <paramref name="scope"/>'s <c>ownedMembership</c> and direct
-        /// <c>ownedImport</c>s into <paramref name="index"/>. Handles both
-        /// <see cref="IMembershipImport"/> and <see cref="INamespaceImport"/>; for the latter,
-        /// the imported namespace's <c>ownedMembership</c> entries are projected into the index
-        /// keyed by the member-relative names exposed by the import.
-        /// </summary>
-        /// <param name="scope">The namespace whose owned + imported members are indexed.</param>
-        /// <param name="index">The destination index to populate.</param>
-        private static void BuildOwnedAndImportedEntries(INamespace scope, Dictionary<string, HashSet<IElement>> index)
-        {
-            try
-            {
-                foreach (var ownedMember in scope.ownedMembership)
-                {
-                    AddMembershipEntry(index, ownedMember);
-                }
-            }
-            catch (NotSupportedException)
-            {
-                // ownedMembership may not be implemented for this namespace; skip.
-            }
-
-            try
-            {
-                foreach (var ownedImport in scope.ownedImport)
-                {
-                    if (ownedImport is IMembershipImport membershipImport
-                        && membershipImport.ImportedMembership is IMembership importedMembership)
-                    {
-                        AddMembershipEntry(index, importedMembership);
-                    }
-                    else if (ownedImport is INamespaceImport namespaceImport
-                             && namespaceImport.ImportedNamespace != null)
-                    {
-                        foreach (var importedMember in namespaceImport.ImportedNamespace.ownedMembership)
-                        {
-                            AddMembershipEntry(index, importedMember);
-                        }
-                    }
-                }
-            }
-            catch (NotSupportedException)
-            {
-                // ownedImport / ImportedMemberships may not be implemented; skip.
-            }
-        }
-
-        /// <summary>
-        /// Adds entries for inherited memberships of <paramref name="type"/> into
-        /// <paramref name="index"/>, keyed by each inherited <see cref="IMembership"/>'s
-        /// <c>MemberShortName</c> / <c>MemberName</c> and mapped to its <c>MemberElement</c>.
-        /// <para>Walks the transitive supertype graph (via <c>AllSupertypes</c>) and indexes
-        /// each supertype's own <c>ownedMembership</c> entries directly. This is
-        /// intentionally <em>different</em> from
-        /// <c>TypeExtensions.ComputeInheritedMembership</c>: that operation runs the
-        /// <c>RemoveRedefinedFeatures</c> filter (which strips inherited Features that have
-        /// been redefined by the local Type), so references such as <c>:&gt;&gt; elements</c>
-        /// — whose very purpose is to redefine <c>elements</c> — would be excluded by name
-        /// resolution that relied on it. For name-resolution purposes the redefined target
-        /// MUST stay reachable, so we bypass that filter and index the raw owned memberships
-        /// of every transitive supertype.</para>
-        /// </summary>
-        /// <param name="type">The type whose transitive-supertype memberships are indexed.</param>
-        /// <param name="index">The destination index to populate.</param>
-        private static void BuildInheritedEntries(IType type, Dictionary<string, HashSet<IElement>> index)
-        {
-            List<IType> supertypes;
-
-            try
-            {
-                supertypes = type.AllSupertypes();
-            }
-            catch (NotSupportedException)
-            {
-                return;
-            }
-
-            foreach (var supertype in supertypes)
-            {
-                if (supertype == null || ReferenceEquals(supertype, type))
-                {
-                    continue;
-                }
-
-                try
-                {
-                    foreach (var ownedMember in supertype.ownedMembership)
-                    {
-                        AddMembershipEntry(index, ownedMember);
-                    }
-                }
-                catch (NotSupportedException)
-                {
-                    // ownedMembership not implemented for this supertype; skip.
-                }
-            }
-        }
-
-        /// <summary>
-        /// Adds the <see cref="IMembership.MemberElement"/> of <paramref name="membership"/>
-        /// to the index under both its <see cref="IMembership.MemberShortName"/> and
-        /// <see cref="IMembership.MemberName"/>, when present.
-        /// </summary>
-        /// <param name="index">The destination index to populate.</param>
-        /// <param name="membership">The membership whose target is indexed.</param>
-        private static void AddMembershipEntry(Dictionary<string, HashSet<IElement>> index, IMembership membership)
-        {
-            if (membership == null)
-            {
-                return;
-            }
-
-            var target = membership.MemberElement;
-
-            if (target == null)
-            {
-                return;
-            }
-
-            AddIndexEntry(index, membership.MemberShortName, target);
-            AddIndexEntry(index, membership.MemberName, target);
-        }
-
-        /// <summary>
-        /// Adds <paramref name="element"/> to <paramref name="index"/> under
-        /// <paramref name="simpleName"/> when the name is non-blank.
-        /// </summary>
-        /// <param name="index">The destination index to populate.</param>
-        /// <param name="simpleName">The simple name to use as the index key.</param>
-        /// <param name="element">The element to record under <paramref name="simpleName"/>.</param>
-        private static void AddIndexEntry(Dictionary<string, HashSet<IElement>> index, string simpleName, IElement element)
-        {
-            if (string.IsNullOrWhiteSpace(simpleName) || element == null)
-            {
-                return;
-            }
-
-            if (!index.TryGetValue(simpleName, out var bucket))
-            {
-                bucket = new HashSet<IElement>();
-                index[simpleName] = bucket;
-            }
-
-            bucket.Add(element);
         }
     }
 }

--- a/SysML2.NET.Serializer.TextualNotation/Writers/TextualNotationWriterContext.cs
+++ b/SysML2.NET.Serializer.TextualNotation/Writers/TextualNotationWriterContext.cs
@@ -21,7 +21,9 @@
 namespace SysML2.NET.Serializer.TextualNotation.Writers
 {
     using System;
+    using System.Collections.Generic;
 
+    using SysML2.NET.Core.POCO.Kernel.Functions;
     using SysML2.NET.Core.POCO.Root.Namespaces;
 
     /// <summary>
@@ -49,7 +51,18 @@ namespace SysML2.NET.Serializer.TextualNotation.Writers
             this.CursorCache = new CursorCache();
             this.ContextNamespace = contextNamespace ?? throw new ArgumentNullException(nameof(contextNamespace));
             this.NameResolutionCache = new NameResolutionCache(contextNamespace);
+            this.OperatorContextStack = new Stack<IExpression>();
         }
+
+        /// <summary>
+        /// Gets the stack of currently-active enclosing operator expressions. The textual
+        /// notation builder for each <c>IOperatorExpression</c>-typed rule pushes its
+        /// <see cref="IExpression"/> poco on entry and pops it on exit (try/finally), so
+        /// operand-emission paths can peek the top to obtain the enclosing operator and
+        /// consult <see cref="OperatorPrecedence.NeedsParenthesesAsOperand"/> to decide
+        /// whether the operand needs to be wrapped in <c>(…)</c>.
+        /// </summary>
+        public Stack<IExpression> OperatorContextStack { get; }
 
         /// <summary>
         /// Gets the <see cref="ICursorCache"/> used for cursor-based element traversal.


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/SysML2.NET/pulls) open
- [x] I have verified that I am following the SysML2.NET [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/SysML2.NET/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
This PR fixes :

- Skipped part
- Invalid naming (was not escaped all the time)
- Invalid construction of expression
- Emission (settings-based) of parenthesis to surrounded contained expression
<!-- Thanks for contributing to SysML2.NET! -->