### PR TITLE
Fix #278: DAL extensions target interface types

### DIFF
--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/FeatureTypingExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/FeatureTypingExtensions.cs
@@ -176,7 +176,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.Type, out lazyPoco))
             {
-                poco.Type = (Core.POCO.Core.Types.Type)lazyPoco.Value;
+                poco.Type = (Core.POCO.Core.Types.IType)lazyPoco.Value;
             }
             else
             {
@@ -185,7 +185,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.TypedFeature, out lazyPoco))
             {
-                poco.TypedFeature = (Core.POCO.Core.Features.Feature)lazyPoco.Value;
+                poco.TypedFeature = (Core.POCO.Core.Features.IFeature)lazyPoco.Value;
             }
             else
             {

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/ReferenceSubsettingExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/ReferenceSubsettingExtensions.cs
@@ -176,7 +176,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.ReferencedFeature, out lazyPoco))
             {
-                poco.ReferencedFeature = (Core.POCO.Core.Features.Feature)lazyPoco.Value;
+                poco.ReferencedFeature = (Core.POCO.Core.Features.IFeature)lazyPoco.Value;
             }
             else
             {

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/SubclassificationExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/SubclassificationExtensions.cs
@@ -176,7 +176,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.Subclassifier, out lazyPoco))
             {
-                poco.Subclassifier = (Core.POCO.Core.Classifiers.Classifier)lazyPoco.Value;
+                poco.Subclassifier = (Core.POCO.Core.Classifiers.IClassifier)lazyPoco.Value;
             }
             else
             {
@@ -185,7 +185,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.Superclassifier, out lazyPoco))
             {
-                poco.Superclassifier = (Core.POCO.Core.Classifiers.Classifier)lazyPoco.Value;
+                poco.Superclassifier = (Core.POCO.Core.Classifiers.IClassifier)lazyPoco.Value;
             }
             else
             {

--- a/SysML2.NET.CodeGenerator/Templates/Uml/core-dal-poco-uml-extensions.hbs
+++ b/SysML2.NET.CodeGenerator/Templates/Uml/core-dal-poco-uml-extensions.hbs
@@ -154,18 +154,14 @@ namespace SysML2.NET.Dal
                                 {{#if property.IsComposite}}
                                     {{#if (Property.IsOfTypeBaseElement property)}}
                                         ((IContained{{property.Owner.Name}})poco).{{ String.PascalCase property.Name}}.Add(lazyPoco.Value);
-                                    {{else if property.Type.IsAbstract }}
-                                        ((IContained{{property.Owner.Name}})poco).{{ String.PascalCase property.Name}}.Add((Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace property.Type }}.I{{ property.Type.Name }})lazyPoco.Value);
                                     {{else}}
-                                        ((IContained{{property.Owner.Name}})poco).{{ String.PascalCase property.Name}}.Add((Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace property.Type }}.{{ property.Type.Name }})lazyPoco.Value);
+                                        ((IContained{{property.Owner.Name}})poco).{{ String.PascalCase property.Name}}.Add((Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace property.Type }}.I{{ property.Type.Name }})lazyPoco.Value);
                                     {{/if}}
                                 {{else}}
                                     {{#if (Property.IsOfTypeBaseElement property)}}
                                         poco.{{ String.PascalCase property.Name}}.Add(lazyPoco.Value);
-                                    {{else if property.Type.IsAbstract }}
-                                        poco.{{ String.PascalCase property.Name}}.Add((Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace property.Type }}.I{{ property.Type.Name }})lazyPoco.Value);
                                     {{else}}
-                                        poco.{{ String.PascalCase property.Name}}.Add((Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace property.Type }}.{{ property.Type.Name }})lazyPoco.Value);
+                                        poco.{{ String.PascalCase property.Name}}.Add((Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace property.Type }}.I{{ property.Type.Name }})lazyPoco.Value);
                                     {{/if}}
                                 {{/if}}
                             }
@@ -177,18 +173,14 @@ namespace SysML2.NET.Dal
                             {{#if property.Opposite.IsComposite}}
                                 {{#if (Property.IsOfTypeBaseElement property)}}
                                     ((IContained{{property.Owner.Name}})poco).{{ String.PascalCase property.Name}} = lazyPoco.Value;
-                                {{else if property.Type.IsAbstract }}
-                                    ((IContained{{property.Owner.Name}})poco).{{ String.PascalCase property.Name}} = (Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace property.Type }}.I{{ property.Type.Name }})lazyPoco.Value;
                                 {{else}}
-                                    ((IContained{{property.Owner.Name}})poco).{{ String.PascalCase property.Name}} = (Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace property.Type }}.{{ property.Type.Name }})lazyPoco.Value;
+                                    ((IContained{{property.Owner.Name}})poco).{{ String.PascalCase property.Name}} = (Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace property.Type }}.I{{ property.Type.Name }})lazyPoco.Value;
                                 {{/if}}
                             {{else}}
                                 {{#if (Property.IsOfTypeBaseElement property)}}
                                     poco.{{ String.PascalCase property.Name}} = lazyPoco.Value;
-                                {{else if property.Type.IsAbstract }}
-                                    poco.{{ String.PascalCase property.Name}} = (Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace property.Type }}.I{{ property.Type.Name }})lazyPoco.Value;
                                 {{else}}
-                                    poco.{{ String.PascalCase property.Name}} = (Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace property.Type }}.{{ property.Type.Name }})lazyPoco.Value;
+                                    poco.{{ String.PascalCase property.Name}} = (Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace property.Type }}.I{{ property.Type.Name }})lazyPoco.Value;
                                 {{/if}}
                             {{/if}}
                         }
@@ -207,18 +199,14 @@ namespace SysML2.NET.Dal
                             {{#if property.Opposite.IsComposite}}
                                 {{#if (Property.IsOfTypeBaseElement property)}}
                                     ((IContained{{property.Owner.Name}})poco).{{ String.PascalCase property.Name}} = lazyPoco.Value;
-                                {{else if property.Type.IsAbstract }}
-                                    ((IContained{{property.Owner.Name}})poco).{{ String.PascalCase property.Name}} = (Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace property.Type }}.I{{ property.Type.Name }})lazyPoco.Value;
                                 {{else}}
-                                    ((IContained{{property.Owner.Name}})poco).{{ String.PascalCase property.Name}} = (Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace property.Type }}.{{ property.Type.Name }})lazyPoco.Value;
+                                    ((IContained{{property.Owner.Name}})poco).{{ String.PascalCase property.Name}} = (Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace property.Type }}.I{{ property.Type.Name }})lazyPoco.Value;
                                 {{/if}}
                             {{else}}
                                 {{#if (Property.IsOfTypeBaseElement property)}}
                                     poco.{{ String.PascalCase property.Name}} = lazyPoco.Value;
-                                {{else if property.Type.IsAbstract }}
-                                    poco.{{ String.PascalCase property.Name}} = (Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace property.Type }}.I{{ property.Type.Name }})lazyPoco.Value;
                                 {{else}}
-                                    poco.{{ String.PascalCase property.Name}} = (Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace property.Type }}.{{ property.Type.Name }})lazyPoco.Value;
+                                    poco.{{ String.PascalCase property.Name}} = (Core.POCO.{{ #NamedElement.WriteFullyQualifiedNameSpace property.Type }}.I{{ property.Type.Name }})lazyPoco.Value;
                                 {{/if}}
                             {{/if}}
                         }

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConjugatedPortTypingExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConjugatedPortTypingExtensions.cs
@@ -138,7 +138,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.ConjugatedPortDefinition, out lazyPoco))
             {
-                poco.ConjugatedPortDefinition = (Core.POCO.Systems.Ports.ConjugatedPortDefinition)lazyPoco.Value;
+                poco.ConjugatedPortDefinition = (Core.POCO.Systems.Ports.IConjugatedPortDefinition)lazyPoco.Value;
             }
             else
             {
@@ -185,7 +185,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.TypedFeature, out lazyPoco))
             {
-                poco.TypedFeature = (Core.POCO.Core.Features.Feature)lazyPoco.Value;
+                poco.TypedFeature = (Core.POCO.Core.Features.IFeature)lazyPoco.Value;
             }
             else
             {

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConjugationExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConjugationExtensions.cs
@@ -138,7 +138,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.ConjugatedType, out lazyPoco))
             {
-                poco.ConjugatedType = (Core.POCO.Core.Types.Type)lazyPoco.Value;
+                poco.ConjugatedType = (Core.POCO.Core.Types.IType)lazyPoco.Value;
             }
             else
             {
@@ -147,7 +147,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.OriginalType, out lazyPoco))
             {
-                poco.OriginalType = (Core.POCO.Core.Types.Type)lazyPoco.Value;
+                poco.OriginalType = (Core.POCO.Core.Types.IType)lazyPoco.Value;
             }
             else
             {

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/CrossSubsettingExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/CrossSubsettingExtensions.cs
@@ -138,7 +138,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.CrossedFeature, out lazyPoco))
             {
-                poco.CrossedFeature = (Core.POCO.Core.Features.Feature)lazyPoco.Value;
+                poco.CrossedFeature = (Core.POCO.Core.Features.IFeature)lazyPoco.Value;
             }
             else
             {

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/DifferencingExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/DifferencingExtensions.cs
@@ -138,7 +138,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.DifferencingType, out lazyPoco))
             {
-                poco.DifferencingType = (Core.POCO.Core.Types.Type)lazyPoco.Value;
+                poco.DifferencingType = (Core.POCO.Core.Types.IType)lazyPoco.Value;
             }
             else
             {

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/DisjoiningExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/DisjoiningExtensions.cs
@@ -138,7 +138,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.DisjoiningType, out lazyPoco))
             {
-                poco.DisjoiningType = (Core.POCO.Core.Types.Type)lazyPoco.Value;
+                poco.DisjoiningType = (Core.POCO.Core.Types.IType)lazyPoco.Value;
             }
             else
             {
@@ -185,7 +185,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.TypeDisjoined, out lazyPoco))
             {
-                poco.TypeDisjoined = (Core.POCO.Core.Types.Type)lazyPoco.Value;
+                poco.TypeDisjoined = (Core.POCO.Core.Types.IType)lazyPoco.Value;
             }
             else
             {

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/FeatureChainingExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/FeatureChainingExtensions.cs
@@ -138,7 +138,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.ChainingFeature, out lazyPoco))
             {
-                poco.ChainingFeature = (Core.POCO.Core.Features.Feature)lazyPoco.Value;
+                poco.ChainingFeature = (Core.POCO.Core.Features.IFeature)lazyPoco.Value;
             }
             else
             {

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/FeatureInvertingExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/FeatureInvertingExtensions.cs
@@ -138,7 +138,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.FeatureInverted, out lazyPoco))
             {
-                poco.FeatureInverted = (Core.POCO.Core.Features.Feature)lazyPoco.Value;
+                poco.FeatureInverted = (Core.POCO.Core.Features.IFeature)lazyPoco.Value;
             }
             else
             {
@@ -147,7 +147,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.InvertingFeature, out lazyPoco))
             {
-                poco.InvertingFeature = (Core.POCO.Core.Features.Feature)lazyPoco.Value;
+                poco.InvertingFeature = (Core.POCO.Core.Features.IFeature)lazyPoco.Value;
             }
             else
             {

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/FeatureTypingExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/FeatureTypingExtensions.cs
@@ -176,7 +176,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.Type, out lazyPoco))
             {
-                poco.Type = (Core.POCO.Core.Types.Type)lazyPoco.Value;
+                poco.Type = (Core.POCO.Core.Types.IType)lazyPoco.Value;
             }
             else
             {
@@ -185,7 +185,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.TypedFeature, out lazyPoco))
             {
-                poco.TypedFeature = (Core.POCO.Core.Features.Feature)lazyPoco.Value;
+                poco.TypedFeature = (Core.POCO.Core.Features.IFeature)lazyPoco.Value;
             }
             else
             {

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/IntersectingExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/IntersectingExtensions.cs
@@ -138,7 +138,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.IntersectingType, out lazyPoco))
             {
-                poco.IntersectingType = (Core.POCO.Core.Types.Type)lazyPoco.Value;
+                poco.IntersectingType = (Core.POCO.Core.Types.IType)lazyPoco.Value;
             }
             else
             {

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/MembershipExposeExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/MembershipExposeExtensions.cs
@@ -144,7 +144,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.ImportedMembership, out lazyPoco))
             {
-                poco.ImportedMembership = (Core.POCO.Root.Namespaces.Membership)lazyPoco.Value;
+                poco.ImportedMembership = (Core.POCO.Root.Namespaces.IMembership)lazyPoco.Value;
             }
             else
             {

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/MembershipImportExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/MembershipImportExtensions.cs
@@ -144,7 +144,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.ImportedMembership, out lazyPoco))
             {
-                poco.ImportedMembership = (Core.POCO.Root.Namespaces.Membership)lazyPoco.Value;
+                poco.ImportedMembership = (Core.POCO.Root.Namespaces.IMembership)lazyPoco.Value;
             }
             else
             {

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/NamespaceExposeExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/NamespaceExposeExtensions.cs
@@ -144,7 +144,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.ImportedNamespace, out lazyPoco))
             {
-                poco.ImportedNamespace = (Core.POCO.Root.Namespaces.Namespace)lazyPoco.Value;
+                poco.ImportedNamespace = (Core.POCO.Root.Namespaces.INamespace)lazyPoco.Value;
             }
             else
             {

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/NamespaceImportExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/NamespaceImportExtensions.cs
@@ -144,7 +144,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.ImportedNamespace, out lazyPoco))
             {
-                poco.ImportedNamespace = (Core.POCO.Root.Namespaces.Namespace)lazyPoco.Value;
+                poco.ImportedNamespace = (Core.POCO.Root.Namespaces.INamespace)lazyPoco.Value;
             }
             else
             {

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/PortConjugationExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/PortConjugationExtensions.cs
@@ -138,7 +138,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.ConjugatedType, out lazyPoco))
             {
-                poco.ConjugatedType = (Core.POCO.Core.Types.Type)lazyPoco.Value;
+                poco.ConjugatedType = (Core.POCO.Core.Types.IType)lazyPoco.Value;
             }
             else
             {
@@ -147,7 +147,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.OriginalPortDefinition, out lazyPoco))
             {
-                poco.OriginalPortDefinition = (Core.POCO.Systems.Ports.PortDefinition)lazyPoco.Value;
+                poco.OriginalPortDefinition = (Core.POCO.Systems.Ports.IPortDefinition)lazyPoco.Value;
             }
             else
             {

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/RedefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/RedefinitionExtensions.cs
@@ -176,7 +176,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.RedefinedFeature, out lazyPoco))
             {
-                poco.RedefinedFeature = (Core.POCO.Core.Features.Feature)lazyPoco.Value;
+                poco.RedefinedFeature = (Core.POCO.Core.Features.IFeature)lazyPoco.Value;
             }
             else
             {
@@ -185,7 +185,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.RedefiningFeature, out lazyPoco))
             {
-                poco.RedefiningFeature = (Core.POCO.Core.Features.Feature)lazyPoco.Value;
+                poco.RedefiningFeature = (Core.POCO.Core.Features.IFeature)lazyPoco.Value;
             }
             else
             {

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ReferenceSubsettingExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ReferenceSubsettingExtensions.cs
@@ -176,7 +176,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.ReferencedFeature, out lazyPoco))
             {
-                poco.ReferencedFeature = (Core.POCO.Core.Features.Feature)lazyPoco.Value;
+                poco.ReferencedFeature = (Core.POCO.Core.Features.IFeature)lazyPoco.Value;
             }
             else
             {

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/SpecializationExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/SpecializationExtensions.cs
@@ -138,7 +138,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.General, out lazyPoco))
             {
-                poco.General = (Core.POCO.Core.Types.Type)lazyPoco.Value;
+                poco.General = (Core.POCO.Core.Types.IType)lazyPoco.Value;
             }
             else
             {
@@ -185,7 +185,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.Specific, out lazyPoco))
             {
-                poco.Specific = (Core.POCO.Core.Types.Type)lazyPoco.Value;
+                poco.Specific = (Core.POCO.Core.Types.IType)lazyPoco.Value;
             }
             else
             {

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/SubclassificationExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/SubclassificationExtensions.cs
@@ -176,7 +176,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.Subclassifier, out lazyPoco))
             {
-                poco.Subclassifier = (Core.POCO.Core.Classifiers.Classifier)lazyPoco.Value;
+                poco.Subclassifier = (Core.POCO.Core.Classifiers.IClassifier)lazyPoco.Value;
             }
             else
             {
@@ -185,7 +185,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.Superclassifier, out lazyPoco))
             {
-                poco.Superclassifier = (Core.POCO.Core.Classifiers.Classifier)lazyPoco.Value;
+                poco.Superclassifier = (Core.POCO.Core.Classifiers.IClassifier)lazyPoco.Value;
             }
             else
             {

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/SubsettingExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/SubsettingExtensions.cs
@@ -176,7 +176,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.SubsettedFeature, out lazyPoco))
             {
-                poco.SubsettedFeature = (Core.POCO.Core.Features.Feature)lazyPoco.Value;
+                poco.SubsettedFeature = (Core.POCO.Core.Features.IFeature)lazyPoco.Value;
             }
             else
             {
@@ -185,7 +185,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.SubsettingFeature, out lazyPoco))
             {
-                poco.SubsettingFeature = (Core.POCO.Core.Features.Feature)lazyPoco.Value;
+                poco.SubsettingFeature = (Core.POCO.Core.Features.IFeature)lazyPoco.Value;
             }
             else
             {

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/TypeFeaturingExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/TypeFeaturingExtensions.cs
@@ -138,7 +138,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.FeatureOfType, out lazyPoco))
             {
-                poco.FeatureOfType = (Core.POCO.Core.Features.Feature)lazyPoco.Value;
+                poco.FeatureOfType = (Core.POCO.Core.Features.IFeature)lazyPoco.Value;
             }
             else
             {
@@ -147,7 +147,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.FeaturingType, out lazyPoco))
             {
-                poco.FeaturingType = (Core.POCO.Core.Types.Type)lazyPoco.Value;
+                poco.FeaturingType = (Core.POCO.Core.Types.IType)lazyPoco.Value;
             }
             else
             {

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/UnioningExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/UnioningExtensions.cs
@@ -176,7 +176,7 @@ namespace SysML2.NET.Dal
 
             if (cache.TryGetValue(dto.UnioningType, out lazyPoco))
             {
-                poco.UnioningType = (Core.POCO.Core.Types.Type)lazyPoco.Value;
+                poco.UnioningType = (Core.POCO.Core.Types.IType)lazyPoco.Value;
             }
             else
             {

--- a/SysML2.NET.Viewer/SysML2.NET.Viewer.csproj
+++ b/SysML2.NET.Viewer/SysML2.NET.Viewer.csproj
@@ -22,7 +22,6 @@
         <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.8" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.8" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.DotNet.HotReload.WebAssembly.Browser" Version="10.0.204" />
         <PackageReference Include="ReactiveUI" Version="23.2.27" />
         <PackageReference Include="Radzen.Blazor" Version="10.4.7" />
         <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/SysML2.NET/pulls) open
- [x] I have verified that I am following the SysML2.NET [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/SysML2.NET/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #278 
Dal extensions uses interface types instead of class types on update reference
<!-- Thanks for contributing to SysML2.NET! -->