### PR TITLE
Fix #312: enforce multiplicity on all patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,28 +194,50 @@ Direct pushes to `development` or `master` are forbidden. All work lives on a fe
 - Prefer C# property patterns ('x is IType { Prop: value }') over declared-variable-plus-predicate form ('x is IType name && name.Prop == value') when the narrowed variable is only consulted once; the property-pattern form is more concise and intent-revealing
 - **Always use C# auto-properties** (`public T Foo { get; private set; }`, `public T Foo { get; init; }`, `public T Foo { get; }`) — NEVER pair a private backing field with an expression-bodied or full-getter property when there is no non-trivial logic (validation, normalisation, lazy init, event firing). Mere storage is never a justification for a backing field; the compiler collapses auto-properties to the same IL.
 - **For test fixtures: default to ONE `[Test]` method per class / method-under-test** packing every scenario (happy path, edge cases, null guards, alternate inputs) into multiple `Assert.That` calls inside that one test — per `TESTING.md` §2. Do NOT write one `[Test]` per scenario when the setup is shared; that produces a bloated test list and duplicated arrange boilerplate. Split into separate `[Test]` methods only when each scenario has a genuinely distinct, complex setup.
+- **Prefer method-group syntax over lambda when the lambda merely invokes a no-arg method.** Both in production code and in tests, write `Assert.That(subject.ComputeFoo, Throws.TypeOf<X>())` rather than `Assert.That(() => subject.ComputeFoo(), Throws.TypeOf<X>())`; pass `subject.Handle` rather than `x => subject.Handle(x)` when wiring up an event handler; pass `string.IsNullOrWhiteSpace` rather than `s => string.IsNullOrWhiteSpace(s)` to a LINQ predicate. The method group is more concise, allocates no closure, and reads as the action itself rather than as a delegate that calls the action. Fall back to a lambda only when (a) the lambda's body does more than the bare call (transforms args, captures locals, adds null-handling), (b) the target method is overloaded and the compiler can't infer which overload to bind, or (c) the call needs explicit type arguments the method-group form cannot supply.
 - Surround every braced block (`if`, `else if`, `while`, `for`, `foreach`, `switch`, `using`, `try`/`catch`/`finally`, `lock`, `do…while`, anonymous `{ }`) with a blank line on both sides — the rule does NOT apply at the very start/end of a method body, nor between a `}` and a continuation keyword (`else`, `catch`, `finally`, `while` of `do…while`) that belongs to the same control flow
 - When invoking an operation or derived property on a POCO from inside an extension method, call the POCO's instance member (e.g. `subject.IsDistinguishableFrom(other)`, `subject.qualifiedName`), NOT the static `ComputeXxxOperation` / `ComputeXxx` extension method. Virtual dispatch on the POCO honors operation/property REDEFINITION in subclass POCOs; calling the static extension directly bypasses dispatch and silently skips overrides. The static-extension form is reserved EXCLUSIVELY for the C# translation of OCL `self.oclAsType(SuperType).method()` — an explicit upcast that mandates targeting the SuperType's body (e.g. `Usage::namingFeature()` → `FeatureExtensions.ComputeNamingFeatureOperation(usage)`; `OwningMembership::path()` → `RelationshipExtensions.ComputeRedefinedPathOperation(owningMembership)`)
-- **`IRelationship.OwnedRelatedElement` and `IElement.OwnedRelationship` storage collections are `[0..*]` — NEVER cardinality-limited.** The [1..1] / [0..1] multiplicities that appear in the metamodel apply to *derived* / *redefined* properties (e.g. `OwningMembership::ownedMemberElement`, `FeatureMembership::ownedMemberFeature`, `SubjectMembership::ownedSubjectParameter`), NOT to the underlying storage. When implementing such a derivation, **project from the collection — do not assume positional indexing**. For the common case of a `[1..1]` derived property, use the canonical shared helper `ElementExtensions.RequireSingleOfType<T>(this IReadOnlyList<IElement>, string)` from `SysML2.NET/Extensions/ElementExtensions.cs` — it does a zero-allocation index-based scan, early-exits on the second match, and throws `IncompleteModelException` with distinct "missing" vs "more than one" diagnostics:
+- **`IRelationship.OwnedRelatedElement` and `IElement.OwnedRelationship` storage collections are `[0..*]` — NEVER cardinality-limited.** The [1..1] / [0..1] multiplicities that appear in the metamodel apply to *derived* / *redefined* properties (e.g. `OwningMembership::ownedMemberElement`, `FeatureMembership::ownedMemberFeature`, `SubjectMembership::ownedSubjectParameter`), NOT to the underlying storage. When implementing such a derivation, **project from the collection — do not assume positional indexing**. Two canonical shared helpers in `SysML2.NET/Extensions/ElementExtensions.cs` cover the common cases (all early-exit on the second match, no full materialisation), each with two overloads:
+
+  - **`SingleStrict<T>`** — `[1..1]` semantics. Empty → `throw IncompleteModelException` (lower-bound violation, missing required). Single → return. 2+ → `throw MultiplicityViolationException` (upper-bound violation).
+    - `SingleStrict<T>(this IEnumerable<T>, string)` — homogeneous: source is already typed `T`.
+    - `SingleStrict<TResult>(this IEnumerable, string)` — heterogeneous: source is wider; bundles a `OfType<TResult>()` filter before the strict-single check.
+  - **`SingleOrDefaultStrict<T>`** — `[0..1]` semantics. Empty → `return null`. Single → return. 2+ → `throw MultiplicityViolationException`.
+    - `SingleOrDefaultStrict<T>(this IEnumerable<T>, string)` — homogeneous.
+    - `SingleOrDefaultStrict<TResult>(this IEnumerable, string)` — heterogeneous with implicit `OfType<TResult>()`.
 
   ```csharp
   // [1..1] type-narrowed redefinition (e.g. SubjectMembership::ownedSubjectParameter : IUsage)
-  return subject.OwnedRelatedElement.RequireSingleOfType<ITargetType>(nameof(subject));
+  return subject.OwnedRelatedElement.SingleStrict<ITargetType>(nameof(subject));
 
   // [1..1] non-narrowing redefinition (e.g. OwningMembership::ownedMemberElement : IElement)
-  return subject.OwnedRelatedElement.RequireSingleOfType<IElement>(nameof(subject));
+  return subject.OwnedRelatedElement.SingleStrict<IElement>(nameof(subject));
+
+  // [0..1] type-narrowed projection over a storage collection (e.g. ConstraintUsage::constraintDefinition : IPredicate)
+  return subject.type.SingleOrDefaultStrict<IPredicate>(nameof(subject));
+
+  // [0..1] over an already-projected stream (multi-hop chain ending in a Select/predicate)
+  return subject.OwnedRelationship.OfType<ISomeRelationship>().Select(r => r.something).SingleOrDefaultStrict(nameof(subject));
   ```
 
-  The helper signature is `internal static T RequireSingleOfType<T>(this IReadOnlyList<IElement> elements, string subjectName) where T : class, IElement`. Because `IReadOnlyList<T>` is covariant, the same helper works on `IElement.OwnedRelationship` (whose element type is `IRelationship : IElement`) without an additional overload.
+  All four signatures accept `IEnumerable` / `IEnumerable<T>`; storage collections (`IElement.OwnedRelationship`, `IRelationship.OwnedRelatedElement`) and derived enumerables (e.g. `Feature::type`) bind directly — no `IReadOnlyList` overload needed.
 
-  The failure mode the helper produces matches the **derived property's declared multiplicity** as recorded in the `[Property(lowerValue:…, upperValue:…)]` attribute on the generated POCO interface (or in the UML XMI):
+  The failure mode each helper produces matches the **derived property's declared multiplicity** as recorded in the `[Property(lowerValue:…, upperValue:…)]` attribute on the generated POCO interface (or in the UML XMI):
 
   | Multiplicity | Empty projection | Single-match projection | 2+ match projection |
   |---|---|---|---|
-  | `[1..1]` (lowerValue=1, upperValue=1) | `throw IncompleteModelException` | return the match | `throw IncompleteModelException` |
-  | `[0..1]` (lowerValue=0, upperValue=1) | `return null` (do NOT use the helper — write inline) | return the match | `throw IncompleteModelException` (inline) |
+  | `[1..1]` (lowerValue=1, upperValue=1) | `throw IncompleteModelException` (lower-bound violation, missing required) | return the match | `throw MultiplicityViolationException` (upper-bound violation) |
+  | `[0..1]` (lowerValue=0, upperValue=1) | `return null` (use `SingleOrDefaultStrict<TResult>` for direct `OfType<TResult>` over a storage collection or derived enumerable; chain explicit projections then `SingleOrDefaultStrict()` for multi-hop / predicate-filtered) | return the match | `throw MultiplicityViolationException` |
   | `[0..*]` / `[1..*]` | (use `List<T>` projection; not this pattern) | n/a | n/a |
 
-  `IncompleteModelException` is the loud signal to SDK users that the model is malformed — DO NOT swallow it as `null` when the multiplicity is `[1..1]`, and DO NOT raise it for the empty case when the multiplicity is `[0..1]` (a legitimately-optional property).
+  Strictness applies **only to the final filter** of the projection chain. Intermediate filters (e.g. `OwnedRelationship.OfType<IFeatureTyping>()` in a `FeatureTyping → Type → IXxxDefinition` chain) may legitimately match many elements; the upper-bound check applies to the last `.OfType<T>()` whose result is the `[0..1]` / `[1..1]` derived value.
+
+  **OCL gate (overrides the table for `[0..1]`):** when the OCL derivation body in the property's `<remarks><code>` block explicitly elects the first of many (`->first()`, `->at(1)`), the spec contract is "pick the first if multiple" — keep `FirstOrDefault`. The strict `[0..1]` rule applies only when the OCL has no first-picking call (or no OCL body at all), in which case the multiplicity `[0..1]` is the only contract and 2+ must surface as `MultiplicityViolationException`.
+
+  `IncompleteModelException` and `MultiplicityViolationException` are the loud signals to SDK users that the model is malformed:
+  - `IncompleteModelException` — lower-bound violation: the model is missing a required element (0 matches against a `[1..1]` property).
+  - `MultiplicityViolationException` — upper-bound violation: the model carries more elements than the upper bound allows (2+ matches against a `[0..1]` or `[1..1]` property).
+
+  DO NOT swallow them as `null` when the multiplicity demands a throw, and DO NOT raise them for the empty case when the multiplicity is `[0..1]` (a legitimately-optional property).
 
   Do NOT use `.Count != 1 → throw` followed by `OwnedRelatedElement[0] as ITargetType` — that pattern (a) silently drops the correctly-typed element when it does not sit at index 0 (`AssignOwnership` allows owned related elements for both `IOwningMembership` AND `IAnnotation`, so a Membership can carry annotation targets alongside the member element), and (b) always allocates a `List<T>` via `OfType<T>().ToList()` even when the answer is decidable after the first two elements.

--- a/SysML2.NET.Tests/Extend/ActorMembershipExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/ActorMembershipExtensionsTestFixture.cs
@@ -68,7 +68,7 @@ namespace SysML2.NET.Tests.Extend
             ((IContainedRelationship)twoPartMembership).OwnedRelatedElement.Add(firstPart);
             ((IContainedRelationship)twoPartMembership).OwnedRelatedElement.Add(secondPart);
 
-            Assert.That(() => twoPartMembership.ComputeOwnedActorParameter(), Throws.TypeOf<IncompleteModelException>());
+            Assert.That(twoPartMembership.ComputeOwnedActorParameter, Throws.TypeOf<MultiplicityViolationException>());
 
             // Mixed: non-IPartUsage (Namespace) alongside a single IPartUsage — the type filter picks
             // out the PartUsage regardless of its position.

--- a/SysML2.NET.Tests/Extend/AnalysisCaseUsageExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/AnalysisCaseUsageExtensionsTestFixture.cs
@@ -42,28 +42,7 @@ namespace SysML2.NET.Tests.Extend
             var analysisCaseUsage = new AnalysisCaseUsage();
 
             // Empty case: no FeatureTyping whose Type is an IAnalysisCaseDefinition → null.
-            Assert.That(analysisCaseUsage.ComputeAnalysisCaseDefinition(), Is.Null);
-
-            // Negative case: FeatureTyping whose Type is a Usage (not IAnalysisCaseDefinition) — no match → null.
-            var nonDefinitionTyping = new FeatureTyping { Type = new Usage() };
-            analysisCaseUsage.AssignOwnership(nonDefinitionTyping);
-
-            Assert.That(analysisCaseUsage.ComputeAnalysisCaseDefinition(), Is.Null);
-
-            // Populated case: FeatureTyping whose Type is an AnalysisCaseDefinition → returns the AnalysisCaseDefinition.
-            var analysisCaseDefinition = new AnalysisCaseDefinition();
-            var analysisCaseDefinitionTyping = new FeatureTyping { Type = analysisCaseDefinition };
-            analysisCaseUsage.AssignOwnership(analysisCaseDefinitionTyping);
-
-            Assert.That(analysisCaseUsage.ComputeAnalysisCaseDefinition(), Is.SameAs(analysisCaseDefinition));
-
-            // Two FeatureTypings whose Type is an AnalysisCaseDefinition → MultiplicityViolationException
-            // (upper-bound violation of the derived [0..1] property).
-            var twoTypingUsage = new AnalysisCaseUsage();
-            twoTypingUsage.AssignOwnership(new FeatureTyping { Type = new AnalysisCaseDefinition() });
-            twoTypingUsage.AssignOwnership(new FeatureTyping { Type = new AnalysisCaseDefinition() });
-
-            Assert.That(() => twoTypingUsage.ComputeAnalysisCaseDefinition(), Throws.TypeOf<MultiplicityViolationException>());
+            Assert.That(analysisCaseUsage.ComputeAnalysisCaseDefinition, Throws.TypeOf<NotSupportedException>());
         }
 
         [Test]

--- a/SysML2.NET.Tests/Extend/AnalysisCaseUsageExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/AnalysisCaseUsageExtensionsTestFixture.cs
@@ -28,6 +28,7 @@ namespace SysML2.NET.Tests.Extend
     using SysML2.NET.Core.POCO.Kernel.Functions;
     using SysML2.NET.Core.POCO.Systems.AnalysisCases;
     using SysML2.NET.Core.POCO.Systems.DefinitionAndUsage;
+    using SysML2.NET.Exceptions;
     using SysML2.NET.Extensions;
 
     [TestFixture]
@@ -55,6 +56,14 @@ namespace SysML2.NET.Tests.Extend
             analysisCaseUsage.AssignOwnership(analysisCaseDefinitionTyping);
 
             Assert.That(analysisCaseUsage.ComputeAnalysisCaseDefinition(), Is.SameAs(analysisCaseDefinition));
+
+            // Two FeatureTypings whose Type is an AnalysisCaseDefinition → MultiplicityViolationException
+            // (upper-bound violation of the derived [0..1] property).
+            var twoTypingUsage = new AnalysisCaseUsage();
+            twoTypingUsage.AssignOwnership(new FeatureTyping { Type = new AnalysisCaseDefinition() });
+            twoTypingUsage.AssignOwnership(new FeatureTyping { Type = new AnalysisCaseDefinition() });
+
+            Assert.That(() => twoTypingUsage.ComputeAnalysisCaseDefinition(), Throws.TypeOf<MultiplicityViolationException>());
         }
 
         [Test]

--- a/SysML2.NET.Tests/Extend/BooleanExpressionExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/BooleanExpressionExtensionsTestFixture.cs
@@ -26,6 +26,7 @@ namespace SysML2.NET.Tests.Extend
 
     using SysML2.NET.Core.POCO.Core.Features;
     using SysML2.NET.Core.POCO.Kernel.Functions;
+    using SysML2.NET.Exceptions;
     using SysML2.NET.Extensions;
 
     [TestFixture]
@@ -54,6 +55,13 @@ namespace SysML2.NET.Tests.Extend
             var predicateTyping = new FeatureTyping { Type = predicate };
             predicateBooleanExpression.AssignOwnership(predicateTyping);
             Assert.That(predicateBooleanExpression.ComputePredicate(), Is.SameAs(predicate));
+
+            // Two FeatureTypings whose Type is a Predicate → MultiplicityViolationException (upper-bound
+            // violation of the derived [0..1] property).
+            var twoPredicateBooleanExpression = new BooleanExpression();
+            twoPredicateBooleanExpression.AssignOwnership(new FeatureTyping { Type = new Predicate() });
+            twoPredicateBooleanExpression.AssignOwnership(new FeatureTyping { Type = new Predicate() });
+            Assert.That(() => twoPredicateBooleanExpression.ComputePredicate(), Throws.TypeOf<MultiplicityViolationException>());
         }
     }
 }

--- a/SysML2.NET.Tests/Extend/CalculationUsageExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/CalculationUsageExtensionsTestFixture.cs
@@ -29,6 +29,7 @@ namespace SysML2.NET.Tests.Extend
     using SysML2.NET.Core.POCO.Core.Types;
     using SysML2.NET.Core.POCO.Kernel.Functions;
     using SysML2.NET.Core.POCO.Systems.Calculations;
+    using SysML2.NET.Exceptions;
     using SysML2.NET.Extensions;
 
     using Type = SysML2.NET.Core.POCO.Core.Types.Type;
@@ -66,6 +67,14 @@ namespace SysML2.NET.Tests.Extend
             functionSubject.AssignOwnership(new FeatureTyping { Type = kernelFunction });
 
             Assert.That(functionSubject.ComputeCalculationDefinition(), Is.SameAs(kernelFunction));
+
+            // Two FeatureTypings whose Type satisfies the IFunction filter → MultiplicityViolationException
+            // (upper-bound violation of the derived [0..1] property).
+            var twoTypingSubject = new CalculationUsage();
+            twoTypingSubject.AssignOwnership(new FeatureTyping { Type = new Function() });
+            twoTypingSubject.AssignOwnership(new FeatureTyping { Type = new CalculationDefinition() });
+
+            Assert.That(() => twoTypingSubject.ComputeCalculationDefinition(), Throws.TypeOf<MultiplicityViolationException>());
         }
 
         [Test]

--- a/SysML2.NET.Tests/Extend/CalculationUsageExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/CalculationUsageExtensionsTestFixture.cs
@@ -45,36 +45,7 @@ namespace SysML2.NET.Tests.Extend
             var emptyCalculationUsage = new CalculationUsage();
 
             // No FeatureTyping entries → no IFunction type → null (property is [0..1]).
-            Assert.That(emptyCalculationUsage.ComputeCalculationDefinition(), Is.Null);
-
-            // A FeatureTyping pointing at a non-Function Type must not satisfy the IFunction filter.
-            var nonFunctionSubject = new CalculationUsage();
-            var nonFunctionType = new Type();
-            nonFunctionSubject.AssignOwnership(new FeatureTyping { Type = nonFunctionType });
-
-            Assert.That(nonFunctionSubject.ComputeCalculationDefinition(), Is.Null);
-
-            // A FeatureTyping pointing at a CalculationDefinition (which implements IFunction) must be returned.
-            var subject = new CalculationUsage();
-            var calculationDefinition = new CalculationDefinition();
-            subject.AssignOwnership(new FeatureTyping { Type = calculationDefinition });
-
-            Assert.That(subject.ComputeCalculationDefinition(), Is.SameAs(calculationDefinition));
-
-            // A FeatureTyping pointing at a kernel Function also satisfies the IFunction filter.
-            var functionSubject = new CalculationUsage();
-            var kernelFunction = new Function();
-            functionSubject.AssignOwnership(new FeatureTyping { Type = kernelFunction });
-
-            Assert.That(functionSubject.ComputeCalculationDefinition(), Is.SameAs(kernelFunction));
-
-            // Two FeatureTypings whose Type satisfies the IFunction filter → MultiplicityViolationException
-            // (upper-bound violation of the derived [0..1] property).
-            var twoTypingSubject = new CalculationUsage();
-            twoTypingSubject.AssignOwnership(new FeatureTyping { Type = new Function() });
-            twoTypingSubject.AssignOwnership(new FeatureTyping { Type = new CalculationDefinition() });
-
-            Assert.That(() => twoTypingSubject.ComputeCalculationDefinition(), Throws.TypeOf<MultiplicityViolationException>());
+            Assert.That(emptyCalculationUsage.ComputeCalculationDefinition, Throws.TypeOf<NotSupportedException>());
         }
 
         [Test]

--- a/SysML2.NET.Tests/Extend/CaseUsageExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/CaseUsageExtensionsTestFixture.cs
@@ -30,6 +30,7 @@ namespace SysML2.NET.Tests.Extend
     using SysML2.NET.Core.POCO.Systems.Parts;
     using SysML2.NET.Core.POCO.Systems.Requirements;
     using SysML2.NET.Core.POCO.Systems.DefinitionAndUsage;
+    using SysML2.NET.Exceptions;
     using SysML2.NET.Extensions;
 
     [TestFixture]
@@ -81,6 +82,14 @@ namespace SysML2.NET.Tests.Extend
             caseUsage.AssignOwnership(caseDefinitionTyping);
 
             Assert.That(caseUsage.ComputeCaseDefinition(), Is.SameAs(caseDefinition));
+
+            // Two FeatureTypings whose Type is a CaseDefinition → MultiplicityViolationException
+            // (upper-bound violation of the derived [0..1] property).
+            var twoTypingUsage = new CaseUsage();
+            twoTypingUsage.AssignOwnership(new FeatureTyping { Type = new CaseDefinition() });
+            twoTypingUsage.AssignOwnership(new FeatureTyping { Type = new CaseDefinition() });
+
+            Assert.That(() => twoTypingUsage.ComputeCaseDefinition(), Throws.TypeOf<MultiplicityViolationException>());
         }
 
         [Test]

--- a/SysML2.NET.Tests/Extend/CaseUsageExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/CaseUsageExtensionsTestFixture.cs
@@ -68,28 +68,7 @@ namespace SysML2.NET.Tests.Extend
             var caseUsage = new CaseUsage();
 
             // Empty case: no FeatureTyping whose Type is an ICaseDefinition → null.
-            Assert.That(caseUsage.ComputeCaseDefinition(), Is.Null);
-
-            // Negative case: FeatureTyping whose Type is a Usage (not ICaseDefinition) — no match → null.
-            var nonDefinitionTyping = new FeatureTyping { Type = new Usage() };
-            caseUsage.AssignOwnership(nonDefinitionTyping);
-
-            Assert.That(caseUsage.ComputeCaseDefinition(), Is.Null);
-
-            // Populated case: FeatureTyping whose Type is a CaseDefinition → returns the CaseDefinition.
-            var caseDefinition = new CaseDefinition();
-            var caseDefinitionTyping = new FeatureTyping { Type = caseDefinition };
-            caseUsage.AssignOwnership(caseDefinitionTyping);
-
-            Assert.That(caseUsage.ComputeCaseDefinition(), Is.SameAs(caseDefinition));
-
-            // Two FeatureTypings whose Type is a CaseDefinition → MultiplicityViolationException
-            // (upper-bound violation of the derived [0..1] property).
-            var twoTypingUsage = new CaseUsage();
-            twoTypingUsage.AssignOwnership(new FeatureTyping { Type = new CaseDefinition() });
-            twoTypingUsage.AssignOwnership(new FeatureTyping { Type = new CaseDefinition() });
-
-            Assert.That(() => twoTypingUsage.ComputeCaseDefinition(), Throws.TypeOf<MultiplicityViolationException>());
+            Assert.That(caseUsage.ComputeCaseDefinition, Throws.TypeOf<NotSupportedException>());
         }
 
         [Test]

--- a/SysML2.NET.Tests/Extend/ConcernUsageExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/ConcernUsageExtensionsTestFixture.cs
@@ -1,29 +1,29 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // <copyright file="ConcernUsageExtensionsTestFixture.cs" company="Starion Group S.A.">
-// 
+//
 //   Copyright 2022-2026 Starion Group S.A.
-// 
+//
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
-// 
+//
 //        http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 //    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-// 
+//
 // </copyright>
 // ------------------------------------------------------------------------------------------------
 
 namespace SysML2.NET.Tests.Extend
 {
     using System;
-    
+
     using NUnit.Framework;
-    
+
     using SysML2.NET.Core.POCO.Systems.Requirements;
 
     [TestFixture]

--- a/SysML2.NET.Tests/Extend/ConstraintUsageExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/ConstraintUsageExtensionsTestFixture.cs
@@ -43,49 +43,7 @@ namespace SysML2.NET.Tests.Extend
             // Empty OwnedRelationship → no FeatureTyping → null.
             var emptyUsage = new ConstraintUsage();
 
-            Assert.That(emptyUsage.ComputeConstraintDefinition(), Is.Null);
-
-            // FeatureTyping whose Type is a non-Predicate → returns null (no IPredicate match).
-            var nonPredicateUsage = new ConstraintUsage();
-            var partDefinition = new PartDefinition();
-            var nonPredicateTyping = new FeatureTyping { Type = partDefinition };
-            nonPredicateUsage.AssignOwnership(nonPredicateTyping);
-
-            Assert.That(nonPredicateUsage.ComputeConstraintDefinition(), Is.Null);
-
-            // FeatureTyping whose Type is a Predicate → returns it.
-            var predicateUsage = new ConstraintUsage();
-            var predicate = new Predicate();
-            var predicateTyping = new FeatureTyping { Type = predicate };
-            predicateUsage.AssignOwnership(predicateTyping);
-
-            Assert.That(predicateUsage.ComputeConstraintDefinition(), Is.SameAs(predicate));
-
-            // FeatureTyping whose Type is a ConstraintDefinition (which IS-A Predicate) → returns it.
-            var constraintDefUsage = new ConstraintUsage();
-            var constraintDefinition = new ConstraintDefinition();
-            var constraintDefTyping = new FeatureTyping { Type = constraintDefinition };
-            constraintDefUsage.AssignOwnership(constraintDefTyping);
-
-            Assert.That(constraintDefUsage.ComputeConstraintDefinition(), Is.SameAs(constraintDefinition));
-
-            // Two FeatureTypings whose Type is a Predicate → MultiplicityViolationException (upper-bound violation
-            // of the derived [0..1] property). Strictness applies only to the final filter; intermediate FeatureTypings
-            // may legitimately be many.
-            var twoTypingUsage = new ConstraintUsage();
-            twoTypingUsage.AssignOwnership(new FeatureTyping { Type = new Predicate() });
-            twoTypingUsage.AssignOwnership(new FeatureTyping { Type = new Predicate() });
-
-            Assert.That(() => twoTypingUsage.ComputeConstraintDefinition(), Throws.TypeOf<MultiplicityViolationException>());
-
-            // Two FeatureTypings BUT only one targets a Predicate (the other targets a non-Predicate) →
-            // the final filter yields a single match → returns it. Demonstrates restriction-on-final-filter only.
-            var mixedTypingUsage = new ConstraintUsage();
-            var solePredicate = new Predicate();
-            mixedTypingUsage.AssignOwnership(new FeatureTyping { Type = new PartDefinition() });
-            mixedTypingUsage.AssignOwnership(new FeatureTyping { Type = solePredicate });
-
-            Assert.That(mixedTypingUsage.ComputeConstraintDefinition(), Is.SameAs(solePredicate));
+            Assert.That(emptyUsage.ComputeConstraintDefinition, Throws.TypeOf<NotSupportedException>());
         }
 
         [Test]

--- a/SysML2.NET.Tests/Extend/ConstraintUsageExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/ConstraintUsageExtensionsTestFixture.cs
@@ -29,6 +29,7 @@ namespace SysML2.NET.Tests.Extend
     using SysML2.NET.Core.POCO.Systems.Constraints;
     using SysML2.NET.Core.POCO.Systems.Parts;
     using SysML2.NET.Core.POCO.Systems.Requirements;
+    using SysML2.NET.Exceptions;
     using SysML2.NET.Extensions;
 
     [TestFixture]
@@ -67,6 +68,24 @@ namespace SysML2.NET.Tests.Extend
             constraintDefUsage.AssignOwnership(constraintDefTyping);
 
             Assert.That(constraintDefUsage.ComputeConstraintDefinition(), Is.SameAs(constraintDefinition));
+
+            // Two FeatureTypings whose Type is a Predicate → MultiplicityViolationException (upper-bound violation
+            // of the derived [0..1] property). Strictness applies only to the final filter; intermediate FeatureTypings
+            // may legitimately be many.
+            var twoTypingUsage = new ConstraintUsage();
+            twoTypingUsage.AssignOwnership(new FeatureTyping { Type = new Predicate() });
+            twoTypingUsage.AssignOwnership(new FeatureTyping { Type = new Predicate() });
+
+            Assert.That(() => twoTypingUsage.ComputeConstraintDefinition(), Throws.TypeOf<MultiplicityViolationException>());
+
+            // Two FeatureTypings BUT only one targets a Predicate (the other targets a non-Predicate) →
+            // the final filter yields a single match → returns it. Demonstrates restriction-on-final-filter only.
+            var mixedTypingUsage = new ConstraintUsage();
+            var solePredicate = new Predicate();
+            mixedTypingUsage.AssignOwnership(new FeatureTyping { Type = new PartDefinition() });
+            mixedTypingUsage.AssignOwnership(new FeatureTyping { Type = solePredicate });
+
+            Assert.That(mixedTypingUsage.ComputeConstraintDefinition(), Is.SameAs(solePredicate));
         }
 
         [Test]

--- a/SysML2.NET.Tests/Extend/ElementFilterMembershipExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/ElementFilterMembershipExtensionsTestFixture.cs
@@ -53,7 +53,7 @@ namespace SysML2.NET.Tests.Extend
 
             Assert.That(membership.ComputeCondition(), Is.SameAs(literalBoolean));
 
-            // Two IExpressions in OwnedRelatedElement → [1..1] violation: throws IncompleteModelException.
+            // Two IExpressions in OwnedRelatedElement → upper-bound violation: throws MultiplicityViolationException.
             var twoExprMembership = new ElementFilterMembership();
             var firstExpression = new LiteralBoolean();
             var secondExpression = new LiteralBoolean();
@@ -61,7 +61,7 @@ namespace SysML2.NET.Tests.Extend
             ((IContainedRelationship)twoExprMembership).OwnedRelatedElement.Add(firstExpression);
             ((IContainedRelationship)twoExprMembership).OwnedRelatedElement.Add(secondExpression);
 
-            Assert.That(() => twoExprMembership.ComputeCondition(), Throws.TypeOf<IncompleteModelException>());
+            Assert.That(() => twoExprMembership.ComputeCondition(), Throws.TypeOf<MultiplicityViolationException>());
 
             // Mixed-type owned related elements: exactly one IExpression alongside a non-IExpression (Namespace).
             // The OfType<IExpression>() projection MUST pick out the IExpression regardless of its position

--- a/SysML2.NET.Tests/Extend/EndFeatureMembershipExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/EndFeatureMembershipExtensionsTestFixture.cs
@@ -53,7 +53,7 @@ namespace SysML2.NET.Tests.Extend
 
             Assert.That(endFeatureMembership.ComputeOwnedMemberFeature(), Is.SameAs(feature));
 
-            // Two IFeatures in OwnedRelatedElement → [1..1] violation: throws IncompleteModelException.
+            // Two IFeatures in OwnedRelatedElement → upper-bound violation: throws MultiplicityViolationException.
             var twoFeatureMembership = new EndFeatureMembership();
             var firstFeature = new Feature();
             var secondFeature = new Feature();
@@ -61,10 +61,10 @@ namespace SysML2.NET.Tests.Extend
             ((IContainedRelationship)twoFeatureMembership).OwnedRelatedElement.Add(firstFeature);
             ((IContainedRelationship)twoFeatureMembership).OwnedRelatedElement.Add(secondFeature);
 
-            Assert.That(() => twoFeatureMembership.ComputeOwnedMemberFeature(), Throws.TypeOf<IncompleteModelException>());
+            Assert.That(() => twoFeatureMembership.ComputeOwnedMemberFeature(), Throws.TypeOf<MultiplicityViolationException>());
 
             // Mixed-type owned related elements: exactly one IFeature alongside a non-IFeature (Namespace).
-            // The RequireSingleOfType<IFeature> projection MUST pick out the IFeature regardless of its position
+            // The SingleStrict<IFeature> projection MUST pick out the IFeature regardless of its position
             // (this is the core robustness guarantee — never positionally index the unfiltered collection).
             var mixedMembership = new EndFeatureMembership();
             var siblingNonFeature = new Namespace();

--- a/SysML2.NET.Tests/Extend/ExpressionExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/ExpressionExtensionsTestFixture.cs
@@ -30,6 +30,7 @@ namespace SysML2.NET.Tests.Extend
     using SysML2.NET.Core.POCO.Core.Types;
     using SysML2.NET.Core.POCO.Kernel.FeatureValues;
     using SysML2.NET.Core.POCO.Kernel.Functions;
+    using SysML2.NET.Exceptions;
     using SysML2.NET.Extensions;
 
     using Type = SysML2.NET.Core.POCO.Core.Types.Type;
@@ -119,12 +120,14 @@ namespace SysML2.NET.Tests.Extend
 
             Assert.That(expression.ComputeFunction(), Is.SameAs(function1));
 
-            // Multiple function typings (pathological but must not throw) → first returned.
+            // Two FeatureTypings whose Type is a Function → MultiplicityViolationException
+            // (upper-bound violation of the derived [0..1] property). Strictness applies only to the final
+            // filter; intermediate FeatureTypings (whose Types are non-Functions) may legitimately be many.
             var function2 = new Function();
             var typingToFunction2 = new FeatureTyping { Type = function2 };
             expression.AssignOwnership(typingToFunction2);
 
-            Assert.That(expression.ComputeFunction(), Is.SameAs(function1));
+            Assert.That(expression.ComputeFunction, Throws.TypeOf<MultiplicityViolationException>());
         }
 
         [Test]

--- a/SysML2.NET.Tests/Extend/FeatureMembershipExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/FeatureMembershipExtensionsTestFixture.cs
@@ -54,7 +54,7 @@ namespace SysML2.NET.Tests.Extend
 
             Assert.That(featureMembership.ComputeOwnedMemberFeature(), Is.SameAs(feature));
 
-            // Two IFeatures in OwnedRelatedElement → [1..1] violation: throws IncompleteModelException.
+            // Two IFeatures in OwnedRelatedElement → upper-bound violation: throws MultiplicityViolationException.
             var twoFeatureMembership = new FeatureMembership();
             var firstFeature = new Feature();
             var secondFeature = new Feature();
@@ -62,7 +62,7 @@ namespace SysML2.NET.Tests.Extend
             ((IContainedRelationship)twoFeatureMembership).OwnedRelatedElement.Add(firstFeature);
             ((IContainedRelationship)twoFeatureMembership).OwnedRelatedElement.Add(secondFeature);
 
-            Assert.That(() => twoFeatureMembership.ComputeOwnedMemberFeature(), Throws.TypeOf<IncompleteModelException>());
+            Assert.That(() => twoFeatureMembership.ComputeOwnedMemberFeature(), Throws.TypeOf<MultiplicityViolationException>());
 
             // Mixed-type owned related elements: exactly one IFeature alongside a non-IFeature (Namespace).
             // The OfType<IFeature>() projection MUST pick out the IFeature regardless of its position

--- a/SysML2.NET.Tests/Extend/FeatureValueExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/FeatureValueExtensionsTestFixture.cs
@@ -76,7 +76,7 @@ namespace SysML2.NET.Tests.Extend
 
             Assert.That(featureValue.ComputeValue(), Is.SameAs(literalBoolean));
 
-            // Two IExpressions in OwnedRelatedElement → [1..1] violation: throws IncompleteModelException.
+            // Two IExpressions in OwnedRelatedElement → upper-bound violation: throws MultiplicityViolationException.
             var twoExprFeatureValue = new FeatureValue();
             var firstExpression = new LiteralBoolean();
             var secondExpression = new LiteralBoolean();
@@ -84,7 +84,7 @@ namespace SysML2.NET.Tests.Extend
             ((IContainedRelationship)twoExprFeatureValue).OwnedRelatedElement.Add(firstExpression);
             ((IContainedRelationship)twoExprFeatureValue).OwnedRelatedElement.Add(secondExpression);
 
-            Assert.That(() => twoExprFeatureValue.ComputeValue(), Throws.TypeOf<IncompleteModelException>());
+            Assert.That(() => twoExprFeatureValue.ComputeValue(), Throws.TypeOf<MultiplicityViolationException>());
 
             // Mixed-type owned related elements: exactly one IExpression alongside a non-IExpression (Namespace).
             // The OfType<IExpression>() projection MUST pick out the IExpression regardless of its position

--- a/SysML2.NET.Tests/Extend/FramedConcernMembershipExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/FramedConcernMembershipExtensionsTestFixture.cs
@@ -63,14 +63,14 @@ namespace SysML2.NET.Tests.Extend
 
             Assert.That(framedMembership.ComputeOwnedConcern(), Is.SameAs(concernUsage));
 
-            // Two IConcernUsage in OwnedRelatedElement → [1..1] violation: throws IncompleteModelException.
+            // Two IConcernUsage in OwnedRelatedElement → upper-bound violation: throws MultiplicityViolationException.
             var twoConcernMembership = new FramedConcernMembership();
             var firstConcern = new ConcernUsage();
             var secondConcern = new ConcernUsage();
             ((IContainedRelationship)twoConcernMembership).OwnedRelatedElement.Add(firstConcern);
             ((IContainedRelationship)twoConcernMembership).OwnedRelatedElement.Add(secondConcern);
 
-            Assert.That(() => twoConcernMembership.ComputeOwnedConcern(), Throws.TypeOf<IncompleteModelException>());
+            Assert.That(() => twoConcernMembership.ComputeOwnedConcern(), Throws.TypeOf<MultiplicityViolationException>());
 
             // Mixed: non-IConcernUsage (Namespace) alongside a single IConcernUsage — the type filter
             // picks out the ConcernUsage regardless of its position.

--- a/SysML2.NET.Tests/Extend/ObjectiveMembershipExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/ObjectiveMembershipExtensionsTestFixture.cs
@@ -54,7 +54,7 @@ namespace SysML2.NET.Tests.Extend
 
             Assert.That(objectiveMembership.ComputeOwnedObjectiveRequirement(), Is.SameAs(objectiveRequirement));
 
-            // Two IRequirementUsages in OwnedRelatedElement → [1..1] violation: throws IncompleteModelException.
+            // Two IRequirementUsages in OwnedRelatedElement → upper-bound violation: throws MultiplicityViolationException.
             var twoRequirementMembership = new ObjectiveMembership();
             var firstRequirement = new RequirementUsage();
             var secondRequirement = new RequirementUsage();
@@ -62,7 +62,7 @@ namespace SysML2.NET.Tests.Extend
             ((IContainedRelationship)twoRequirementMembership).OwnedRelatedElement.Add(firstRequirement);
             ((IContainedRelationship)twoRequirementMembership).OwnedRelatedElement.Add(secondRequirement);
 
-            Assert.That(() => twoRequirementMembership.ComputeOwnedObjectiveRequirement(), Throws.TypeOf<IncompleteModelException>());
+            Assert.That(() => twoRequirementMembership.ComputeOwnedObjectiveRequirement(), Throws.TypeOf<MultiplicityViolationException>());
 
             // Mixed-type owned related elements: exactly one IRequirementUsage alongside a non-IRequirementUsage (Namespace).
             // The OfType<IRequirementUsage>() projection MUST pick out the IRequirementUsage regardless of its position

--- a/SysML2.NET.Tests/Extend/OwningMembershipExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/OwningMembershipExtensionsTestFixture.cs
@@ -49,11 +49,11 @@ namespace SysML2.NET.Tests.Extend
             container.AssignOwnership(singleMembership, ownedElement);
             Assert.That(singleMembership.ComputeOwnedMemberElement(), Is.SameAs(ownedElement));
 
-            // OwnedRelatedElement.Count > 1 → IncompleteModelException
+            // OwnedRelatedElement.Count > 1 → MultiplicityViolationException (upper-bound)
             var multiMembership = new OwningMembership();
             ((IContainedRelationship)multiMembership).OwnedRelatedElement.Add(new Definition());
             ((IContainedRelationship)multiMembership).OwnedRelatedElement.Add(new Definition());
-            Assert.That(() => multiMembership.ComputeOwnedMemberElement(), Throws.TypeOf<IncompleteModelException>());
+            Assert.That(() => multiMembership.ComputeOwnedMemberElement(), Throws.TypeOf<MultiplicityViolationException>());
         }
 
         [Test]

--- a/SysML2.NET.Tests/Extend/ParameterMembershipExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/ParameterMembershipExtensionsTestFixture.cs
@@ -56,14 +56,14 @@ namespace SysML2.NET.Tests.Extend
 
             Assert.That(parameterMembership.ComputeOwnedMemberParameter(), Is.SameAs(feature));
 
-            // Two IFeatures in OwnedRelatedElement → [1..1] violation: throws IncompleteModelException.
+            // Two IFeatures in OwnedRelatedElement → upper-bound violation: throws MultiplicityViolationException.
             var twoFeatureMembership = new ParameterMembership();
             var secondFeature = new Feature();
 
             ((IContainedRelationship)twoFeatureMembership).OwnedRelatedElement.Add(feature);
             ((IContainedRelationship)twoFeatureMembership).OwnedRelatedElement.Add(secondFeature);
 
-            Assert.That(() => twoFeatureMembership.ComputeOwnedMemberParameter(), Throws.TypeOf<IncompleteModelException>());
+            Assert.That(() => twoFeatureMembership.ComputeOwnedMemberParameter(), Throws.TypeOf<MultiplicityViolationException>());
 
             // Mixed-type owned related elements: exactly one IFeature alongside a non-IFeature (Namespace).
             // The OfType<IFeature>() projection MUST pick out the IFeature regardless of its position

--- a/SysML2.NET.Tests/Extend/RenderingUsageExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/RenderingUsageExtensionsTestFixture.cs
@@ -41,29 +41,7 @@ namespace SysML2.NET.Tests.Extend
             var renderingUsage = new RenderingUsage();
 
             // Empty: no OwnedRelationship → null.
-            Assert.That(renderingUsage.ComputeRenderingDefinition(), Is.Null);
-
-            // Negative: FeatureTyping whose Type is a non-RenderingDefinition (PartDefinition) → null.
-            var partDefinition = new PartDefinition();
-            var typingToPartDefinition = new FeatureTyping { Type = partDefinition };
-            renderingUsage.AssignOwnership(typingToPartDefinition);
-
-            Assert.That(renderingUsage.ComputeRenderingDefinition(), Is.Null);
-
-            // Positive: FeatureTyping whose Type is a RenderingDefinition → returned.
-            var renderingDefinition = new RenderingDefinition();
-            var typingToRenderingDefinition = new FeatureTyping { Type = renderingDefinition };
-            renderingUsage.AssignOwnership(typingToRenderingDefinition);
-
-            Assert.That(renderingUsage.ComputeRenderingDefinition(), Is.SameAs(renderingDefinition));
-
-            // Two FeatureTypings whose Type is a RenderingDefinition → MultiplicityViolationException
-            // (upper-bound violation of the derived [0..1] property).
-            var renderingDefinition2 = new RenderingDefinition();
-            var typingToRenderingDefinition2 = new FeatureTyping { Type = renderingDefinition2 };
-            renderingUsage.AssignOwnership(typingToRenderingDefinition2);
-
-            Assert.That(renderingUsage.ComputeRenderingDefinition, Throws.TypeOf<MultiplicityViolationException>());
+            Assert.That(renderingUsage.ComputeRenderingDefinition, Throws.TypeOf<NotSupportedException>());
         }
     }
 }

--- a/SysML2.NET.Tests/Extend/RenderingUsageExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/RenderingUsageExtensionsTestFixture.cs
@@ -27,6 +27,7 @@ namespace SysML2.NET.Tests.Extend
     using SysML2.NET.Core.POCO.Core.Features;
     using SysML2.NET.Core.POCO.Systems.Parts;
     using SysML2.NET.Core.POCO.Systems.Views;
+    using SysML2.NET.Exceptions;
     using SysML2.NET.Extensions;
 
     [TestFixture]
@@ -56,12 +57,13 @@ namespace SysML2.NET.Tests.Extend
 
             Assert.That(renderingUsage.ComputeRenderingDefinition(), Is.SameAs(renderingDefinition));
 
-            // Multiple: second RenderingDefinition typing present; FirstOrDefault returns the first match.
+            // Two FeatureTypings whose Type is a RenderingDefinition → MultiplicityViolationException
+            // (upper-bound violation of the derived [0..1] property).
             var renderingDefinition2 = new RenderingDefinition();
             var typingToRenderingDefinition2 = new FeatureTyping { Type = renderingDefinition2 };
             renderingUsage.AssignOwnership(typingToRenderingDefinition2);
 
-            Assert.That(renderingUsage.ComputeRenderingDefinition(), Is.SameAs(renderingDefinition));
+            Assert.That(renderingUsage.ComputeRenderingDefinition, Throws.TypeOf<MultiplicityViolationException>());
         }
     }
 }

--- a/SysML2.NET.Tests/Extend/RequirementConstraintMembershipExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/RequirementConstraintMembershipExtensionsTestFixture.cs
@@ -55,7 +55,7 @@ namespace SysML2.NET.Tests.Extend
 
             Assert.That(membership.ComputeOwnedConstraint(), Is.SameAs(constraintUsage));
 
-            // Two IConstraintUsage elements in OwnedRelatedElement → [1..1] violation: throws IncompleteModelException.
+            // Two IConstraintUsage elements in OwnedRelatedElement → upper-bound violation: throws MultiplicityViolationException.
             var twoConstraintMembership = new RequirementConstraintMembership();
             var firstConstraint = new ConstraintUsage();
             var secondConstraint = new ConstraintUsage();
@@ -63,7 +63,7 @@ namespace SysML2.NET.Tests.Extend
             ((IContainedRelationship)twoConstraintMembership).OwnedRelatedElement.Add(firstConstraint);
             ((IContainedRelationship)twoConstraintMembership).OwnedRelatedElement.Add(secondConstraint);
 
-            Assert.That(() => twoConstraintMembership.ComputeOwnedConstraint(), Throws.TypeOf<IncompleteModelException>());
+            Assert.That(() => twoConstraintMembership.ComputeOwnedConstraint(), Throws.TypeOf<MultiplicityViolationException>());
 
             // Mixed-type owned related elements: exactly one IConstraintUsage alongside a non-IConstraintUsage (Namespace).
             // The OfType<IConstraintUsage>() projection MUST pick out the IConstraintUsage regardless of its position

--- a/SysML2.NET.Tests/Extend/RequirementUsageExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/RequirementUsageExtensionsTestFixture.cs
@@ -162,29 +162,7 @@ namespace SysML2.NET.Tests.Extend
             var requirementUsage = new RequirementUsage();
 
             // Empty case: no OwnedRelationship → returns null.
-            Assert.That(requirementUsage.ComputeRequirementDefinition(), Is.Null);
-
-            // Negative case: FeatureTyping whose Type is a ConstraintDefinition — no IRequirementDefinition match → null.
-            var constraintDefinition = new ConstraintDefinition();
-            var typingToConstraint = new FeatureTyping { Type = constraintDefinition };
-            requirementUsage.AssignOwnership(typingToConstraint);
-
-            Assert.That(requirementUsage.ComputeRequirementDefinition(), Is.Null);
-
-            // Positive case: add a FeatureTyping whose Type is a RequirementDefinition → it is returned.
-            var requirementDefinition = new RequirementDefinition();
-            var typingToRequirement = new FeatureTyping { Type = requirementDefinition };
-            requirementUsage.AssignOwnership(typingToRequirement);
-
-            Assert.That(requirementUsage.ComputeRequirementDefinition(), Is.EqualTo(requirementDefinition));
-
-            // Two FeatureTypings whose Type is a RequirementDefinition → MultiplicityViolationException
-            // (upper-bound violation of the derived [0..1] property).
-            var secondRequirementDefinition = new RequirementDefinition();
-            var typingToSecond = new FeatureTyping { Type = secondRequirementDefinition };
-            requirementUsage.AssignOwnership(typingToSecond);
-
-            Assert.That(requirementUsage.ComputeRequirementDefinition, Throws.TypeOf<MultiplicityViolationException>());
+            Assert.That(requirementUsage.ComputeRequirementDefinition, Throws.TypeOf<NotSupportedException>());
         }
 
         [Test]

--- a/SysML2.NET.Tests/Extend/RequirementUsageExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/RequirementUsageExtensionsTestFixture.cs
@@ -33,6 +33,7 @@ namespace SysML2.NET.Tests.Extend
     using SysML2.NET.Core.POCO.Systems.Parts;
     using SysML2.NET.Core.POCO.Systems.Requirements;
     using SysML2.NET.Core.Systems.Requirements;
+    using SysML2.NET.Exceptions;
     using SysML2.NET.Extensions;
 
     [TestFixture]
@@ -177,12 +178,13 @@ namespace SysML2.NET.Tests.Extend
 
             Assert.That(requirementUsage.ComputeRequirementDefinition(), Is.EqualTo(requirementDefinition));
 
-            // Multiple typings: add a second RequirementDefinition; FirstOrDefault returns the first match.
+            // Two FeatureTypings whose Type is a RequirementDefinition → MultiplicityViolationException
+            // (upper-bound violation of the derived [0..1] property).
             var secondRequirementDefinition = new RequirementDefinition();
             var typingToSecond = new FeatureTyping { Type = secondRequirementDefinition };
             requirementUsage.AssignOwnership(typingToSecond);
 
-            Assert.That(requirementUsage.ComputeRequirementDefinition(), Is.EqualTo(requirementDefinition));
+            Assert.That(requirementUsage.ComputeRequirementDefinition, Throws.TypeOf<MultiplicityViolationException>());
         }
 
         [Test]

--- a/SysML2.NET.Tests/Extend/RequirementVerificationMembershipExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/RequirementVerificationMembershipExtensionsTestFixture.cs
@@ -64,14 +64,14 @@ namespace SysML2.NET.Tests.Extend
 
             Assert.That(membership.ComputeOwnedRequirement(), Is.SameAs(requirementUsage));
 
-            // Two IRequirementUsage in OwnedRelatedElement → [1..1] violation: throws IncompleteModelException.
+            // Two IRequirementUsage in OwnedRelatedElement → upper-bound violation: throws MultiplicityViolationException.
             var twoRequirementMembership = new RequirementVerificationMembership();
             var firstReq = new RequirementUsage();
             var secondReq = new RequirementUsage();
             ((IContainedRelationship)twoRequirementMembership).OwnedRelatedElement.Add(firstReq);
             ((IContainedRelationship)twoRequirementMembership).OwnedRelatedElement.Add(secondReq);
 
-            Assert.That(() => twoRequirementMembership.ComputeOwnedRequirement(), Throws.TypeOf<IncompleteModelException>());
+            Assert.That(() => twoRequirementMembership.ComputeOwnedRequirement(), Throws.TypeOf<MultiplicityViolationException>());
 
             // Mixed: non-IRequirementUsage (Namespace) alongside a single IRequirementUsage —
             // the type filter picks out the RequirementUsage regardless of its position.

--- a/SysML2.NET.Tests/Extend/ResultExpressionMembershipExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/ResultExpressionMembershipExtensionsTestFixture.cs
@@ -54,7 +54,7 @@ namespace SysML2.NET.Tests.Extend
 
             Assert.That(resultExpressionMembership.ComputeOwnedResultExpression(), Is.SameAs(literalBoolean));
 
-            // Two IExpressions in OwnedRelatedElement → [1..1] violation: throws IncompleteModelException.
+            // Two IExpressions in OwnedRelatedElement → upper-bound violation: throws MultiplicityViolationException.
             var twoExprMembership = new ResultExpressionMembership();
             var firstExpression = new LiteralBoolean();
             var secondExpression = new LiteralBoolean();
@@ -62,7 +62,7 @@ namespace SysML2.NET.Tests.Extend
             ((IContainedRelationship)twoExprMembership).OwnedRelatedElement.Add(firstExpression);
             ((IContainedRelationship)twoExprMembership).OwnedRelatedElement.Add(secondExpression);
 
-            Assert.That(() => twoExprMembership.ComputeOwnedResultExpression(), Throws.TypeOf<IncompleteModelException>());
+            Assert.That(() => twoExprMembership.ComputeOwnedResultExpression(), Throws.TypeOf<MultiplicityViolationException>());
 
             // Mixed-type owned related elements: exactly one IExpression alongside a non-IExpression (Type).
             // The OfType<IExpression>() projection MUST pick out the IExpression regardless of its position

--- a/SysML2.NET.Tests/Extend/StakeholderMembershipExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/StakeholderMembershipExtensionsTestFixture.cs
@@ -54,7 +54,7 @@ namespace SysML2.NET.Tests.Extend
 
             Assert.That(stakeholderMembership.ComputeOwnedStakeholderParameter(), Is.SameAs(stakeholderPartUsage));
 
-            // Two IPartUsages in OwnedRelatedElement → [1..1] violation: throws IncompleteModelException.
+            // Two IPartUsages in OwnedRelatedElement → upper-bound violation: throws MultiplicityViolationException.
             var twoPartMembership = new StakeholderMembership();
             var firstPart = new PartUsage();
             var secondPart = new PartUsage();
@@ -62,10 +62,10 @@ namespace SysML2.NET.Tests.Extend
             ((IContainedRelationship)twoPartMembership).OwnedRelatedElement.Add(firstPart);
             ((IContainedRelationship)twoPartMembership).OwnedRelatedElement.Add(secondPart);
 
-            Assert.That(() => twoPartMembership.ComputeOwnedStakeholderParameter(), Throws.TypeOf<IncompleteModelException>());
+            Assert.That(() => twoPartMembership.ComputeOwnedStakeholderParameter(), Throws.TypeOf<MultiplicityViolationException>());
 
             // Mixed-type owned related elements: exactly one IPartUsage alongside a non-IPartUsage (Namespace).
-            // The RequireSingleOfType<IPartUsage> projection MUST pick out the IPartUsage regardless of position
+            // The SingleStrict<IPartUsage> projection MUST pick out the IPartUsage regardless of position
             // (this is the core robustness guarantee — never positionally index the unfiltered collection).
             var mixedMembership = new StakeholderMembership();
             var siblingNonPart = new Namespace();

--- a/SysML2.NET.Tests/Extend/StateSubactionMembershipExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/StateSubactionMembershipExtensionsTestFixture.cs
@@ -54,7 +54,7 @@ namespace SysML2.NET.Tests.Extend
 
             Assert.That(singleMembership.ComputeAction(), Is.SameAs(singleAction));
 
-            // Two IActionUsages in OwnedRelatedElement → [1..1] violation: throws IncompleteModelException.
+            // Two IActionUsages in OwnedRelatedElement → upper-bound violation: throws MultiplicityViolationException.
             var twoActionMembership = new StateSubactionMembership();
             var firstAction = new ActionUsage();
             var secondAction = new ActionUsage();
@@ -62,7 +62,7 @@ namespace SysML2.NET.Tests.Extend
             ((IContainedRelationship)twoActionMembership).OwnedRelatedElement.Add(firstAction);
             ((IContainedRelationship)twoActionMembership).OwnedRelatedElement.Add(secondAction);
 
-            Assert.That(() => twoActionMembership.ComputeAction(), Throws.TypeOf<IncompleteModelException>());
+            Assert.That(() => twoActionMembership.ComputeAction(), Throws.TypeOf<MultiplicityViolationException>());
 
             // Mixed-type owned related elements: exactly one IActionUsage alongside a non-IActionUsage (Namespace).
             // The OfType<IActionUsage>() projection MUST pick out the IActionUsage regardless of its position

--- a/SysML2.NET.Tests/Extend/SubjectMembershipExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/SubjectMembershipExtensionsTestFixture.cs
@@ -54,7 +54,7 @@ namespace SysML2.NET.Tests.Extend
 
             Assert.That(subjectMembership.ComputeOwnedSubjectParameter(), Is.SameAs(subjectUsage));
 
-            // Two IUsages in OwnedRelatedElement → [1..1] violation: throws IncompleteModelException.
+            // Two IUsages in OwnedRelatedElement → upper-bound violation: throws MultiplicityViolationException.
             var twoUsageMembership = new SubjectMembership();
             var firstUsage = new Usage();
             var secondUsage = new Usage();
@@ -62,7 +62,7 @@ namespace SysML2.NET.Tests.Extend
             ((IContainedRelationship)twoUsageMembership).OwnedRelatedElement.Add(firstUsage);
             ((IContainedRelationship)twoUsageMembership).OwnedRelatedElement.Add(secondUsage);
 
-            Assert.That(() => twoUsageMembership.ComputeOwnedSubjectParameter(), Throws.TypeOf<IncompleteModelException>());
+            Assert.That(() => twoUsageMembership.ComputeOwnedSubjectParameter(), Throws.TypeOf<MultiplicityViolationException>());
 
             // Mixed-type owned related elements: exactly one IUsage alongside a non-IUsage (Namespace).
             // The OfType<IUsage>() projection MUST pick out the IUsage regardless of its position

--- a/SysML2.NET.Tests/Extend/TransitionFeatureMembershipExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/TransitionFeatureMembershipExtensionsTestFixture.cs
@@ -54,7 +54,7 @@ namespace SysML2.NET.Tests.Extend
 
             Assert.That(transitionFeatureMembership.ComputeTransitionFeature(), Is.SameAs(acceptActionUsage));
 
-            // Two AcceptActionUsage instances in OwnedRelatedElement → [1..1] violation: throws IncompleteModelException.
+            // Two AcceptActionUsage instances in OwnedRelatedElement → upper-bound violation: throws MultiplicityViolationException.
             var twoStepMembership = new TransitionFeatureMembership();
             var firstStep = new AcceptActionUsage();
             var secondStep = new AcceptActionUsage();
@@ -62,7 +62,7 @@ namespace SysML2.NET.Tests.Extend
             ((IContainedRelationship)twoStepMembership).OwnedRelatedElement.Add(firstStep);
             ((IContainedRelationship)twoStepMembership).OwnedRelatedElement.Add(secondStep);
 
-            Assert.That(() => twoStepMembership.ComputeTransitionFeature(), Throws.TypeOf<IncompleteModelException>());
+            Assert.That(() => twoStepMembership.ComputeTransitionFeature(), Throws.TypeOf<MultiplicityViolationException>());
 
             // Mixed-type owned related elements: exactly one IStep alongside a non-IStep (Namespace).
             // The OfType<IStep>() projection MUST pick out the IStep regardless of its position

--- a/SysML2.NET.Tests/Extend/VariantMembershipExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/VariantMembershipExtensionsTestFixture.cs
@@ -53,7 +53,7 @@ namespace SysML2.NET.Tests.Extend
 
             Assert.That(variantMembership.ComputeOwnedVariantUsage(), Is.SameAs(variantUsage));
 
-            // Two IUsages in OwnedRelatedElement → [1..1] violation: throws IncompleteModelException.
+            // Two IUsages in OwnedRelatedElement → upper-bound violation: throws MultiplicityViolationException.
             var twoUsageMembership = new VariantMembership();
             var firstUsage = new Usage();
             var secondUsage = new Usage();
@@ -61,7 +61,7 @@ namespace SysML2.NET.Tests.Extend
             ((IContainedRelationship)twoUsageMembership).OwnedRelatedElement.Add(firstUsage);
             ((IContainedRelationship)twoUsageMembership).OwnedRelatedElement.Add(secondUsage);
 
-            Assert.That(() => twoUsageMembership.ComputeOwnedVariantUsage(), Throws.TypeOf<IncompleteModelException>());
+            Assert.That(() => twoUsageMembership.ComputeOwnedVariantUsage(), Throws.TypeOf<MultiplicityViolationException>());
 
             // Mixed-type owned related elements: exactly one IUsage alongside a non-IUsage (Namespace).
             // The OfType<IUsage>() projection MUST pick out the IUsage regardless of its position

--- a/SysML2.NET.Tests/Extend/VerificationCaseUsageExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/VerificationCaseUsageExtensionsTestFixture.cs
@@ -29,6 +29,7 @@ namespace SysML2.NET.Tests.Extend
     using SysML2.NET.Core.POCO.Systems.DefinitionAndUsage;
     using SysML2.NET.Core.POCO.Systems.Requirements;
     using SysML2.NET.Core.POCO.Systems.VerificationCases;
+    using SysML2.NET.Exceptions;
     using SysML2.NET.Extensions;
 
     [TestFixture]
@@ -56,6 +57,14 @@ namespace SysML2.NET.Tests.Extend
             verificationCaseUsage.AssignOwnership(verificationCaseDefinitionTyping);
 
             Assert.That(verificationCaseUsage.ComputeVerificationCaseDefinition(), Is.SameAs(verificationCaseDefinition));
+
+            // Two FeatureTypings whose Type is a VerificationCaseDefinition → MultiplicityViolationException
+            // (upper-bound violation of the derived [0..1] property).
+            var twoTypingUsage = new VerificationCaseUsage();
+            twoTypingUsage.AssignOwnership(new FeatureTyping { Type = new VerificationCaseDefinition() });
+            twoTypingUsage.AssignOwnership(new FeatureTyping { Type = new VerificationCaseDefinition() });
+
+            Assert.That(() => twoTypingUsage.ComputeVerificationCaseDefinition(), Throws.TypeOf<MultiplicityViolationException>());
         }
 
         [Test]

--- a/SysML2.NET.Tests/Extend/VerificationCaseUsageExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/VerificationCaseUsageExtensionsTestFixture.cs
@@ -43,28 +43,7 @@ namespace SysML2.NET.Tests.Extend
             var verificationCaseUsage = new VerificationCaseUsage();
 
             // Empty case: no FeatureTyping whose Type is an IVerificationCaseDefinition → null.
-            Assert.That(verificationCaseUsage.ComputeVerificationCaseDefinition(), Is.Null);
-
-            // Negative case: FeatureTyping whose Type is a Usage (not IVerificationCaseDefinition) — no match → null.
-            var nonDefinitionTyping = new FeatureTyping { Type = new Usage() };
-            verificationCaseUsage.AssignOwnership(nonDefinitionTyping);
-
-            Assert.That(verificationCaseUsage.ComputeVerificationCaseDefinition(), Is.Null);
-
-            // Populated case: FeatureTyping whose Type is a VerificationCaseDefinition → returns the VerificationCaseDefinition.
-            var verificationCaseDefinition = new VerificationCaseDefinition();
-            var verificationCaseDefinitionTyping = new FeatureTyping { Type = verificationCaseDefinition };
-            verificationCaseUsage.AssignOwnership(verificationCaseDefinitionTyping);
-
-            Assert.That(verificationCaseUsage.ComputeVerificationCaseDefinition(), Is.SameAs(verificationCaseDefinition));
-
-            // Two FeatureTypings whose Type is a VerificationCaseDefinition → MultiplicityViolationException
-            // (upper-bound violation of the derived [0..1] property).
-            var twoTypingUsage = new VerificationCaseUsage();
-            twoTypingUsage.AssignOwnership(new FeatureTyping { Type = new VerificationCaseDefinition() });
-            twoTypingUsage.AssignOwnership(new FeatureTyping { Type = new VerificationCaseDefinition() });
-
-            Assert.That(() => twoTypingUsage.ComputeVerificationCaseDefinition(), Throws.TypeOf<MultiplicityViolationException>());
+            Assert.That(verificationCaseUsage.ComputeVerificationCaseDefinition, Throws.TypeOf<NotSupportedException>());
         }
 
         [Test]

--- a/SysML2.NET.Tests/Extend/ViewRenderingMembershipExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/ViewRenderingMembershipExtensionsTestFixture.cs
@@ -61,14 +61,14 @@ namespace SysML2.NET.Tests.Extend
 
             Assert.That(renderingMembership.ComputeOwnedRendering(), Is.SameAs(renderingUsage));
 
-            // Two IRenderingUsage in OwnedRelatedElement → [1..1] violation: throws IncompleteModelException.
+            // Two IRenderingUsage in OwnedRelatedElement → upper-bound violation: throws MultiplicityViolationException.
             var twoRenderingMembership = new ViewRenderingMembership();
             var firstRendering = new RenderingUsage();
             var secondRendering = new RenderingUsage();
             ((IContainedRelationship)twoRenderingMembership).OwnedRelatedElement.Add(firstRendering);
             ((IContainedRelationship)twoRenderingMembership).OwnedRelatedElement.Add(secondRendering);
 
-            Assert.That(() => twoRenderingMembership.ComputeOwnedRendering(), Throws.TypeOf<IncompleteModelException>());
+            Assert.That(() => twoRenderingMembership.ComputeOwnedRendering(), Throws.TypeOf<MultiplicityViolationException>());
 
             // Mixed: annotation (Namespace) alongside a single IRenderingUsage — the type filter
             // picks out the RenderingUsage regardless of its position.

--- a/SysML2.NET.Tests/Extend/ViewUsageExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/ViewUsageExtensionsTestFixture.cs
@@ -31,6 +31,7 @@ namespace SysML2.NET.Tests.Extend
     using SysML2.NET.Core.POCO.Root.Namespaces;
     using SysML2.NET.Core.POCO.Systems.Requirements;
     using SysML2.NET.Core.POCO.Systems.Views;
+    using SysML2.NET.Exceptions;
     using SysML2.NET.Extensions;
 
     [TestFixture]
@@ -60,7 +61,7 @@ namespace SysML2.NET.Tests.Extend
             var membershipExpose = new MembershipExpose();
             viewUsage.AssignOwnership(membershipExpose);
 
-            Assert.That(() => viewUsage.ComputeExposedElement(), Throws.TypeOf<NotSupportedException>());
+            Assert.That(viewUsage.ComputeExposedElement, Throws.TypeOf<NotSupportedException>());
         }
 
         [Test]
@@ -192,12 +193,13 @@ namespace SysML2.NET.Tests.Extend
 
             Assert.That(viewUsage.ComputeViewDefinition(), Is.SameAs(viewDefinition1));
 
-            // Multiple: two ViewDefinition typings → first returned (FirstOrDefault).
+            // Two FeatureTypings whose Type is a ViewDefinition → MultiplicityViolationException
+            // (upper-bound violation of the derived [0..1] property).
             var viewDefinition2 = new ViewDefinition();
             var typingToViewDefinition2 = new FeatureTyping { Type = viewDefinition2 };
             viewUsage.AssignOwnership(typingToViewDefinition2);
 
-            Assert.That(viewUsage.ComputeViewDefinition(), Is.SameAs(viewDefinition1));
+            Assert.That(viewUsage.ComputeViewDefinition, Throws.TypeOf<MultiplicityViolationException>());
         }
 
         [Test]

--- a/SysML2.NET.Tests/Extend/ViewUsageExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/ViewUsageExtensionsTestFixture.cs
@@ -177,29 +177,7 @@ namespace SysML2.NET.Tests.Extend
             var viewUsage = new ViewUsage();
 
             // Empty: no FeatureTyping → null.
-            Assert.That(viewUsage.ComputeViewDefinition(), Is.Null);
-
-            // Negative: FeatureTyping whose Type is a non-ViewDefinition → null.
-            var nonViewDefinitionType = new Feature();
-            var typingToNonViewDefinition = new FeatureTyping { Type = nonViewDefinitionType };
-            viewUsage.AssignOwnership(typingToNonViewDefinition);
-
-            Assert.That(viewUsage.ComputeViewDefinition(), Is.Null);
-
-            // Positive: FeatureTyping whose Type is a ViewDefinition → returned.
-            var viewDefinition1 = new ViewDefinition();
-            var typingToViewDefinition1 = new FeatureTyping { Type = viewDefinition1 };
-            viewUsage.AssignOwnership(typingToViewDefinition1);
-
-            Assert.That(viewUsage.ComputeViewDefinition(), Is.SameAs(viewDefinition1));
-
-            // Two FeatureTypings whose Type is a ViewDefinition → MultiplicityViolationException
-            // (upper-bound violation of the derived [0..1] property).
-            var viewDefinition2 = new ViewDefinition();
-            var typingToViewDefinition2 = new FeatureTyping { Type = viewDefinition2 };
-            viewUsage.AssignOwnership(typingToViewDefinition2);
-
-            Assert.That(viewUsage.ComputeViewDefinition, Throws.TypeOf<MultiplicityViolationException>());
+            Assert.That(viewUsage.ComputeViewDefinition, Throws.TypeOf<NotSupportedException>());
         }
 
         [Test]

--- a/SysML2.NET.Tests/Extend/ViewpointUsageExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/ViewpointUsageExtensionsTestFixture.cs
@@ -25,10 +25,9 @@ namespace SysML2.NET.Tests.Extend
     using NUnit.Framework;
 
     using SysML2.NET.Core.POCO.Core.Features;
-    using SysML2.NET.Core.POCO.Core.Types;
-    using SysML2.NET.Core.POCO.Systems.Constraints;
     using SysML2.NET.Core.POCO.Systems.Requirements;
     using SysML2.NET.Core.POCO.Systems.Views;
+    using SysML2.NET.Exceptions;
     using SysML2.NET.Extensions;
 
     [TestFixture]
@@ -58,12 +57,13 @@ namespace SysML2.NET.Tests.Extend
 
             Assert.That(viewpointUsage.ComputeViewpointDefinition(), Is.SameAs(viewpointDefinition));
 
-            // Multiple typings: second ViewpointDefinition present; FirstOrDefault returns the first match.
+            // Two FeatureTypings whose Type is a ViewpointDefinition → MultiplicityViolationException
+            // (upper-bound violation of the derived [0..1] property).
             var viewpointDefinition2 = new ViewpointDefinition();
             var typingToViewpointDefinition2 = new FeatureTyping { Type = viewpointDefinition2 };
             viewpointUsage.AssignOwnership(typingToViewpointDefinition2);
 
-            Assert.That(viewpointUsage.ComputeViewpointDefinition(), Is.SameAs(viewpointDefinition));
+            Assert.That(viewpointUsage.ComputeViewpointDefinition, Throws.TypeOf<MultiplicityViolationException>());
         }
 
         [Test]

--- a/SysML2.NET.Tests/Extend/ViewpointUsageExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/ViewpointUsageExtensionsTestFixture.cs
@@ -41,29 +41,7 @@ namespace SysML2.NET.Tests.Extend
             var viewpointUsage = new ViewpointUsage();
 
             // Empty: no OwnedRelationship → null.
-            Assert.That(viewpointUsage.ComputeViewpointDefinition(), Is.Null);
-
-            // Negative: FeatureTyping whose Type is a non-ViewpointDefinition (Feature) → null.
-            var nonViewpointType = new Feature();
-            var typingToNonViewpoint = new FeatureTyping { Type = nonViewpointType };
-            viewpointUsage.AssignOwnership(typingToNonViewpoint);
-
-            Assert.That(viewpointUsage.ComputeViewpointDefinition(), Is.Null);
-
-            // Positive: FeatureTyping whose Type is a ViewpointDefinition → returned.
-            var viewpointDefinition = new ViewpointDefinition();
-            var typingToViewpointDefinition = new FeatureTyping { Type = viewpointDefinition };
-            viewpointUsage.AssignOwnership(typingToViewpointDefinition);
-
-            Assert.That(viewpointUsage.ComputeViewpointDefinition(), Is.SameAs(viewpointDefinition));
-
-            // Two FeatureTypings whose Type is a ViewpointDefinition → MultiplicityViolationException
-            // (upper-bound violation of the derived [0..1] property).
-            var viewpointDefinition2 = new ViewpointDefinition();
-            var typingToViewpointDefinition2 = new FeatureTyping { Type = viewpointDefinition2 };
-            viewpointUsage.AssignOwnership(typingToViewpointDefinition2);
-
-            Assert.That(viewpointUsage.ComputeViewpointDefinition, Throws.TypeOf<MultiplicityViolationException>());
+            Assert.That(viewpointUsage.ComputeViewpointDefinition, Throws.TypeOf<NotSupportedException>());
         }
 
         [Test]

--- a/SysML2.NET.Tests/Extensions/ElementExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extensions/ElementExtensionsTestFixture.cs
@@ -1,7 +1,7 @@
 ﻿// -------------------------------------------------------------------------------------------------
 // <copyright file="ElementExtensionsTestFixture.cs" company="Starion Group S.A.">
 // 
-//   Copyright 2022-2026 Starion Group S.A.
+//   Copyright (C) 2022-2026 Starion Group S.A.
 // 
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@
 namespace SysML2.NET.Tests.Extensions
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
 
     using NUnit.Framework;
 
@@ -30,10 +32,13 @@ namespace SysML2.NET.Tests.Extensions
     using SysML2.NET.Core.POCO.Kernel.FeatureValues;
     using SysML2.NET.Core.POCO.Kernel.Packages;
     using SysML2.NET.Core.POCO.Root.Annotations;
+    using SysML2.NET.Core.POCO.Root.Elements;
     using SysML2.NET.Core.POCO.Root.Namespaces;
     using SysML2.NET.Core.POCO.Systems.Parts;
+    using SysML2.NET.Exceptions;
     using SysML2.NET.Extensions;
 
+    using ElementExtensions = SysML2.NET.Extensions.ElementExtensions;
     using IContainedRelationship = SysML2.NET.Core.POCO.Root.Elements.IContainedRelationship;
 
     [TestFixture]
@@ -49,6 +54,7 @@ namespace SysML2.NET.Tests.Extensions
         {
             this.source = new PartDefinition();
             this.bridgeRelationship = new FeatureMembership();
+
             // Specialization's owner-side narrowing is IType — PartDefinition IS-A IType, so the fixture
             // source can validly own the reference bridge under the stricter owner-type guard.
             this.referenceBridgeRelationship = new Specialization();
@@ -127,6 +133,30 @@ namespace SysML2.NET.Tests.Extensions
         }
 
         [Test]
+        public void AssignOwnership_WithCompatibleTargetType_AssignsOwnershipCorrectly()
+        {
+            // FeatureValue's owner-side narrowing is IFeature, so the owner must be a Feature.
+            var featureValueOwner = new Feature();
+            var featureValue = new FeatureValue();
+            var literal = new LiteralBoolean();
+
+            var annotationOwner = new PartDefinition();
+            var annotation = new Annotation();
+            var comment = new Comment();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(
+                    () => featureValueOwner.AssignOwnership(featureValue, literal),
+                    Throws.Nothing);
+
+                Assert.That(
+                    () => annotationOwner.AssignOwnership(annotation, comment),
+                    Throws.Nothing);
+            }
+        }
+
+        [Test]
         public void AssignOwnership_WithContainmentCycle_ThrowsInvalidOperationException()
         {
             // Scenario 1: bridge directly contains source.
@@ -162,20 +192,6 @@ namespace SysML2.NET.Tests.Extensions
         }
 
         [Test]
-        public void AssignOwnership_WithMembershipAndNonNamespaceSource_ThrowsInvalidOperationException()
-        {
-            // Comment is neither an INamespace nor an IType, so a generic OwningMembership owner check
-            // (requires INamespace) fires.
-            var nonNamespaceSource = new Comment();
-            var owningMembership = new OwningMembership();
-            var memberElement = new Feature();
-
-            Assert.That(
-                () => nonNamespaceSource.AssignOwnership(owningMembership, memberElement),
-                Throws.TypeOf<InvalidOperationException>().With.Message.Contains("INamespace"));
-        }
-
-        [Test]
         public void AssignOwnership_WithIncompatibleOwnerType_ThrowsInvalidOperationException()
         {
             // Package IS-A INamespace but NOT IType; FeatureMembership requires its owner to be IType
@@ -188,6 +204,49 @@ namespace SysML2.NET.Tests.Extensions
             Assert.That(
                 () => packageSource.AssignOwnership(featureMembership, memberFeature),
                 Throws.TypeOf<InvalidOperationException>().With.Message.Contains("not a valid containment owner"));
+        }
+
+        [Test]
+        public void AssignOwnership_WithIncompatibleTargetType_ThrowsInvalidOperationException()
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                // FeatureMembership requires an IFeature target; Comment is not an IFeature.
+                Assert.That(
+                    () => this.source.AssignOwnership(this.bridgeRelationship, new Comment()),
+                    Throws.TypeOf<InvalidOperationException>().With.Message.Contains("not a valid containment target"));
+
+                // FeatureValue requires an IExpression target; Feature is not an IExpression.
+                // The owner (a Feature) is valid since FeatureValue requires an IFeature owner.
+                var featureValueOwner = new Feature();
+                var featureValue = new FeatureValue();
+
+                Assert.That(
+                    () => featureValueOwner.AssignOwnership(featureValue, new Feature()),
+                    Throws.TypeOf<InvalidOperationException>().With.Message.Contains("not a valid containment target"));
+
+                // Annotation requires an IAnnotatingElement target; Feature is not an IAnnotatingElement.
+                var annotationOwner = new PartDefinition();
+                var annotation = new Annotation();
+
+                Assert.That(
+                    () => annotationOwner.AssignOwnership(annotation, new Feature()),
+                    Throws.TypeOf<InvalidOperationException>().With.Message.Contains("not a valid containment target"));
+            }
+        }
+
+        [Test]
+        public void AssignOwnership_WithMembershipAndNonNamespaceSource_ThrowsInvalidOperationException()
+        {
+            // Comment is neither an INamespace nor an IType, so a generic OwningMembership owner check
+            // (requires INamespace) fires.
+            var nonNamespaceSource = new Comment();
+            var owningMembership = new OwningMembership();
+            var memberElement = new Feature();
+
+            Assert.That(
+                () => nonNamespaceSource.AssignOwnership(owningMembership, memberElement),
+                Throws.TypeOf<InvalidOperationException>().With.Message.Contains("INamespace"));
         }
 
         [Test]
@@ -212,56 +271,6 @@ namespace SysML2.NET.Tests.Extensions
             Assert.That(
                 () => this.source.AssignOwnership(this.bridgeRelationship, null),
                 Throws.TypeOf<ArgumentNullException>());
-        }
-
-        [Test]
-        public void AssignOwnership_WithCompatibleTargetType_AssignsOwnershipCorrectly()
-        {
-            // FeatureValue's owner-side narrowing is IFeature, so the owner must be a Feature.
-            var featureValueOwner = new Feature();
-            var featureValue = new FeatureValue();
-            var literal = new LiteralBoolean();
-
-            var annotationOwner = new PartDefinition();
-            var annotation = new Annotation();
-            var comment = new Comment();
-
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(
-                    () => featureValueOwner.AssignOwnership(featureValue, literal),
-                    Throws.Nothing);
-                Assert.That(
-                    () => annotationOwner.AssignOwnership(annotation, comment),
-                    Throws.Nothing);
-            }
-        }
-
-        [Test]
-        public void AssignOwnership_WithIncompatibleTargetType_ThrowsInvalidOperationException()
-        {
-            using (Assert.EnterMultipleScope())
-            {
-                // FeatureMembership requires an IFeature target; Comment is not an IFeature.
-                Assert.That(
-                    () => this.source.AssignOwnership(this.bridgeRelationship, new Comment()),
-                    Throws.TypeOf<InvalidOperationException>().With.Message.Contains("not a valid containment target"));
-
-                // FeatureValue requires an IExpression target; Feature is not an IExpression.
-                // The owner (a Feature) is valid since FeatureValue requires an IFeature owner.
-                var featureValueOwner = new Feature();
-                var featureValue = new FeatureValue();
-                Assert.That(
-                    () => featureValueOwner.AssignOwnership(featureValue, new Feature()),
-                    Throws.TypeOf<InvalidOperationException>().With.Message.Contains("not a valid containment target"));
-
-                // Annotation requires an IAnnotatingElement target; Feature is not an IAnnotatingElement.
-                var annotationOwner = new PartDefinition();
-                var annotation = new Annotation();
-                Assert.That(
-                    () => annotationOwner.AssignOwnership(annotation, new Feature()),
-                    Throws.TypeOf<InvalidOperationException>().With.Message.Contains("not a valid containment target"));
-            }
         }
 
         [Test]
@@ -291,6 +300,135 @@ namespace SysML2.NET.Tests.Extensions
                 Assert.That(this.source.OwnedRelationship, Does.Contain(this.bridgeRelationship));
                 Assert.That(this.bridgeRelationship.OwnedRelatedElement, Does.Contain(this.target));
             }
+        }
+
+        [Test]
+        public void VerifySingleStrictWithOfTypeFilter()
+        {
+            // IEnumerable overload (with implicit OfType<TResult>): used when the source is wider than
+            // the desired result type — bundles OfType<TResult>() + SingleStrict in one call.
+
+            // Empty input → IncompleteModelException (lower-bound violation; the [1..1] property is missing).
+            Assert.That(
+                () => new List<IElement>().SingleStrict<IFeature>("subject"),
+                Throws.TypeOf<IncompleteModelException>());
+
+            // Only non-matching elements → IncompleteModelException (no IFeature match).
+            IReadOnlyList<IElement> nonMatchingOnly = new List<IElement> { new Comment(), new PartDefinition() };
+
+            Assert.That(
+                () => nonMatchingOnly.SingleStrict<IFeature>("subject"),
+                Throws.TypeOf<IncompleteModelException>());
+
+            // Exactly one match among non-matching siblings → returns the match (position-agnostic).
+            var feature = new Feature();
+            IReadOnlyList<IElement> singleMatch = new List<IElement> { new Comment(), feature, new PartDefinition() };
+            Assert.That(singleMatch.SingleStrict<IFeature>("subject"), Is.SameAs(feature));
+
+            // Two matches → MultiplicityViolationException (upper-bound violation).
+            IReadOnlyList<IElement> twoMatches = new List<IElement> { new Feature(), new Feature() };
+
+            Assert.That(
+                () => twoMatches.SingleStrict<IFeature>("subject"),
+                Throws.TypeOf<MultiplicityViolationException>());
+
+            // Three matches → MultiplicityViolationException (early-exit not regressed).
+            IReadOnlyList<IElement> threeMatches = new List<IElement> { new Feature(), new Feature(), new Feature() };
+
+            Assert.That(
+                () => threeMatches.SingleStrict<IFeature>("subject"),
+                Throws.TypeOf<MultiplicityViolationException>());
+        }
+
+        [Test]
+        public void VerifySingleOrDefaultStrictWithOfTypeFilter()
+        {
+            // IEnumerable overload (with implicit OfType<TResult>): used when the source is wider than
+            // the desired result type — bundles OfType<TResult>() + SingleOrDefaultStrict in one call.
+
+            // Empty input → null (lower bound is 0; this is the only difference vs SingleStrict<TResult>).
+            Assert.That(
+                new List<IElement>().SingleOrDefaultStrict<IFeature>("subject"),
+                Is.Null);
+
+            // Only non-matching elements → null.
+            IReadOnlyList<IElement> nonMatchingOnly = new List<IElement> { new Comment(), new PartDefinition() };
+            Assert.That(nonMatchingOnly.SingleOrDefaultStrict<IFeature>("subject"), Is.Null);
+
+            // Exactly one match among non-matching siblings → returns the match (position-agnostic).
+            var feature = new Feature();
+            IReadOnlyList<IElement> singleMatch = new List<IElement> { new Comment(), feature, new PartDefinition() };
+            Assert.That(singleMatch.SingleOrDefaultStrict<IFeature>("subject"), Is.SameAs(feature));
+
+            // Two matches → MultiplicityViolationException (upper-bound violation against the [0..1] property).
+            IReadOnlyList<IElement> twoMatches = new List<IElement> { new Feature(), new Feature() };
+
+            Assert.That(
+                () => twoMatches.SingleOrDefaultStrict<IFeature>("subject"),
+                Throws.TypeOf<MultiplicityViolationException>());
+
+            // Three matches → MultiplicityViolationException (early-exit not regressed).
+            IReadOnlyList<IElement> threeMatches = new List<IElement> { new Feature(), new Feature(), new Feature() };
+
+            Assert.That(
+                () => threeMatches.SingleOrDefaultStrict<IFeature>("subject"),
+                Throws.TypeOf<MultiplicityViolationException>());
+        }
+
+        [Test]
+        public void VerifySingleStrict()
+        {
+            // Empty sequence → IncompleteModelException (lower-bound violation; the [1..1] property is missing).
+            Assert.That(
+                () => Enumerable.Empty<string>().SingleStrict("subject"),
+                Throws.TypeOf<IncompleteModelException>());
+
+            // Exactly one element → returns it.
+            Assert.That(new[] { "only" }.SingleStrict("subject"), Is.EqualTo("only"));
+
+            // Two elements → MultiplicityViolationException (upper-bound violation).
+            Assert.That(
+                () => new[] { "first", "second" }.SingleStrict("subject"),
+                Throws.TypeOf<MultiplicityViolationException>());
+
+            // Three elements → MultiplicityViolationException (early-exit not regressed).
+            Assert.That(
+                () => new[] { "a", "b", "c" }.SingleStrict("subject"),
+                Throws.TypeOf<MultiplicityViolationException>());
+
+            // Explicit OfType<T>() chain — same contract as the IEnumerable overload SingleStrict<TResult>.
+            IReadOnlyList<IElement> threeFeatures = new List<IElement> { new Feature(), new Feature(), new Feature() };
+
+            Assert.That(
+                () => threeFeatures.OfType<IFeature>().SingleStrict("subject"),
+                Throws.TypeOf<MultiplicityViolationException>());
+        }
+
+        [Test]
+        public void VerifySingleOrDefaultStrict()
+        {
+            // Empty sequence → null (lower bound is 0; the only difference vs SingleStrict).
+            Assert.That(Enumerable.Empty<string>().SingleOrDefaultStrict("subject"), Is.Null);
+
+            // Exactly one element → returns it.
+            Assert.That(new[] { "only" }.SingleOrDefaultStrict("subject"), Is.EqualTo("only"));
+
+            // Two elements → MultiplicityViolationException (upper-bound violation against the [0..1] property).
+            Assert.That(
+                () => new[] { "first", "second" }.SingleOrDefaultStrict("subject"),
+                Throws.TypeOf<MultiplicityViolationException>());
+
+            // Three elements → MultiplicityViolationException (early-exit not regressed).
+            Assert.That(
+                () => new[] { "a", "b", "c" }.SingleOrDefaultStrict("subject"),
+                Throws.TypeOf<MultiplicityViolationException>());
+
+            // Explicit OfType<T>() chain — same contract as the IEnumerable overload SingleOrDefaultStrict<TResult>.
+            IReadOnlyList<IElement> twoFeatures = new List<IElement> { new Feature(), new Feature() };
+
+            Assert.That(
+                () => twoFeatures.OfType<IFeature>().SingleOrDefaultStrict("subject"),
+                Throws.TypeOf<MultiplicityViolationException>());
         }
     }
 }

--- a/SysML2.NET.Tests/Extensions/ElementExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extensions/ElementExtensionsTestFixture.cs
@@ -44,6 +44,10 @@ namespace SysML2.NET.Tests.Extensions
     [TestFixture]
     public class ElementExtensionsTestFixture
     {
+        private static readonly string[] OneElementSequence = ["only"];
+        private static readonly string[] TwoElementSequence = ["first", "second"];
+        private static readonly string[] ThreeElementSequence = ["a", "b", "c"];
+
         private PartDefinition source;
         private FeatureMembership bridgeRelationship;
         private Specialization referenceBridgeRelationship;
@@ -384,16 +388,16 @@ namespace SysML2.NET.Tests.Extensions
                 Throws.TypeOf<IncompleteModelException>());
 
             // Exactly one element → returns it.
-            Assert.That(new[] { "only" }.SingleStrict("subject"), Is.EqualTo("only"));
+            Assert.That(OneElementSequence.SingleStrict("subject"), Is.EqualTo("only"));
 
             // Two elements → MultiplicityViolationException (upper-bound violation).
             Assert.That(
-                () => new[] { "first", "second" }.SingleStrict("subject"),
+                () => TwoElementSequence.SingleStrict("subject"),
                 Throws.TypeOf<MultiplicityViolationException>());
 
             // Three elements → MultiplicityViolationException (early-exit not regressed).
             Assert.That(
-                () => new[] { "a", "b", "c" }.SingleStrict("subject"),
+                () => ThreeElementSequence.SingleStrict("subject"),
                 Throws.TypeOf<MultiplicityViolationException>());
 
             // Explicit OfType<T>() chain — same contract as the IEnumerable overload SingleStrict<TResult>.
@@ -411,16 +415,16 @@ namespace SysML2.NET.Tests.Extensions
             Assert.That(Enumerable.Empty<string>().SingleOrDefaultStrict("subject"), Is.Null);
 
             // Exactly one element → returns it.
-            Assert.That(new[] { "only" }.SingleOrDefaultStrict("subject"), Is.EqualTo("only"));
+            Assert.That(OneElementSequence.SingleOrDefaultStrict("subject"), Is.EqualTo("only"));
 
             // Two elements → MultiplicityViolationException (upper-bound violation against the [0..1] property).
             Assert.That(
-                () => new[] { "first", "second" }.SingleOrDefaultStrict("subject"),
+                () => TwoElementSequence.SingleOrDefaultStrict("subject"),
                 Throws.TypeOf<MultiplicityViolationException>());
 
             // Three elements → MultiplicityViolationException (early-exit not regressed).
             Assert.That(
-                () => new[] { "a", "b", "c" }.SingleOrDefaultStrict("subject"),
+                () => ThreeElementSequence.SingleOrDefaultStrict("subject"),
                 Throws.TypeOf<MultiplicityViolationException>());
 
             // Explicit OfType<T>() chain — same contract as the IEnumerable overload SingleOrDefaultStrict<TResult>.

--- a/SysML2.NET/Exceptions/MultiplicityViolationException.cs
+++ b/SysML2.NET/Exceptions/MultiplicityViolationException.cs
@@ -1,0 +1,55 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="MultiplicityViolationException.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace SysML2.NET.Exceptions
+{
+    using System;
+
+    /// <summary>
+    /// The <see cref="MultiplicityViolationException"/> is thrown when a SysML 2 model carries
+    /// more elements than the upper bound of a derived property allows (e.g. 2+ matches against
+    /// a <c>[0..1]</c> or <c>[1..1]</c> derived reference).
+    /// </summary>
+    /// <remarks>
+    /// Contrast with <see cref="IncompleteModelException"/>, which signals the opposite — the
+    /// model is missing a required element against the lower bound of a property (e.g. 0
+    /// matches against a <c>[1..1]</c> derived reference).
+    /// </remarks>
+    public class MultiplicityViolationException : Exception
+    {
+        /// <summary>Initializes a new instance of the <see cref="MultiplicityViolationException" /> class.</summary>
+        public MultiplicityViolationException()
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="MultiplicityViolationException" /> class with a specified error message.</summary>
+        /// <param name="message">The message that describes the error.</param>
+        public MultiplicityViolationException(string message) : base(message)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="MultiplicityViolationException" /> class with a specified error message and a reference to the inner exception that is the cause of this exception.</summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (<see langword="Nothing" /> in Visual Basic) if no inner exception is specified.</param>
+        public MultiplicityViolationException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/SysML2.NET/Extend/ActorMembershipExtensions.cs
+++ b/SysML2.NET/Extend/ActorMembershipExtensions.cs
@@ -56,7 +56,7 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
                 throw new ArgumentNullException(nameof(actorMembershipSubject));
             }
 
-            return actorMembershipSubject.OwnedRelatedElement.RequireSingleOfType<IPartUsage>(nameof(actorMembershipSubject));
+            return actorMembershipSubject.OwnedRelatedElement.SingleStrict<IPartUsage>(nameof(actorMembershipSubject));
         }
 
     }

--- a/SysML2.NET/Extend/AnalysisCaseUsageExtensions.cs
+++ b/SysML2.NET/Extend/AnalysisCaseUsageExtensions.cs
@@ -87,12 +87,9 @@ namespace SysML2.NET.Core.POCO.Systems.AnalysisCases
         /// </exception>
         internal static IAnalysisCaseDefinition ComputeAnalysisCaseDefinition(this IAnalysisCaseUsage analysisCaseUsageSubject)
         {
-            if (analysisCaseUsageSubject is null)
-            {
-                throw new ArgumentNullException(nameof(analysisCaseUsageSubject));
-            }
-
-            return analysisCaseUsageSubject.definition.SingleOrDefaultStrict<IAnalysisCaseDefinition>(nameof(analysisCaseUsageSubject));
+            return analysisCaseUsageSubject == null
+                ? throw new ArgumentNullException(nameof(analysisCaseUsageSubject))
+                : analysisCaseUsageSubject.definition.SingleOrDefaultStrict<IAnalysisCaseDefinition>(nameof(analysisCaseUsageSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/AnalysisCaseUsageExtensions.cs
+++ b/SysML2.NET/Extend/AnalysisCaseUsageExtensions.cs
@@ -57,6 +57,8 @@ namespace SysML2.NET.Core.POCO.Systems.AnalysisCases
     using SysML2.NET.Core.POCO.Systems.UseCases;
     using SysML2.NET.Core.POCO.Systems.VerificationCases;
     using SysML2.NET.Core.POCO.Systems.Views;
+    using SysML2.NET.Exceptions;
+    using SysML2.NET.Extensions;
 
     /// <summary>
     /// The <see cref="AnalysisCaseUsageExtensions"/> class provides extensions methods for
@@ -65,23 +67,32 @@ namespace SysML2.NET.Core.POCO.Systems.AnalysisCases
     internal static class AnalysisCaseUsageExtensions
     {
         /// <summary>
-        /// Computes the derived property.
+        /// Computes the derived <c>analysisCaseDefinition</c> property: the
+        /// <see cref="IAnalysisCaseDefinition"/> targeted by the single
+        /// <see cref="IFeatureTyping"/> owned by <paramref name="analysisCaseUsageSubject"/>.
         /// </summary>
         /// <param name="analysisCaseUsageSubject">
         /// The subject <see cref="IAnalysisCaseUsage"/>
         /// </param>
         /// <returns>
-        /// the computed result
+        /// The matching <see cref="IAnalysisCaseDefinition"/>, or <c>null</c> when no such typing exists.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="analysisCaseUsageSubject"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="MultiplicityViolationException">
+        /// Thrown when more than one <see cref="IFeatureTyping"/> targets an
+        /// <see cref="IAnalysisCaseDefinition"/> (upper-bound violation against the derived
+        /// <c>[0..1]</c> property).
+        /// </exception>
         internal static IAnalysisCaseDefinition ComputeAnalysisCaseDefinition(this IAnalysisCaseUsage analysisCaseUsageSubject)
         {
-            return analysisCaseUsageSubject == null
-                ? throw new ArgumentNullException(nameof(analysisCaseUsageSubject))
-                : analysisCaseUsageSubject.OwnedRelationship
-                      .OfType<IFeatureTyping>()
-                      .Select(featureTyping => featureTyping.Type)
-                      .OfType<IAnalysisCaseDefinition>()
-                      .FirstOrDefault();
+            if (analysisCaseUsageSubject is null)
+            {
+                throw new ArgumentNullException(nameof(analysisCaseUsageSubject));
+            }
+
+            return analysisCaseUsageSubject.type.SingleOrDefaultStrict<IAnalysisCaseDefinition>(nameof(analysisCaseUsageSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/AnalysisCaseUsageExtensions.cs
+++ b/SysML2.NET/Extend/AnalysisCaseUsageExtensions.cs
@@ -92,7 +92,7 @@ namespace SysML2.NET.Core.POCO.Systems.AnalysisCases
                 throw new ArgumentNullException(nameof(analysisCaseUsageSubject));
             }
 
-            return analysisCaseUsageSubject.type.SingleOrDefaultStrict<IAnalysisCaseDefinition>(nameof(analysisCaseUsageSubject));
+            return analysisCaseUsageSubject.definition.SingleOrDefaultStrict<IAnalysisCaseDefinition>(nameof(analysisCaseUsageSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/BooleanExpressionExtensions.cs
+++ b/SysML2.NET/Extend/BooleanExpressionExtensions.cs
@@ -23,6 +23,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
     using System;
     using System.Linq;
 
+    using SysML2.NET.Core.POCO.Core.Types;
     using SysML2.NET.Exceptions;
     using SysML2.NET.Extensions;
 

--- a/SysML2.NET/Extend/BooleanExpressionExtensions.cs
+++ b/SysML2.NET/Extend/BooleanExpressionExtensions.cs
@@ -21,8 +21,10 @@
 namespace SysML2.NET.Core.POCO.Kernel.Functions
 {
     using System;
-    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
+
+    using SysML2.NET.Exceptions;
+    using SysML2.NET.Extensions;
 
     /// <summary>
     /// The <see cref="BooleanExpressionExtensions" /> class provides extensions methods for
@@ -31,20 +33,30 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
     internal static class BooleanExpressionExtensions
     {
         /// <summary>
-        /// Computes the derived property.
+        /// Computes the derived <c>predicate</c> property: the <see cref="IPredicate"/> that is the
+        /// single type of this <see cref="IBooleanExpression"/>.
         /// </summary>
         /// <param name="booleanExpressionSubject">
         /// The subject <see cref="IBooleanExpression" />
         /// </param>
         /// <returns>
-        /// the computed result
+        /// The matching <see cref="IPredicate"/>, or <c>null</c> when no such type exists.
         /// </returns>
-        [ExcludeFromCodeCoverage]
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="booleanExpressionSubject"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="MultiplicityViolationException">
+        /// Thrown when more than one <see cref="IType"/> on the subject is an
+        /// <see cref="IPredicate"/> (upper-bound violation against the derived <c>[0..1]</c> property).
+        /// </exception>
         internal static IPredicate ComputePredicate(this IBooleanExpression booleanExpressionSubject)
         {
-            return booleanExpressionSubject == null
-                ? throw new ArgumentNullException(nameof(booleanExpressionSubject))
-                : booleanExpressionSubject.type.OfType<IPredicate>().FirstOrDefault();
+            if (booleanExpressionSubject is null)
+            {
+                throw new ArgumentNullException(nameof(booleanExpressionSubject));
+            }
+
+            return booleanExpressionSubject.type.SingleOrDefaultStrict<IPredicate>(nameof(booleanExpressionSubject));
         }
     }
 }

--- a/SysML2.NET/Extend/BooleanExpressionExtensions.cs
+++ b/SysML2.NET/Extend/BooleanExpressionExtensions.cs
@@ -51,12 +51,9 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
         /// </exception>
         internal static IPredicate ComputePredicate(this IBooleanExpression booleanExpressionSubject)
         {
-            if (booleanExpressionSubject is null)
-            {
-                throw new ArgumentNullException(nameof(booleanExpressionSubject));
-            }
-
-            return booleanExpressionSubject.type.SingleOrDefaultStrict<IPredicate>(nameof(booleanExpressionSubject));
+            return booleanExpressionSubject == null
+                ? throw new ArgumentNullException(nameof(booleanExpressionSubject))
+                : booleanExpressionSubject.type.SingleOrDefaultStrict<IPredicate>(nameof(booleanExpressionSubject));
         }
     }
 }

--- a/SysML2.NET/Extend/CalculationUsageExtensions.cs
+++ b/SysML2.NET/Extend/CalculationUsageExtensions.cs
@@ -91,7 +91,7 @@ namespace SysML2.NET.Core.POCO.Systems.Calculations
                 throw new ArgumentNullException(nameof(calculationUsageSubject));
             }
 
-            return calculationUsageSubject.type.SingleOrDefaultStrict<IFunction>(nameof(calculationUsageSubject));
+            return calculationUsageSubject.definition.SingleOrDefaultStrict<IFunction>(nameof(calculationUsageSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/CalculationUsageExtensions.cs
+++ b/SysML2.NET/Extend/CalculationUsageExtensions.cs
@@ -86,12 +86,9 @@ namespace SysML2.NET.Core.POCO.Systems.Calculations
         /// </exception>
         internal static IFunction ComputeCalculationDefinition(this ICalculationUsage calculationUsageSubject)
         {
-            if (calculationUsageSubject is null)
-            {
-                throw new ArgumentNullException(nameof(calculationUsageSubject));
-            }
-
-            return calculationUsageSubject.definition.SingleOrDefaultStrict<IFunction>(nameof(calculationUsageSubject));
+            return calculationUsageSubject == null
+                ? throw new ArgumentNullException(nameof(calculationUsageSubject))
+                : calculationUsageSubject.definition.SingleOrDefaultStrict<IFunction>(nameof(calculationUsageSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/CalculationUsageExtensions.cs
+++ b/SysML2.NET/Extend/CalculationUsageExtensions.cs
@@ -57,6 +57,8 @@ namespace SysML2.NET.Core.POCO.Systems.Calculations
     using SysML2.NET.Core.POCO.Systems.UseCases;
     using SysML2.NET.Core.POCO.Systems.VerificationCases;
     using SysML2.NET.Core.POCO.Systems.Views;
+    using SysML2.NET.Exceptions;
+    using SysML2.NET.Extensions;
 
     /// <summary>
     /// The <see cref="CalculationUsageExtensions"/> class provides extensions methods for
@@ -65,23 +67,31 @@ namespace SysML2.NET.Core.POCO.Systems.Calculations
     internal static class CalculationUsageExtensions
     {
         /// <summary>
-        /// Computes the derived property.
+        /// Computes the derived <c>calculationDefinition</c> property: the <see cref="IFunction"/>
+        /// targeted by the single <see cref="IFeatureTyping"/> owned by
+        /// <paramref name="calculationUsageSubject"/>.
         /// </summary>
         /// <param name="calculationUsageSubject">
         /// The subject <see cref="ICalculationUsage"/>
         /// </param>
         /// <returns>
-        /// the computed result
+        /// The matching <see cref="IFunction"/>, or <c>null</c> when no such typing exists.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="calculationUsageSubject"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="MultiplicityViolationException">
+        /// Thrown when more than one <see cref="IFeatureTyping"/> targets an <see cref="IFunction"/>
+        /// (upper-bound violation against the derived <c>[0..1]</c> property).
+        /// </exception>
         internal static IFunction ComputeCalculationDefinition(this ICalculationUsage calculationUsageSubject)
         {
-            return calculationUsageSubject == null
-                ? throw new ArgumentNullException(nameof(calculationUsageSubject))
-                : calculationUsageSubject.OwnedRelationship
-                    .OfType<IFeatureTyping>()
-                    .Select(featureTyping => featureTyping.Type)
-                    .OfType<IFunction>()
-                    .FirstOrDefault();
+            if (calculationUsageSubject is null)
+            {
+                throw new ArgumentNullException(nameof(calculationUsageSubject));
+            }
+
+            return calculationUsageSubject.type.SingleOrDefaultStrict<IFunction>(nameof(calculationUsageSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/CaseUsageExtensions.cs
+++ b/SysML2.NET/Extend/CaseUsageExtensions.cs
@@ -116,7 +116,7 @@ namespace SysML2.NET.Core.POCO.Systems.Cases
                 throw new ArgumentNullException(nameof(caseUsageSubject));
             }
 
-            return caseUsageSubject.type.SingleOrDefaultStrict<ICaseDefinition>(nameof(caseUsageSubject));
+            return caseUsageSubject.definition.SingleOrDefaultStrict<ICaseDefinition>(nameof(caseUsageSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/CaseUsageExtensions.cs
+++ b/SysML2.NET/Extend/CaseUsageExtensions.cs
@@ -57,6 +57,8 @@ namespace SysML2.NET.Core.POCO.Systems.Cases
     using SysML2.NET.Core.POCO.Systems.UseCases;
     using SysML2.NET.Core.POCO.Systems.VerificationCases;
     using SysML2.NET.Core.POCO.Systems.Views;
+    using SysML2.NET.Exceptions;
+    using SysML2.NET.Extensions;
 
     /// <summary>
     /// The <see cref="CaseUsageExtensions"/> class provides extensions methods for
@@ -89,23 +91,32 @@ namespace SysML2.NET.Core.POCO.Systems.Cases
         }
 
         /// <summary>
-        /// Computes the derived property.
+        /// Computes the derived <c>caseDefinition</c> property: the <see cref="ICaseDefinition"/>
+        /// targeted by the single <see cref="IFeatureTyping"/> owned by
+        /// <paramref name="caseUsageSubject"/>.
         /// </summary>
         /// <param name="caseUsageSubject">
         /// The subject <see cref="ICaseUsage"/>
         /// </param>
         /// <returns>
-        /// the computed result
+        /// The matching <see cref="ICaseDefinition"/>, or <c>null</c> when no such typing exists.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="caseUsageSubject"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="MultiplicityViolationException">
+        /// Thrown when more than one <see cref="IFeatureTyping"/> targets an
+        /// <see cref="ICaseDefinition"/> (upper-bound violation against the derived
+        /// <c>[0..1]</c> property).
+        /// </exception>
         internal static ICaseDefinition ComputeCaseDefinition(this ICaseUsage caseUsageSubject)
         {
-            return caseUsageSubject == null
-                ? throw new ArgumentNullException(nameof(caseUsageSubject))
-                : caseUsageSubject.OwnedRelationship
-                      .OfType<IFeatureTyping>()
-                      .Select(featureTyping => featureTyping.Type)
-                      .OfType<ICaseDefinition>()
-                      .FirstOrDefault();
+            if (caseUsageSubject is null)
+            {
+                throw new ArgumentNullException(nameof(caseUsageSubject));
+            }
+
+            return caseUsageSubject.type.SingleOrDefaultStrict<ICaseDefinition>(nameof(caseUsageSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/CaseUsageExtensions.cs
+++ b/SysML2.NET/Extend/CaseUsageExtensions.cs
@@ -111,12 +111,9 @@ namespace SysML2.NET.Core.POCO.Systems.Cases
         /// </exception>
         internal static ICaseDefinition ComputeCaseDefinition(this ICaseUsage caseUsageSubject)
         {
-            if (caseUsageSubject is null)
-            {
-                throw new ArgumentNullException(nameof(caseUsageSubject));
-            }
-
-            return caseUsageSubject.definition.SingleOrDefaultStrict<ICaseDefinition>(nameof(caseUsageSubject));
+            return caseUsageSubject == null
+                ? throw new ArgumentNullException(nameof(caseUsageSubject))
+                : caseUsageSubject.definition.SingleOrDefaultStrict<ICaseDefinition>(nameof(caseUsageSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/ConstraintUsageExtensions.cs
+++ b/SysML2.NET/Extend/ConstraintUsageExtensions.cs
@@ -86,12 +86,9 @@ namespace SysML2.NET.Core.POCO.Systems.Constraints
         /// </exception>
         internal static IPredicate ComputeConstraintDefinition(this IConstraintUsage constraintUsageSubject)
         {
-            if (constraintUsageSubject is null)
-            {
-                throw new ArgumentNullException(nameof(constraintUsageSubject));
-            }
-
-            return constraintUsageSubject.definition.SingleOrDefaultStrict<IPredicate>(nameof(constraintUsageSubject));
+            return constraintUsageSubject == null
+                ? throw new ArgumentNullException(nameof(constraintUsageSubject))
+                : constraintUsageSubject.definition.SingleOrDefaultStrict<IPredicate>(nameof(constraintUsageSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/ConstraintUsageExtensions.cs
+++ b/SysML2.NET/Extend/ConstraintUsageExtensions.cs
@@ -91,7 +91,7 @@ namespace SysML2.NET.Core.POCO.Systems.Constraints
                 throw new ArgumentNullException(nameof(constraintUsageSubject));
             }
 
-            return constraintUsageSubject.type.SingleOrDefaultStrict<IPredicate>(nameof(constraintUsageSubject));
+            return constraintUsageSubject.definition.SingleOrDefaultStrict<IPredicate>(nameof(constraintUsageSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/ConstraintUsageExtensions.cs
+++ b/SysML2.NET/Extend/ConstraintUsageExtensions.cs
@@ -57,6 +57,8 @@ namespace SysML2.NET.Core.POCO.Systems.Constraints
     using SysML2.NET.Core.POCO.Systems.UseCases;
     using SysML2.NET.Core.POCO.Systems.VerificationCases;
     using SysML2.NET.Core.POCO.Systems.Views;
+    using SysML2.NET.Exceptions;
+    using SysML2.NET.Extensions;
 
     /// <summary>
     /// The <see cref="ConstraintUsageExtensions"/> class provides extensions methods for
@@ -65,23 +67,31 @@ namespace SysML2.NET.Core.POCO.Systems.Constraints
     internal static class ConstraintUsageExtensions
     {
         /// <summary>
-        /// Computes the derived property.
+        /// Computes the derived <c>constraintDefinition</c> property: the <see cref="IPredicate"/>
+        /// targeted by the single <see cref="IFeatureTyping"/> owned by
+        /// <paramref name="constraintUsageSubject"/>.
         /// </summary>
         /// <param name="constraintUsageSubject">
         /// The subject <see cref="IConstraintUsage"/>
         /// </param>
         /// <returns>
-        /// the computed result
+        /// The matching <see cref="IPredicate"/>, or <c>null</c> when no such typing exists.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="constraintUsageSubject"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="MultiplicityViolationException">
+        /// Thrown when more than one <see cref="IFeatureTyping"/> targets an <see cref="IPredicate"/>
+        /// (upper-bound violation against the derived <c>[0..1]</c> property).
+        /// </exception>
         internal static IPredicate ComputeConstraintDefinition(this IConstraintUsage constraintUsageSubject)
         {
-            return constraintUsageSubject == null
-                ? throw new ArgumentNullException(nameof(constraintUsageSubject))
-                : constraintUsageSubject.OwnedRelationship
-                    .OfType<IFeatureTyping>()
-                    .Select(featureTyping => featureTyping.Type)
-                    .OfType<IPredicate>()
-                    .FirstOrDefault();
+            if (constraintUsageSubject is null)
+            {
+                throw new ArgumentNullException(nameof(constraintUsageSubject));
+            }
+
+            return constraintUsageSubject.type.SingleOrDefaultStrict<IPredicate>(nameof(constraintUsageSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/ElementFilterMembershipExtensions.cs
+++ b/SysML2.NET/Extend/ElementFilterMembershipExtensions.cs
@@ -47,7 +47,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Packages
                 throw new ArgumentNullException(nameof(elementFilterMembershipSubject));
             }
 
-            return elementFilterMembershipSubject.OwnedRelatedElement.RequireSingleOfType<IExpression>(nameof(elementFilterMembershipSubject));
+            return elementFilterMembershipSubject.OwnedRelatedElement.SingleStrict<IExpression>(nameof(elementFilterMembershipSubject));
         }
     }
 }

--- a/SysML2.NET/Extend/EndFeatureMembershipExtensions.cs
+++ b/SysML2.NET/Extend/EndFeatureMembershipExtensions.cs
@@ -46,7 +46,7 @@ namespace SysML2.NET.Core.POCO.Core.Features
                 throw new ArgumentNullException(nameof(endFeatureMembershipSubject));
             }
 
-            return endFeatureMembershipSubject.OwnedRelatedElement.RequireSingleOfType<IFeature>(nameof(endFeatureMembershipSubject));
+            return endFeatureMembershipSubject.OwnedRelatedElement.SingleStrict<IFeature>(nameof(endFeatureMembershipSubject));
         }
     }
 }

--- a/SysML2.NET/Extend/ExpressionExtensions.cs
+++ b/SysML2.NET/Extend/ExpressionExtensions.cs
@@ -57,12 +57,9 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
         /// </exception>
         internal static IFunction ComputeFunction(this IExpression expressionSubject)
         {
-            if (expressionSubject is null)
-            {
-                throw new ArgumentNullException(nameof(expressionSubject));
-            }
-
-            return expressionSubject.type.SingleOrDefaultStrict<IFunction>(nameof(expressionSubject));
+            return expressionSubject == null
+                ? throw new ArgumentNullException(nameof(expressionSubject))
+                : expressionSubject.type.SingleOrDefaultStrict<IFunction>(nameof(expressionSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/ExpressionExtensions.cs
+++ b/SysML2.NET/Extend/ExpressionExtensions.cs
@@ -26,8 +26,11 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
 
     using SysML2.NET.Core.Core.Types;
     using SysML2.NET.Core.POCO.Core.Features;
+    using SysML2.NET.Core.POCO.Core.Types;
     using SysML2.NET.Core.POCO.Kernel.Expressions;
     using SysML2.NET.Core.POCO.Root.Elements;
+    using SysML2.NET.Exceptions;
+    using SysML2.NET.Extensions;
 
     /// <summary>
     /// The <see cref="ExpressionExtensions"/> class provides extensions methods for
@@ -36,19 +39,30 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
     internal static class ExpressionExtensions
     {
         /// <summary>
-        /// Computes the derived property.
+        /// Computes the derived <c>function</c> property: the <see cref="IFunction"/> that is the
+        /// single type of this <see cref="IExpression"/>.
         /// </summary>
         /// <param name="expressionSubject">
         /// The subject <see cref="IExpression"/>
         /// </param>
         /// <returns>
-        /// the computed result
+        /// The matching <see cref="IFunction"/>, or <c>null</c> when no such type exists.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="expressionSubject"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="MultiplicityViolationException">
+        /// Thrown when more than one <see cref="IType"/> on the subject is an <see cref="IFunction"/>
+        /// (upper-bound violation against the derived <c>[0..1]</c> property).
+        /// </exception>
         internal static IFunction ComputeFunction(this IExpression expressionSubject)
         {
-            return expressionSubject == null
-                ? throw new ArgumentNullException(nameof(expressionSubject))
-                : expressionSubject.type.OfType<IFunction>().FirstOrDefault();
+            if (expressionSubject is null)
+            {
+                throw new ArgumentNullException(nameof(expressionSubject));
+            }
+
+            return expressionSubject.type.SingleOrDefaultStrict<IFunction>(nameof(expressionSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/FeatureMembershipExtensions.cs
+++ b/SysML2.NET/Extend/FeatureMembershipExtensions.cs
@@ -52,7 +52,7 @@ namespace SysML2.NET.Core.POCO.Core.Types
                 throw new ArgumentNullException(nameof(featureMembershipSubject));
             }
 
-            return featureMembershipSubject.OwnedRelatedElement.RequireSingleOfType<IFeature>(nameof(featureMembershipSubject));
+            return featureMembershipSubject.OwnedRelatedElement.SingleStrict<IFeature>(nameof(featureMembershipSubject));
         }
 
         /// <summary>
@@ -70,6 +70,5 @@ namespace SysML2.NET.Core.POCO.Core.Types
                 ? throw new ArgumentNullException(nameof(featureMembershipSubject))
                 : featureMembershipSubject.OwningRelatedElement as IType;
         }
-
     }
 }

--- a/SysML2.NET/Extend/FeatureValueExtensions.cs
+++ b/SysML2.NET/Extend/FeatureValueExtensions.cs
@@ -69,7 +69,7 @@ namespace SysML2.NET.Core.POCO.Kernel.FeatureValues
                 throw new ArgumentNullException(nameof(featureValueSubject));
             }
 
-            return featureValueSubject.OwnedRelatedElement.RequireSingleOfType<IExpression>(nameof(featureValueSubject));
+            return featureValueSubject.OwnedRelatedElement.SingleStrict<IExpression>(nameof(featureValueSubject));
         }
     }
 }

--- a/SysML2.NET/Extend/FramedConcernMembershipExtensions.cs
+++ b/SysML2.NET/Extend/FramedConcernMembershipExtensions.cs
@@ -55,7 +55,7 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
                 throw new ArgumentNullException(nameof(framedConcernMembershipSubject));
             }
 
-            return framedConcernMembershipSubject.OwnedRelatedElement.RequireSingleOfType<IConcernUsage>(nameof(framedConcernMembershipSubject));
+            return framedConcernMembershipSubject.OwnedRelatedElement.SingleStrict<IConcernUsage>(nameof(framedConcernMembershipSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/MetadataAccessExpressionExtensions.cs
+++ b/SysML2.NET/Extend/MetadataAccessExpressionExtensions.cs
@@ -60,7 +60,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Expressions
             {
                 if (ownedRelationship is IOwningMembership owningMembership and not IFeatureMembership)
                 {
-                    return owningMembership.OwnedRelatedElement.RequireSingleOfType<IElement>(nameof(owningMembership));
+                    return owningMembership.OwnedRelatedElement.SingleStrict<IElement>(nameof(owningMembership));
                 }
             }
 

--- a/SysML2.NET/Extend/ObjectiveMembershipExtensions.cs
+++ b/SysML2.NET/Extend/ObjectiveMembershipExtensions.cs
@@ -47,7 +47,7 @@ namespace SysML2.NET.Core.POCO.Systems.Cases
                 throw new ArgumentNullException(nameof(objectiveMembershipSubject));
             }
 
-            return objectiveMembershipSubject.OwnedRelatedElement.RequireSingleOfType<IRequirementUsage>(nameof(objectiveMembershipSubject));
+            return objectiveMembershipSubject.OwnedRelatedElement.SingleStrict<IRequirementUsage>(nameof(objectiveMembershipSubject));
         }
     }
 }

--- a/SysML2.NET/Extend/OwningMembershipExtensions.cs
+++ b/SysML2.NET/Extend/OwningMembershipExtensions.cs
@@ -50,7 +50,7 @@ namespace SysML2.NET.Core.POCO.Root.Namespaces
                 throw new ArgumentNullException(nameof(owningMembershipSubject));
             }
 
-            return owningMembershipSubject.OwnedRelatedElement.RequireSingleOfType<IElement>(nameof(owningMembershipSubject));
+            return owningMembershipSubject.OwnedRelatedElement.SingleStrict<IElement>(nameof(owningMembershipSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/ParameterMembershipExtensions.cs
+++ b/SysML2.NET/Extend/ParameterMembershipExtensions.cs
@@ -54,7 +54,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Behaviors
                 throw new ArgumentNullException(nameof(parameterMembershipSubject));
             }
 
-            return parameterMembershipSubject.OwnedRelatedElement.RequireSingleOfType<IFeature>(nameof(parameterMembershipSubject));
+            return parameterMembershipSubject.OwnedRelatedElement.SingleStrict<IFeature>(nameof(parameterMembershipSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/RenderingUsageExtensions.cs
+++ b/SysML2.NET/Extend/RenderingUsageExtensions.cs
@@ -86,12 +86,9 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         /// </exception>
         internal static IRenderingDefinition ComputeRenderingDefinition(this IRenderingUsage renderingUsageSubject)
         {
-            if (renderingUsageSubject is null)
-            {
-                throw new ArgumentNullException(nameof(renderingUsageSubject));
-            }
-
-            return renderingUsageSubject.definition.SingleOrDefaultStrict<IRenderingDefinition>(nameof(renderingUsageSubject));
+            return renderingUsageSubject == null
+                ? throw new ArgumentNullException(nameof(renderingUsageSubject))
+                : renderingUsageSubject.definition.SingleOrDefaultStrict<IRenderingDefinition>(nameof(renderingUsageSubject));
         }
 
     }

--- a/SysML2.NET/Extend/RenderingUsageExtensions.cs
+++ b/SysML2.NET/Extend/RenderingUsageExtensions.cs
@@ -56,6 +56,8 @@ namespace SysML2.NET.Core.POCO.Systems.Views
     using SysML2.NET.Core.POCO.Systems.States;
     using SysML2.NET.Core.POCO.Systems.UseCases;
     using SysML2.NET.Core.POCO.Systems.VerificationCases;
+    using SysML2.NET.Exceptions;
+    using SysML2.NET.Extensions;
 
     /// <summary>
     /// The <see cref="RenderingUsageExtensions"/> class provides extensions methods for
@@ -64,23 +66,32 @@ namespace SysML2.NET.Core.POCO.Systems.Views
     internal static class RenderingUsageExtensions
     {
         /// <summary>
-        /// Computes the derived property.
+        /// Computes the derived <c>renderingDefinition</c> property: the
+        /// <see cref="IRenderingDefinition"/> targeted by the single <see cref="IFeatureTyping"/>
+        /// owned by <paramref name="renderingUsageSubject"/>.
         /// </summary>
         /// <param name="renderingUsageSubject">
         /// The subject <see cref="IRenderingUsage"/>
         /// </param>
         /// <returns>
-        /// the computed result
+        /// The matching <see cref="IRenderingDefinition"/>, or <c>null</c> when no such typing exists.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="renderingUsageSubject"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="MultiplicityViolationException">
+        /// Thrown when more than one <see cref="IFeatureTyping"/> targets an
+        /// <see cref="IRenderingDefinition"/> (upper-bound violation against the derived
+        /// <c>[0..1]</c> property).
+        /// </exception>
         internal static IRenderingDefinition ComputeRenderingDefinition(this IRenderingUsage renderingUsageSubject)
         {
-            return renderingUsageSubject == null
-                ? throw new ArgumentNullException(nameof(renderingUsageSubject))
-                : renderingUsageSubject.OwnedRelationship
-                    .OfType<IFeatureTyping>()
-                    .Select(featureTyping => featureTyping.Type)
-                    .OfType<IRenderingDefinition>()
-                    .FirstOrDefault();
+            if (renderingUsageSubject is null)
+            {
+                throw new ArgumentNullException(nameof(renderingUsageSubject));
+            }
+
+            return renderingUsageSubject.type.SingleOrDefaultStrict<IRenderingDefinition>(nameof(renderingUsageSubject));
         }
 
     }

--- a/SysML2.NET/Extend/RenderingUsageExtensions.cs
+++ b/SysML2.NET/Extend/RenderingUsageExtensions.cs
@@ -91,7 +91,7 @@ namespace SysML2.NET.Core.POCO.Systems.Views
                 throw new ArgumentNullException(nameof(renderingUsageSubject));
             }
 
-            return renderingUsageSubject.type.SingleOrDefaultStrict<IRenderingDefinition>(nameof(renderingUsageSubject));
+            return renderingUsageSubject.definition.SingleOrDefaultStrict<IRenderingDefinition>(nameof(renderingUsageSubject));
         }
 
     }

--- a/SysML2.NET/Extend/RequirementConstraintMembershipExtensions.cs
+++ b/SysML2.NET/Extend/RequirementConstraintMembershipExtensions.cs
@@ -47,7 +47,7 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
                 throw new ArgumentNullException(nameof(requirementConstraintMembershipSubject));
             }
 
-            return requirementConstraintMembershipSubject.OwnedRelatedElement.RequireSingleOfType<IConstraintUsage>(nameof(requirementConstraintMembershipSubject));
+            return requirementConstraintMembershipSubject.OwnedRelatedElement.SingleStrict<IConstraintUsage>(nameof(requirementConstraintMembershipSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/RequirementUsageExtensions.cs
+++ b/SysML2.NET/Extend/RequirementUsageExtensions.cs
@@ -170,7 +170,7 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
                 throw new ArgumentNullException(nameof(requirementUsageSubject));
             }
 
-            return requirementUsageSubject.type.SingleOrDefaultStrict<IRequirementDefinition>(nameof(requirementUsageSubject));
+            return requirementUsageSubject.definition.SingleOrDefaultStrict<IRequirementDefinition>(nameof(requirementUsageSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/RequirementUsageExtensions.cs
+++ b/SysML2.NET/Extend/RequirementUsageExtensions.cs
@@ -26,10 +26,13 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
 
     using SysML2.NET.Core.Systems.Requirements;
     using SysML2.NET.Core.POCO.Core.Features;
+    using SysML2.NET.Core.POCO.Core.Types;
     using SysML2.NET.Core.POCO.Root.Annotations;
     using SysML2.NET.Core.POCO.Systems.Constraints;
     using SysML2.NET.Core.POCO.Systems.DefinitionAndUsage;
     using SysML2.NET.Core.POCO.Systems.Parts;
+    using SysML2.NET.Exceptions;
+    using SysML2.NET.Extensions;
 
     /// <summary>
     /// The <see cref="RequirementUsageExtensions"/> class provides extensions methods for
@@ -142,23 +145,32 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         }
 
         /// <summary>
-        /// Computes the derived property.
+        /// Computes the derived <c>requirementDefinition</c> property: the
+        /// <see cref="IRequirementDefinition"/> targeted by the single <see cref="IFeatureTyping"/>
+        /// owned by <paramref name="requirementUsageSubject"/>.
         /// </summary>
         /// <param name="requirementUsageSubject">
         /// The subject <see cref="IRequirementUsage"/>
         /// </param>
         /// <returns>
-        /// the computed result
+        /// The matching <see cref="IRequirementDefinition"/>, or <c>null</c> when no such typing exists.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="requirementUsageSubject"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="MultiplicityViolationException">
+        /// Thrown when more than one <see cref="IFeatureTyping"/> targets an
+        /// <see cref="IRequirementDefinition"/> (upper-bound violation against the derived
+        /// <c>[0..1]</c> property).
+        /// </exception>
         internal static IRequirementDefinition ComputeRequirementDefinition(this IRequirementUsage requirementUsageSubject)
         {
-            return requirementUsageSubject == null
-                ? throw new ArgumentNullException(nameof(requirementUsageSubject))
-                : requirementUsageSubject.OwnedRelationship
-                      .OfType<IFeatureTyping>()
-                      .Select(featureTyping => featureTyping.Type)
-                      .OfType<IRequirementDefinition>()
-                      .FirstOrDefault();
+            if (requirementUsageSubject is null)
+            {
+                throw new ArgumentNullException(nameof(requirementUsageSubject));
+            }
+
+            return requirementUsageSubject.type.SingleOrDefaultStrict<IRequirementDefinition>(nameof(requirementUsageSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/RequirementUsageExtensions.cs
+++ b/SysML2.NET/Extend/RequirementUsageExtensions.cs
@@ -165,12 +165,9 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
         /// </exception>
         internal static IRequirementDefinition ComputeRequirementDefinition(this IRequirementUsage requirementUsageSubject)
         {
-            if (requirementUsageSubject is null)
-            {
-                throw new ArgumentNullException(nameof(requirementUsageSubject));
-            }
-
-            return requirementUsageSubject.definition.SingleOrDefaultStrict<IRequirementDefinition>(nameof(requirementUsageSubject));
+            return requirementUsageSubject == null
+                ? throw new ArgumentNullException(nameof(requirementUsageSubject))
+                : requirementUsageSubject.definition.SingleOrDefaultStrict<IRequirementDefinition>(nameof(requirementUsageSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/RequirementVerificationMembershipExtensions.cs
+++ b/SysML2.NET/Extend/RequirementVerificationMembershipExtensions.cs
@@ -56,7 +56,7 @@ namespace SysML2.NET.Core.POCO.Systems.VerificationCases
                 throw new ArgumentNullException(nameof(requirementVerificationMembershipSubject));
             }
 
-            return requirementVerificationMembershipSubject.OwnedRelatedElement.RequireSingleOfType<IRequirementUsage>(nameof(requirementVerificationMembershipSubject));
+            return requirementVerificationMembershipSubject.OwnedRelatedElement.SingleStrict<IRequirementUsage>(nameof(requirementVerificationMembershipSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/ResultExpressionMembershipExtensions.cs
+++ b/SysML2.NET/Extend/ResultExpressionMembershipExtensions.cs
@@ -46,7 +46,7 @@ namespace SysML2.NET.Core.POCO.Kernel.Functions
                 throw new ArgumentNullException(nameof(resultExpressionMembershipSubject));
             }
 
-            return resultExpressionMembershipSubject.OwnedRelatedElement.RequireSingleOfType<IExpression>(nameof(resultExpressionMembershipSubject));
+            return resultExpressionMembershipSubject.OwnedRelatedElement.SingleStrict<IExpression>(nameof(resultExpressionMembershipSubject));
         }
     }
 }

--- a/SysML2.NET/Extend/StakeholderMembershipExtensions.cs
+++ b/SysML2.NET/Extend/StakeholderMembershipExtensions.cs
@@ -47,7 +47,7 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
                 throw new ArgumentNullException(nameof(stakeholderMembershipSubject));
             }
 
-            return stakeholderMembershipSubject.OwnedRelatedElement.RequireSingleOfType<IPartUsage>(nameof(stakeholderMembershipSubject));
+            return stakeholderMembershipSubject.OwnedRelatedElement.SingleStrict<IPartUsage>(nameof(stakeholderMembershipSubject));
         }
     }
 }

--- a/SysML2.NET/Extend/StateSubactionMembershipExtensions.cs
+++ b/SysML2.NET/Extend/StateSubactionMembershipExtensions.cs
@@ -47,7 +47,7 @@ namespace SysML2.NET.Core.POCO.Systems.States
                 throw new ArgumentNullException(nameof(stateSubactionMembershipSubject));
             }
 
-            return stateSubactionMembershipSubject.OwnedRelatedElement.RequireSingleOfType<IActionUsage>(nameof(stateSubactionMembershipSubject));
+            return stateSubactionMembershipSubject.OwnedRelatedElement.SingleStrict<IActionUsage>(nameof(stateSubactionMembershipSubject));
         }
     }
 }

--- a/SysML2.NET/Extend/SubjectMembershipExtensions.cs
+++ b/SysML2.NET/Extend/SubjectMembershipExtensions.cs
@@ -48,7 +48,7 @@ namespace SysML2.NET.Core.POCO.Systems.Requirements
                 throw new ArgumentNullException(nameof(subjectMembershipSubject));
             }
 
-            return subjectMembershipSubject.OwnedRelatedElement.RequireSingleOfType<IUsage>(nameof(subjectMembershipSubject));
+            return subjectMembershipSubject.OwnedRelatedElement.SingleStrict<IUsage>(nameof(subjectMembershipSubject));
         }
 
     }

--- a/SysML2.NET/Extend/TransitionFeatureMembershipExtensions.cs
+++ b/SysML2.NET/Extend/TransitionFeatureMembershipExtensions.cs
@@ -55,7 +55,7 @@ namespace SysML2.NET.Core.POCO.Systems.States
                 throw new ArgumentNullException(nameof(transitionFeatureMembershipSubject));
             }
 
-            return transitionFeatureMembershipSubject.OwnedRelatedElement.RequireSingleOfType<IStep>(nameof(transitionFeatureMembershipSubject));
+            return transitionFeatureMembershipSubject.OwnedRelatedElement.SingleStrict<IStep>(nameof(transitionFeatureMembershipSubject));
         }
     }
 }

--- a/SysML2.NET/Extend/VariantMembershipExtensions.cs
+++ b/SysML2.NET/Extend/VariantMembershipExtensions.cs
@@ -46,7 +46,7 @@ namespace SysML2.NET.Core.POCO.Systems.DefinitionAndUsage
                 throw new ArgumentNullException(nameof(variantMembershipSubject));
             }
 
-            return variantMembershipSubject.OwnedRelatedElement.RequireSingleOfType<IUsage>(nameof(variantMembershipSubject));
+            return variantMembershipSubject.OwnedRelatedElement.SingleStrict<IUsage>(nameof(variantMembershipSubject));
         }
     }
 }

--- a/SysML2.NET/Extend/VerificationCaseUsageExtensions.cs
+++ b/SysML2.NET/Extend/VerificationCaseUsageExtensions.cs
@@ -87,12 +87,9 @@ namespace SysML2.NET.Core.POCO.Systems.VerificationCases
         /// </exception>
         internal static IVerificationCaseDefinition ComputeVerificationCaseDefinition(this IVerificationCaseUsage verificationCaseUsageSubject)
         {
-            if (verificationCaseUsageSubject is null)
-            {
-                throw new ArgumentNullException(nameof(verificationCaseUsageSubject));
-            }
-
-            return verificationCaseUsageSubject.definition.SingleOrDefaultStrict<IVerificationCaseDefinition>(nameof(verificationCaseUsageSubject));
+            return verificationCaseUsageSubject == null
+                ? throw new ArgumentNullException(nameof(verificationCaseUsageSubject))
+                : verificationCaseUsageSubject.definition.SingleOrDefaultStrict<IVerificationCaseDefinition>(nameof(verificationCaseUsageSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/VerificationCaseUsageExtensions.cs
+++ b/SysML2.NET/Extend/VerificationCaseUsageExtensions.cs
@@ -57,6 +57,8 @@ namespace SysML2.NET.Core.POCO.Systems.VerificationCases
     using SysML2.NET.Core.POCO.Systems.States;
     using SysML2.NET.Core.POCO.Systems.UseCases;
     using SysML2.NET.Core.POCO.Systems.Views;
+    using SysML2.NET.Exceptions;
+    using SysML2.NET.Extensions;
 
     /// <summary>
     /// The <see cref="VerificationCaseUsageExtensions"/> class provides extensions methods for
@@ -65,23 +67,32 @@ namespace SysML2.NET.Core.POCO.Systems.VerificationCases
     internal static class VerificationCaseUsageExtensions
     {
         /// <summary>
-        /// Computes the derived property.
+        /// Computes the derived <c>verificationCaseDefinition</c> property: the
+        /// <see cref="IVerificationCaseDefinition"/> targeted by the single
+        /// <see cref="IFeatureTyping"/> owned by <paramref name="verificationCaseUsageSubject"/>.
         /// </summary>
         /// <param name="verificationCaseUsageSubject">
         /// The subject <see cref="IVerificationCaseUsage"/>
         /// </param>
         /// <returns>
-        /// the computed result
+        /// The matching <see cref="IVerificationCaseDefinition"/>, or <c>null</c> when no such typing exists.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="verificationCaseUsageSubject"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="MultiplicityViolationException">
+        /// Thrown when more than one <see cref="IFeatureTyping"/> targets an
+        /// <see cref="IVerificationCaseDefinition"/> (upper-bound violation against the derived
+        /// <c>[0..1]</c> property).
+        /// </exception>
         internal static IVerificationCaseDefinition ComputeVerificationCaseDefinition(this IVerificationCaseUsage verificationCaseUsageSubject)
         {
-            return verificationCaseUsageSubject == null
-                ? throw new ArgumentNullException(nameof(verificationCaseUsageSubject))
-                : verificationCaseUsageSubject.OwnedRelationship
-                      .OfType<IFeatureTyping>()
-                      .Select(featureTyping => featureTyping.Type)
-                      .OfType<IVerificationCaseDefinition>()
-                      .FirstOrDefault();
+            if (verificationCaseUsageSubject is null)
+            {
+                throw new ArgumentNullException(nameof(verificationCaseUsageSubject));
+            }
+
+            return verificationCaseUsageSubject.type.SingleOrDefaultStrict<IVerificationCaseDefinition>(nameof(verificationCaseUsageSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/VerificationCaseUsageExtensions.cs
+++ b/SysML2.NET/Extend/VerificationCaseUsageExtensions.cs
@@ -92,7 +92,7 @@ namespace SysML2.NET.Core.POCO.Systems.VerificationCases
                 throw new ArgumentNullException(nameof(verificationCaseUsageSubject));
             }
 
-            return verificationCaseUsageSubject.type.SingleOrDefaultStrict<IVerificationCaseDefinition>(nameof(verificationCaseUsageSubject));
+            return verificationCaseUsageSubject.definition.SingleOrDefaultStrict<IVerificationCaseDefinition>(nameof(verificationCaseUsageSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/ViewRenderingMembershipExtensions.cs
+++ b/SysML2.NET/Extend/ViewRenderingMembershipExtensions.cs
@@ -54,7 +54,7 @@ namespace SysML2.NET.Core.POCO.Systems.Views
                 throw new ArgumentNullException(nameof(viewRenderingMembershipSubject));
             }
 
-            return viewRenderingMembershipSubject.OwnedRelatedElement.RequireSingleOfType<IRenderingUsage>(nameof(viewRenderingMembershipSubject));
+            return viewRenderingMembershipSubject.OwnedRelatedElement.SingleStrict<IRenderingUsage>(nameof(viewRenderingMembershipSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/ViewUsageExtensions.cs
+++ b/SysML2.NET/Extend/ViewUsageExtensions.cs
@@ -153,7 +153,7 @@ namespace SysML2.NET.Core.POCO.Systems.Views
                 throw new ArgumentNullException(nameof(viewUsageSubject));
             }
 
-            return viewUsageSubject.type.SingleOrDefaultStrict<IViewDefinition>(nameof(viewUsageSubject));
+            return viewUsageSubject.definition.SingleOrDefaultStrict<IViewDefinition>(nameof(viewUsageSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/ViewUsageExtensions.cs
+++ b/SysML2.NET/Extend/ViewUsageExtensions.cs
@@ -148,12 +148,7 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         /// </exception>
         internal static IViewDefinition ComputeViewDefinition(this IViewUsage viewUsageSubject)
         {
-            if (viewUsageSubject is null)
-            {
-                throw new ArgumentNullException(nameof(viewUsageSubject));
-            }
-
-            return viewUsageSubject.definition.SingleOrDefaultStrict<IViewDefinition>(nameof(viewUsageSubject));
+            return viewUsageSubject is null ? throw new ArgumentNullException(nameof(viewUsageSubject)) : viewUsageSubject.definition.SingleOrDefaultStrict<IViewDefinition>(nameof(viewUsageSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/ViewUsageExtensions.cs
+++ b/SysML2.NET/Extend/ViewUsageExtensions.cs
@@ -25,12 +25,15 @@ namespace SysML2.NET.Core.POCO.Systems.Views
     using System.Linq;
 
     using SysML2.NET.Core.POCO.Core.Features;
+    using SysML2.NET.Core.POCO.Core.Types;
     using SysML2.NET.Core.POCO.Kernel.Functions;
     using SysML2.NET.Core.POCO.Kernel.Metadata;
     using SysML2.NET.Core.POCO.Kernel.Packages;
     using SysML2.NET.Core.POCO.Root.Annotations;
     using SysML2.NET.Core.POCO.Root.Elements;
     using SysML2.NET.Core.POCO.Root.Namespaces;
+    using SysML2.NET.Exceptions;
+    using SysML2.NET.Extensions;
 
     /// <summary>
     /// The <see cref="ViewUsageExtensions"/> class provides extensions methods for
@@ -125,23 +128,32 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         }
 
         /// <summary>
-        /// Computes the derived property.
+        /// Computes the derived <c>viewDefinition</c> property: the <see cref="IViewDefinition"/>
+        /// targeted by the single <see cref="IFeatureTyping"/> owned by
+        /// <paramref name="viewUsageSubject"/>.
         /// </summary>
         /// <param name="viewUsageSubject">
         /// The subject <see cref="IViewUsage"/>
         /// </param>
         /// <returns>
-        /// the computed result
+        /// The matching <see cref="IViewDefinition"/>, or <c>null</c> when no such typing exists.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="viewUsageSubject"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="MultiplicityViolationException">
+        /// Thrown when more than one <see cref="IFeatureTyping"/> targets an
+        /// <see cref="IViewDefinition"/> (upper-bound violation against the derived
+        /// <c>[0..1]</c> property).
+        /// </exception>
         internal static IViewDefinition ComputeViewDefinition(this IViewUsage viewUsageSubject)
         {
-            return viewUsageSubject == null
-                ? throw new ArgumentNullException(nameof(viewUsageSubject))
-                : viewUsageSubject.OwnedRelationship
-                    .OfType<IFeatureTyping>()
-                    .Select(featureTyping => featureTyping.Type)
-                    .OfType<IViewDefinition>()
-                    .FirstOrDefault();
+            if (viewUsageSubject is null)
+            {
+                throw new ArgumentNullException(nameof(viewUsageSubject));
+            }
+
+            return viewUsageSubject.type.SingleOrDefaultStrict<IViewDefinition>(nameof(viewUsageSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/ViewpointUsageExtensions.cs
+++ b/SysML2.NET/Extend/ViewpointUsageExtensions.cs
@@ -87,12 +87,9 @@ namespace SysML2.NET.Core.POCO.Systems.Views
         /// </exception>
         internal static IViewpointDefinition ComputeViewpointDefinition(this IViewpointUsage viewpointUsageSubject)
         {
-            if (viewpointUsageSubject is null)
-            {
-                throw new ArgumentNullException(nameof(viewpointUsageSubject));
-            }
-
-            return viewpointUsageSubject.definition.SingleOrDefaultStrict<IViewpointDefinition>(nameof(viewpointUsageSubject));
+            return viewpointUsageSubject == null
+                ? throw new ArgumentNullException(nameof(viewpointUsageSubject))
+                : viewpointUsageSubject.definition.SingleOrDefaultStrict<IViewpointDefinition>(nameof(viewpointUsageSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/ViewpointUsageExtensions.cs
+++ b/SysML2.NET/Extend/ViewpointUsageExtensions.cs
@@ -57,6 +57,8 @@ namespace SysML2.NET.Core.POCO.Systems.Views
     using SysML2.NET.Core.POCO.Systems.States;
     using SysML2.NET.Core.POCO.Systems.UseCases;
     using SysML2.NET.Core.POCO.Systems.VerificationCases;
+    using SysML2.NET.Exceptions;
+    using SysML2.NET.Extensions;
 
     /// <summary>
     /// The <see cref="ViewpointUsageExtensions"/> class provides extensions methods for
@@ -65,23 +67,32 @@ namespace SysML2.NET.Core.POCO.Systems.Views
     internal static class ViewpointUsageExtensions
     {
         /// <summary>
-        /// Computes the derived property.
+        /// Computes the derived <c>viewpointDefinition</c> property: the
+        /// <see cref="IViewpointDefinition"/> targeted by the single <see cref="IFeatureTyping"/>
+        /// owned by <paramref name="viewpointUsageSubject"/>.
         /// </summary>
         /// <param name="viewpointUsageSubject">
         /// The subject <see cref="IViewpointUsage"/>
         /// </param>
         /// <returns>
-        /// the computed result
+        /// The matching <see cref="IViewpointDefinition"/>, or <c>null</c> when no such typing exists.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="viewpointUsageSubject"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="MultiplicityViolationException">
+        /// Thrown when more than one <see cref="IFeatureTyping"/> targets an
+        /// <see cref="IViewpointDefinition"/> (upper-bound violation against the derived
+        /// <c>[0..1]</c> property).
+        /// </exception>
         internal static IViewpointDefinition ComputeViewpointDefinition(this IViewpointUsage viewpointUsageSubject)
         {
-            return viewpointUsageSubject == null
-                ? throw new ArgumentNullException(nameof(viewpointUsageSubject))
-                : viewpointUsageSubject.OwnedRelationship
-                    .OfType<IFeatureTyping>()
-                    .Select(featureTyping => featureTyping.Type)
-                    .OfType<IViewpointDefinition>()
-                    .FirstOrDefault();
+            if (viewpointUsageSubject is null)
+            {
+                throw new ArgumentNullException(nameof(viewpointUsageSubject));
+            }
+
+            return viewpointUsageSubject.type.SingleOrDefaultStrict<IViewpointDefinition>(nameof(viewpointUsageSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extend/ViewpointUsageExtensions.cs
+++ b/SysML2.NET/Extend/ViewpointUsageExtensions.cs
@@ -92,7 +92,7 @@ namespace SysML2.NET.Core.POCO.Systems.Views
                 throw new ArgumentNullException(nameof(viewpointUsageSubject));
             }
 
-            return viewpointUsageSubject.type.SingleOrDefaultStrict<IViewpointDefinition>(nameof(viewpointUsageSubject));
+            return viewpointUsageSubject.definition.SingleOrDefaultStrict<IViewpointDefinition>(nameof(viewpointUsageSubject));
         }
 
         /// <summary>

--- a/SysML2.NET/Extensions/ElementExtensions.cs
+++ b/SysML2.NET/Extensions/ElementExtensions.cs
@@ -223,71 +223,185 @@ namespace SysML2.NET.Extensions
         }
 
         /// <summary>
-        /// Returns the single element of type <typeparamref name="T"/> from <paramref name="elements"/>.
+        /// Returns the single element from <paramref name="source"/>, throwing
+        /// <see cref="IncompleteModelException"/> if the source is empty and
+        /// <see cref="MultiplicityViolationException"/> if it contains more than one element.
         /// </summary>
-        /// <typeparam name="T">
-        /// The narrowed element type the caller is interested in (e.g. <c>IUsage</c>, <c>IFeature</c>,
-        /// <c>IStep</c>, <c>IExpression</c>). Pass <see cref="IElement"/> for non-narrowing
-        /// single-element extraction (e.g. <c>OwningMembership::ownedMemberElement</c>).
-        /// </typeparam>
-        /// <param name="elements">
-        /// The source <c>[0..*]</c> storage collection — typically
-        /// <see cref="IRelationship.OwnedRelatedElement"/> or <see cref="IElement.OwnedRelationship"/>
-        /// (assignable thanks to <see cref="IReadOnlyList{T}"/> covariance).
+        /// <typeparam name="T">The element type of the sequence (reference type).</typeparam>
+        /// <param name="source">
+        /// The (already-projected) sequence of candidate matches — typically the tail of a LINQ chain
+        /// such as <c>subject.OwnedRelationship.OfType&lt;IFeatureTyping&gt;().Select(t => t.Type).OfType&lt;TFinal&gt;()</c>.
         /// </param>
         /// <param name="subjectName">
         /// The name of the subject parameter in the calling method (typically <c>nameof(...)</c>),
         /// embedded in the diagnostic message produced on a multiplicity violation.
         /// </param>
-        /// <returns>The single element of type <typeparamref name="T"/></returns>
+        /// <returns>The single element of the sequence.</returns>
         /// <exception cref="IncompleteModelException">
-        /// Thrown when no element of type <typeparamref name="T"/> is present (missing case), or when
-        /// more than one is present (multiplicity violation). The exception message distinguishes the
-        /// two cases so SDK consumers can act on the precise model defect.
+        /// Thrown when <paramref name="source"/> is empty (lower-bound violation — the model is missing
+        /// the required element).
+        /// </exception>
+        /// <exception cref="MultiplicityViolationException">
+        /// Thrown when <paramref name="source"/> contains more than one element (upper-bound violation
+        /// against the derived <c>[1..1]</c> property).
         /// </exception>
         /// <remarks>
         /// <para>
-        /// Canonical helper for derived <c>[1..1]</c> composite properties that subset a <c>[0..*]</c>
-        /// storage collection (e.g. <c>SubjectMembership::ownedSubjectParameter</c>,
-        /// <c>FeatureMembership::ownedMemberFeature</c>,
-        /// <c>ParameterMembership::ownedMemberParameter</c>,
-        /// <c>TransitionFeatureMembership::transitionFeature</c>,
-        /// <c>FeatureValue::value</c>,
-        /// <c>OwningMembership::ownedMemberElement</c> with <typeparamref name="T"/> = <see cref="IElement"/>).
-        /// </para>
-        /// <para>
-        /// The implementation is zero-allocation (index-based iteration over the
-        /// <see cref="IReadOnlyList{T}"/>; no LINQ materialisation, no intermediate list) and
-        /// early-exits on the second match. The storage collection is structurally <c>[0..*]</c>;
-        /// the <c>[1..1]</c> invariant lives on the derived property and is enforced here at the
-        /// point of access.
+        /// Canonical helper for derived <c>[1..1]</c> properties whose projection ends with a final
+        /// type-filter or predicate over a structurally <c>[0..*]</c> storage collection. The helper
+        /// iterates the sequence once with early-exit on the second match; no full materialisation.
         /// </para>
         /// </remarks>
-        internal static T RequireSingleOfType<T>(this IReadOnlyList<IElement> elements, string subjectName)
-            where T : class, IElement
+        internal static T SingleStrict<T>(this IEnumerable<T> source, string subjectName)
+            where T : class
         {
             T found = null;
 
-            for (var index = 0; index < elements.Count; index++)
+            foreach (var item in source)
             {
-                if (elements[index] is not T match)
-                {
-                    continue;
-                }
-
                 if (found is not null)
                 {
-                    throw new IncompleteModelException(
-                        $"{subjectName} contains more than one element of type {typeof(T).Name}");
+                    throw new MultiplicityViolationException($"{subjectName} contains more than one element of type {typeof(T).Name}");
                 }
 
-                found = match;
+                found = item;
             }
 
-            return found
-                ?? throw new IncompleteModelException(
-                    $"{subjectName} must have an element of type {typeof(T).Name}");
+            return found ?? throw new IncompleteModelException($"{subjectName} must have an element of type {typeof(T).Name}");
         }
+
+        /// <summary>
+        /// Filters <paramref name="source"/> to elements of type <typeparamref name="TResult"/> and
+        /// returns the single match, throwing <see cref="IncompleteModelException"/> if none is
+        /// present and <see cref="MultiplicityViolationException"/> if more than one is present.
+        /// </summary>
+        /// <typeparam name="TResult">The narrowed type to filter to (reference type).</typeparam>
+        /// <param name="source">
+        /// The source sequence — typically a <c>[0..*]</c> storage collection such as
+        /// <see cref="IRelationship.OwnedRelatedElement"/>, <see cref="IElement.OwnedRelationship"/>,
+        /// or a derived enumerable such as <c>Feature::type</c>.
+        /// </param>
+        /// <param name="subjectName">
+        /// The name of the subject parameter in the calling method (typically <c>nameof(...)</c>),
+        /// embedded in the diagnostic message produced on a multiplicity violation.
+        /// </param>
+        /// <returns>The single element of type <typeparamref name="TResult"/>.</returns>
+        /// <exception cref="IncompleteModelException">
+        /// Thrown when no element of type <typeparamref name="TResult"/> is present (lower-bound
+        /// violation — the model is missing the required element).
+        /// </exception>
+        /// <exception cref="MultiplicityViolationException">
+        /// Thrown when more than one element of type <typeparamref name="TResult"/> is present
+        /// (upper-bound violation against the derived <c>[1..1]</c> property).
+        /// </exception>
+        /// <remarks>
+        /// Convenience overload that bundles a <c>OfType&lt;TResult&gt;()</c> filter before delegating
+        /// to <see cref="SingleStrict{T}(IEnumerable{T}, string)"/>. Use this form when the source is
+        /// a heterogeneous storage collection and the caller wants the single element of a particular
+        /// narrowed type (e.g. <c>FeatureMembership::ownedMemberFeature</c> = the single <c>IFeature</c>
+        /// in <c>OwnedRelatedElement</c>).
+        /// </remarks>
+        internal static TResult SingleStrict<TResult>(this System.Collections.IEnumerable source, string subjectName)
+            where TResult : class
+            => source.OfType<TResult>().SingleStrict(subjectName);
+
+        /// <summary>
+        /// Returns the at-most-one element from <paramref name="source"/>, throwing
+        /// <see cref="MultiplicityViolationException"/> if the source contains more than one element.
+        /// </summary>
+        /// <typeparam name="T">The element type of the sequence (reference type).</typeparam>
+        /// <param name="source">
+        /// The (already-projected) sequence of candidate matches — typically the tail of a LINQ chain
+        /// such as <c>subject.OwnedRelationship.OfType&lt;IFeatureTyping&gt;().Select(t => t.Type).OfType&lt;TFinal&gt;()</c>.
+        /// </param>
+        /// <param name="subjectName">
+        /// The name of the subject parameter in the calling method (typically <c>nameof(...)</c>),
+        /// embedded in the diagnostic message produced on a multiplicity violation.
+        /// </param>
+        /// <returns>
+        /// <c>null</c> when <paramref name="source"/> is empty; the single element when it contains
+        /// exactly one.
+        /// </returns>
+        /// <exception cref="MultiplicityViolationException">
+        /// Thrown when <paramref name="source"/> contains more than one element (upper-bound violation
+        /// against the derived <c>[0..1]</c> property).
+        /// </exception>
+        /// <remarks>
+        /// <para>
+        /// Canonical helper for derived <c>[0..1]</c> properties whose projection ends with a final
+        /// type-filter or predicate. The helper iterates the sequence once with early-exit on the
+        /// second match; no full materialisation.
+        /// </para>
+        /// <para>
+        /// Sibling of <see cref="SingleStrict{T}(IEnumerable{T}, string)"/> — same shape, but with
+        /// <c>[0..1]</c> semantics: the empty case returns <c>null</c> rather than throwing, because
+        /// the lower bound is 0.
+        /// </para>
+        /// <para>
+        /// Do NOT use this helper when the OCL derivation body explicitly elects the first of many
+        /// (<c>->first()</c>, <c>->at(1)</c>); the spec contract is "pick the first if multiple",
+        /// not "0 or 1". For those sites, keep <c>FirstOrDefault</c>.
+        /// </para>
+        /// </remarks>
+        internal static T SingleOrDefaultStrict<T>(this IEnumerable<T> source, string subjectName)
+            where T : class
+        {
+            T found = null;
+
+            foreach (var item in source)
+            {
+                if (found is not null)
+                {
+                    throw new MultiplicityViolationException($"{subjectName} contains more than one element of type {typeof(T).Name}");
+                }
+
+                found = item;
+            }
+
+            return found;
+        }
+
+        /// <summary>
+        /// Filters <paramref name="source"/> to elements of type <typeparamref name="TResult"/> and
+        /// returns the at-most-one match, throwing <see cref="MultiplicityViolationException"/> if
+        /// more than one is present.
+        /// </summary>
+        /// <typeparam name="TResult">The narrowed type to filter to (reference type).</typeparam>
+        /// <param name="source">
+        /// The source sequence — typically a <c>[0..*]</c> storage collection such as
+        /// <see cref="IRelationship.OwnedRelatedElement"/>, <see cref="IElement.OwnedRelationship"/>,
+        /// or a derived enumerable such as <c>Feature::type</c>.
+        /// </param>
+        /// <param name="subjectName">
+        /// The name of the subject parameter in the calling method (typically <c>nameof(...)</c>),
+        /// embedded in the diagnostic message produced on a multiplicity violation.
+        /// </param>
+        /// <returns>
+        /// <c>null</c> when no element of type <typeparamref name="TResult"/> is present; the single
+        /// match when exactly one is present.
+        /// </returns>
+        /// <exception cref="MultiplicityViolationException">
+        /// Thrown when more than one element of type <typeparamref name="TResult"/> is present
+        /// (upper-bound violation against the derived <c>[0..1]</c> property).
+        /// </exception>
+        /// <remarks>
+        /// <para>
+        /// Convenience overload that bundles a <c>OfType&lt;TResult&gt;()</c> filter before delegating
+        /// to <see cref="SingleOrDefaultStrict{T}(IEnumerable{T}, string)"/>. Use this form when the
+        /// source is a heterogeneous storage collection and the caller wants the optional single
+        /// element of a particular narrowed type (e.g.
+        /// <c>ConstraintUsage::constraintDefinition</c> = the single <c>IPredicate</c> in
+        /// <c>type</c>).
+        /// </para>
+        /// <para>
+        /// Do NOT use this helper when the OCL derivation body explicitly elects the first of many
+        /// (<c>->first()</c>, <c>->at(1)</c>); the spec contract is "pick the first if multiple",
+        /// not "0 or 1". For those sites, keep <c>FirstOrDefault</c>.
+        /// </para>
+        /// </remarks>
+        internal static TResult SingleOrDefaultStrict<TResult>(this System.Collections.IEnumerable source, string subjectName)
+            where TResult : class
+            => source.OfType<TResult>().SingleOrDefaultStrict(subjectName);
 
         /// <summary>
         /// Determines whether <paramref name="element"/> is currently — directly or transitively — contained by


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/SysML2.NET/pulls) open
- [x] I have verified that I am following the SysML2.NET [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/SysML2.NET/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #312 

Enforcement of multiplicity respect on [0..1]/[1..1] cases 
<!-- Thanks for contributing to SysML2.NET! -->