### PR TITLE
Version bumps and remove env on action since resigned

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -13,15 +13,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    env:
-      # Use cached CRL data only for cert revocation checks. Works around
-      # NU3012 ("certificate revoked") for transitive ReactiveUI / Splat 19.3.1
-      # packages whose author certificate (Glenn Watson) was revoked at the CA
-      # in 2026-Q2. `signatureValidationMode=accept` in NuGet.Config does NOT
-      # cover this case because it only relaxes the "require signature" check,
-      # not the chain-validation step that NU3012 fires from. Revert this env
-      # var once the affected packages are re-signed and re-published.
-      NUGET_CERT_REVOCATION_MODE: offline
+
     steps:
       - uses: actions/checkout@v6.0.2
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,13 +11,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    env:
-      # Use cached CRL data only for cert revocation checks. Works around
-      # NU3012 ("certificate revoked") for transitive ReactiveUI / Splat 19.3.1
-      # packages whose author certificate was revoked at the CA in 2026-Q2.
-      # Revert this env var once the affected packages are re-signed.
-      NUGET_CERT_REVOCATION_MODE: offline
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-      # Use cached CRL data only for cert revocation checks. Works around
-      # NU3012 ("certificate revoked") for transitive ReactiveUI / Splat 19.3.1
-      # packages whose author certificate was revoked at the CA in 2026-Q2.
-      # Revert this env var once the affected packages are re-signed.
-      NUGET_CERT_REVOCATION_MODE: offline
       
     steps:
       - uses: actions/checkout@v6.0.2

--- a/SySML2.NET.REST.Tests/SySML2.NET.REST.Tests.csproj
+++ b/SySML2.NET.REST.Tests/SySML2.NET.REST.Tests.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
         <PackageReference Include="NUnit" Version="4.6.1" />
         <PackageReference Include="NUnit.Console" Version="3.22.0" />

--- a/SysML2.NET.CodeGenerator.Tests/SysML2.NET.CodeGenerator.Tests.csproj
+++ b/SysML2.NET.CodeGenerator.Tests/SysML2.NET.CodeGenerator.Tests.csproj
@@ -1144,7 +1144,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit.Console" Version="3.22.0" />

--- a/SysML2.NET.Dal.Tests/SysML2.NET.Dal.Tests.csproj
+++ b/SysML2.NET.Dal.Tests/SysML2.NET.Dal.Tests.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
         <PackageReference Include="NUnit" Version="4.6.1" />
         <PackageReference Include="NUnit.Console" Version="3.22.0" />

--- a/SysML2.NET.Extensions.Tests/SysML2.NET.Extensions.Tests.csproj
+++ b/SysML2.NET.Extensions.Tests/SysML2.NET.Extensions.Tests.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
         <PackageReference Include="NUnit" Version="4.6.1" />
         <PackageReference Include="NUnit.Console" Version="3.22.0" />

--- a/SysML2.NET.Kpar.Tests/SysML2.NET.Kpar.Tests.csproj
+++ b/SysML2.NET.Kpar.Tests/SysML2.NET.Kpar.Tests.csproj
@@ -55,7 +55,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
         <PackageReference Include="NUnit" Version="4.6.1" />
         <PackageReference Include="NUnit.Console" Version="3.22.0" />

--- a/SysML2.NET.Serializer.Json.Tests/SysML2.NET.Serializer.Json.Tests.csproj
+++ b/SysML2.NET.Serializer.Json.Tests/SysML2.NET.Serializer.Json.Tests.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
         <PackageReference Include="NUnit" Version="4.6.1" />
         <PackageReference Include="NUnit.Console" Version="3.22.0" />

--- a/SysML2.NET.Serializer.Json/SysML2.NET.Serializer.Json.csproj
+++ b/SysML2.NET.Serializer.Json/SysML2.NET.Serializer.Json.csproj
@@ -24,7 +24,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Json" Version="10.0.8" />
+        <PackageReference Include="System.Text.Json" Version="10.0.9" />
         <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" PrivateAssets="all" />
     </ItemGroup>
 

--- a/SysML2.NET.Serializer.MessagePack.Tests/SysML2.NET.Serializer.MessagePack.Tests.csproj
+++ b/SysML2.NET.Serializer.MessagePack.Tests/SysML2.NET.Serializer.MessagePack.Tests.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
         <PackageReference Include="NUnit" Version="4.6.1" />
         <PackageReference Include="NUnit.Console" Version="3.22.0" />

--- a/SysML2.NET.Serializer.MessagePack/SysML2.NET.Serializer.MessagePack.csproj
+++ b/SysML2.NET.Serializer.MessagePack/SysML2.NET.Serializer.MessagePack.csproj
@@ -28,8 +28,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MessagePack" Version="3.1.6" />
-        <PackageReference Include="System.IO.Pipelines" Version="10.0.8" />
+        <PackageReference Include="MessagePack" Version="3.1.7" />
+        <PackageReference Include="System.IO.Pipelines" Version="10.0.9" />
         <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" PrivateAssets="all" />
     </ItemGroup>
 

--- a/SysML2.NET.Serializer.TextualNotation.Tests/SysML2.NET.Serializer.TextualNotation.Tests.csproj
+++ b/SysML2.NET.Serializer.TextualNotation.Tests/SysML2.NET.Serializer.TextualNotation.Tests.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="NUnit" Version="4.6.1" />

--- a/SysML2.NET.Serializer.TextualNotation/SysML2.NET.Serializer.TextualNotation.csproj
+++ b/SysML2.NET.Serializer.TextualNotation/SysML2.NET.Serializer.TextualNotation.csproj
@@ -29,9 +29,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
         <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" PrivateAssets="all" />
-        <PackageReference Include="System.Collections.Immutable" Version="10.0.8" />
+        <PackageReference Include="System.Collections.Immutable" Version="10.0.9" />
     </ItemGroup>
 
     <ItemGroup>

--- a/SysML2.NET.Serializer.Xmi.Tests/SysML2.NET.Serializer.Xmi.Tests.csproj
+++ b/SysML2.NET.Serializer.Xmi.Tests/SysML2.NET.Serializer.Xmi.Tests.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
         <PackageReference Include="NUnit" Version="4.6.1" />
         <PackageReference Include="NUnit.Console" Version="3.22.0"/>

--- a/SysML2.NET.Tests/SysML2.NET.Tests.csproj
+++ b/SysML2.NET.Tests/SysML2.NET.Tests.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="NUnit" Version="4.6.1" />

--- a/SysML2.NET.Viewer.Tests/SysML2.NET.Viewer.Tests.csproj
+++ b/SysML2.NET.Viewer.Tests/SysML2.NET.Viewer.Tests.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
       <PackageReference Include="bunit.web" Version="1.40.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
       <PackageReference Include="Moq" Version="4.20.72" />
       <PackageReference Include="NUnit" Version="4.6.1" />

--- a/SysML2.NET.Viewer/SysML2.NET.Viewer.csproj
+++ b/SysML2.NET.Viewer/SysML2.NET.Viewer.csproj
@@ -19,10 +19,10 @@
     <ItemGroup>
         <PackageReference Include="Blazor.SessionStorage.WebAssembly" Version="10.0.0" />
         <PackageReference Include="BlazorStrap.V5" Version="5.2.104" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.8" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.8" PrivateAssets="all" />
-        <PackageReference Include="ReactiveUI" Version="23.2.27" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" PrivateAssets="all" />
+        <PackageReference Include="ReactiveUI" Version="23.2.28" />
         <PackageReference Include="Radzen.Blazor" Version="10.4.7" />
         <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
         <PackageReference Include="Serilog.Enrichers.Process" Version="3.0.0" />

--- a/SysML2.NET/SysML2.NET.csproj
+++ b/SysML2.NET/SysML2.NET.csproj
@@ -27,9 +27,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
         <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" PrivateAssets="all" />
-        <PackageReference Include="System.Collections.Immutable" Version="10.0.8" />
+        <PackageReference Include="System.Collections.Immutable" Version="10.0.9" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/SysML2.NET/pulls) open
- [x] I have verified that I am following the SysML2.NET [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/SysML2.NET/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
ReactiveUI provides new release with signed version. Workflow can discard the NUGET_CERT_REVOCATION_MODE flag
<!-- Thanks for contributing to SysML2.NET! -->