### PR TITLE
Fix #89

### DIFF
--- a/SysML2.NET.Tests/Extend/ActionDefinitionExtensionsTestFixture.cs
+++ b/SysML2.NET.Tests/Extend/ActionDefinitionExtensionsTestFixture.cs
@@ -21,18 +21,39 @@
 namespace SysML2.NET.Tests.Extend
 {
     using System;
-    
+
     using NUnit.Framework;
-    
+
+    using SysML2.NET.Core.POCO.Core.Types;
     using SysML2.NET.Core.POCO.Systems.Actions;
+    using SysML2.NET.Core.POCO.Systems.DefinitionAndUsage;
+    using SysML2.NET.Extensions;
 
     [TestFixture]
     public class ActionDefinitionExtensionsTestFixture
     {
         [Test]
-        public void ComputeAction_ThrowsNotSupportedException()
+        public void VerifyComputeAction()
         {
-            Assert.That(() => ((IActionDefinition)null).ComputeAction(), Throws.TypeOf<NotSupportedException>());
+            Assert.That(() => ((IActionDefinition)null).ComputeAction(), Throws.TypeOf<ArgumentNullException>());
+
+            var emptyActionDefinition = new ActionDefinition();
+
+            Assert.That(emptyActionDefinition.ComputeAction(), Has.Count.EqualTo(0));
+
+            // Only ActionUsage instances must be returned; a bare Usage must be filtered out.
+            var subject = new ActionDefinition();
+            var actionUsage = new ActionUsage();
+            var bareUsage = new Usage();
+
+            subject.AssignOwnership(new FeatureMembership(), actionUsage);
+            subject.AssignOwnership(new FeatureMembership(), bareUsage);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(subject.ComputeAction(), Does.Contain(actionUsage));
+                Assert.That(subject.ComputeAction(), Does.Not.Contain(bareUsage));
+            }
         }
     }
 }

--- a/SysML2.NET/Extend/ActionDefinitionExtensions.cs
+++ b/SysML2.NET/Extend/ActionDefinitionExtensions.cs
@@ -22,6 +22,7 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     using SysML2.NET.Core.Core.Types;
     using SysML2.NET.Core.Root.Namespaces;
@@ -75,10 +76,11 @@ namespace SysML2.NET.Core.POCO.Systems.Actions
         /// <returns>
         /// the computed result
         /// </returns>
-        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         internal static List<IActionUsage> ComputeAction(this IActionDefinition actionDefinitionSubject)
         {
-            throw new NotSupportedException("Create a GitHub issue when this method is required");
+            return actionDefinitionSubject == null
+                ? throw new ArgumentNullException(nameof(actionDefinitionSubject))
+                : [.. actionDefinitionSubject.usage.OfType<IActionUsage>()];
         }
 
     }


### PR DESCRIPTION
Fixes #89.

Implements the single stubbed derived-property computation in `SysML2.NET/Extend/ActionDefinitionExtensions.cs`.

### Change

`List<IActionUsage> ComputeAction(this IActionDefinition)` previously threw `NotSupportedException`. It now implements the OCL derivation:

```
action = usage->selectByKind(ActionUsage)
```

as `[.. actionDefinitionSubject.usage.OfType<IActionUsage>()]`, with an `ArgumentNullException` guard on the subject. This mirrors the existing `CalculationDefinitionExtensions.ComputeCalculation` implementation.

### Ordering contract

Per the metamodel (`ActionDefinition::action`, constraint `deriveActionDefinitionAction`), `action` is `derived, ordered` and `usage` (inherited from `Definition`) is likewise `derived, ordered`. The implementation preserves this contract: `OfType<IActionUsage>()` enumerates the ordered `usage` list in source order and `[.. ]` materializes that order, so `action` follows `usage`'s ordering. `ActionUsage → OccurrenceUsage → Usage`, so the `selectByKind(ActionUsage)` filter over `usage : Usage [0..*]` is well-formed.

### Tests

`SysML2.NET.Tests/Extend/ActionDefinitionExtensionsTestFixture.cs` — the obsolete placeholder test (asserting `NotSupportedException`) is replaced with `VerifyComputeAction` covering:

- null subject → `ArgumentNullException`
- empty `ActionDefinition` → empty result
- positive (`ActionUsage` returned) + negative (bare `Usage` filtered out)

Solution builds with 0 errors; the fixture passes (1/1).
